### PR TITLE
Add drag-and-drop questionnaire builder admin interface

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -2,133 +2,438 @@
 require_once __DIR__.'/../config.php';
 auth_required(['admin']);
 $t = load_lang($_SESSION['lang'] ?? 'en');
-$msg='';
 
-if (isset($_POST['create_q'])) { csrf_check();
-  $stm=$pdo->prepare("INSERT INTO questionnaire (title, description) VALUES (?,?)");
-  $stm->execute([$_POST['title'], $_POST['description']]);
-  $msg='Questionnaire created';
-}
-if (isset($_POST['create_s'])) { csrf_check();
-  $stm=$pdo->prepare("INSERT INTO questionnaire_section (questionnaire_id,title,description,order_index) VALUES (?,?,?,?)");
-  $stm->execute([$_POST['qid'], $_POST['title'], $_POST['description'], (int)$_POST['order_index']]);
-  $msg='Section created';
-}
-if (isset($_POST['create_i'])) { csrf_check();
-  $stm=$pdo->prepare("INSERT INTO questionnaire_item (questionnaire_id,section_id,linkId,text,type,order_index,weight_percent) VALUES (?,?,?,?,?,?,?)");
-  $sec = $_POST['section_id'] ?: null;
-  $w = (int)$_POST['weight_percent'];
-  $stm->execute([$_POST['qid'], $sec, $_POST['linkId'], $_POST['text'], $_POST['type'], (int)$_POST['order_index'], $w]);
-  $msg='Item created';
+function send_json(array $payload, int $status = 200): void {
+    http_response_code($status);
+    header('Content-Type: application/json');
+    echo json_encode($payload);
+    exit;
 }
 
-# Import FHIR JSON/XML (same as before, weight default 0)
-if (isset($_POST['import'])) { csrf_check();
-  if (!empty($_FILES['file']['tmp_name'])) {
-    $raw = file_get_contents($_FILES['file']['tmp_name']);
-    $data = null;
-    if (stripos($_FILES['file']['name'], '.json') !== false) {
-        $data = json_decode($raw, true);
-    } else {
-        $xml = simplexml_load_string($raw, 'SimpleXMLElement', LIBXML_NOCDATA);
-        $json = json_encode($xml);
-        $data = json_decode($json, true);
+function resolve_csrf_token(?array $payload = null): string {
+    if (!empty($_SERVER['HTTP_X_CSRF_TOKEN'])) {
+        return (string)$_SERVER['HTTP_X_CSRF_TOKEN'];
     }
-    if ($data) {
-        $qs = [];
-        if (($data['resourceType'] ?? '') === 'Bundle') {
-            foreach ($data['entry'] ?? [] as $e) {
-                if (($e['resource']['resourceType'] ?? '') === 'Questionnaire') $qs[] = $e['resource'];
-            }
-        } elseif (($data['resourceType'] ?? '') === 'Questionnaire') {
-            $qs[] = $data;
-        }
-        foreach ($qs as $qq) {
-            $pdo->prepare("INSERT INTO questionnaire (title, description) VALUES (?,?)")->execute([$qq['title'] ?? 'FHIR Questionnaire', $qq['description'] ?? null]);
-            $qid = (int)$pdo->lastInsertId();
-            $order = 1;
-            foreach (($qq['item'] ?? []) as $it) {
-                $type = $it['type'] ?? 'text';
-                $text = $it['text'] ?? ($it['linkId'] ?? 'item');
-                $pdo->prepare("INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent) VALUES (?,?,?,?,?,?,?)")
-                    ->execute([$qid, null, $it['linkId'] ?? ('i'.$order), $text, in_array($type,['boolean','text','textarea'])?$type:'text', $order, 0]);
-                $order++;
-            }
-        }
-        $msg = 'FHIR import complete';
-    } else $msg='Invalid file';
-  } else $msg='No file';
+    if (isset($_GET['csrf'])) {
+        return (string)$_GET['csrf'];
+    }
+    if (isset($_POST['csrf'])) {
+        return (string)$_POST['csrf'];
+    }
+    if ($payload && isset($payload['csrf'])) {
+        return (string)$payload['csrf'];
+    }
+    return '';
 }
 
-$qs = $pdo->query("SELECT * FROM questionnaire ORDER BY id DESC")->fetchAll();
-$sections = $pdo->query("SELECT * FROM questionnaire_section ORDER BY questionnaire_id, order_index")->fetchAll();
-$items = $pdo->query("SELECT * FROM questionnaire_item ORDER BY questionnaire_id, order_index")->fetchAll();
+function ensure_csrf(?array $payload = null): void {
+    $token = resolve_csrf_token($payload);
+    if (!isset($_SESSION['csrf']) || !hash_equals($_SESSION['csrf'], $token)) {
+        send_json([
+            'status' => 'error',
+            'message' => 'Invalid CSRF token',
+        ], 400);
+    }
+}
+
+$action = $_GET['action'] ?? '';
+
+if ($action === 'fetch') {
+    if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+        send_json(['status' => 'error', 'message' => 'Method not allowed'], 405);
+    }
+    ensure_csrf();
+
+    $qsRows = $pdo->query('SELECT * FROM questionnaire ORDER BY id DESC')->fetchAll();
+    $sectionsRows = $pdo->query('SELECT * FROM questionnaire_section ORDER BY questionnaire_id, order_index, id')->fetchAll();
+    $itemsRows = $pdo->query('SELECT * FROM questionnaire_item ORDER BY questionnaire_id, order_index, id')->fetchAll();
+
+    $sectionsByQuestionnaire = [];
+    foreach ($sectionsRows as $section) {
+        $qid = (int)$section['questionnaire_id'];
+        $sectionsByQuestionnaire[$qid][] = [
+            'id' => (int)$section['id'],
+            'questionnaire_id' => $qid,
+            'title' => $section['title'],
+            'description' => $section['description'],
+            'order_index' => (int)$section['order_index'],
+        ];
+    }
+
+    $itemsByQuestionnaire = [];
+    $itemsBySection = [];
+    foreach ($itemsRows as $item) {
+        $qid = (int)$item['questionnaire_id'];
+        $sid = $item['section_id'] !== null ? (int)$item['section_id'] : null;
+        $formatted = [
+            'id' => (int)$item['id'],
+            'questionnaire_id' => $qid,
+            'section_id' => $sid,
+            'linkId' => $item['linkId'],
+            'text' => $item['text'],
+            'type' => $item['type'],
+            'order_index' => (int)$item['order_index'],
+            'weight_percent' => (int)$item['weight_percent'],
+        ];
+        if ($sid) {
+            $itemsBySection[$sid][] = $formatted;
+        } else {
+            $itemsByQuestionnaire[$qid][] = $formatted;
+        }
+    }
+
+    $questionnaires = [];
+    foreach ($qsRows as $row) {
+        $qid = (int)$row['id'];
+        $sections = [];
+        foreach ($sectionsByQuestionnaire[$qid] ?? [] as $section) {
+            $sectionId = $section['id'];
+            $sections[] = $section + [
+                'items' => $itemsBySection[$sectionId] ?? [],
+            ];
+        }
+        $questionnaires[] = [
+            'id' => $qid,
+            'title' => $row['title'],
+            'description' => $row['description'],
+            'created_at' => $row['created_at'],
+            'sections' => $sections,
+            'items' => $itemsByQuestionnaire[$qid] ?? [],
+        ];
+    }
+
+    send_json([
+        'status' => 'ok',
+        'csrf' => csrf_token(),
+        'questionnaires' => $questionnaires,
+    ]);
+}
+
+if ($action === 'save' || $action === 'publish') {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        send_json(['status' => 'error', 'message' => 'Method not allowed'], 405);
+    }
+    $raw = file_get_contents('php://input');
+    $payload = json_decode($raw, true);
+    if (!is_array($payload)) {
+        send_json(['status' => 'error', 'message' => 'Invalid payload'], 400);
+    }
+    ensure_csrf($payload);
+
+    $structures = $payload['questionnaires'] ?? [];
+    if (!is_array($structures)) {
+        send_json(['status' => 'error', 'message' => 'Invalid questionnaire data'], 400);
+    }
+
+    $existingQs = $pdo->query('SELECT * FROM questionnaire ORDER BY id')->fetchAll();
+    $questionnaireMap = [];
+    foreach ($existingQs as $row) {
+        $questionnaireMap[(int)$row['id']] = $row;
+    }
+
+    $sectionsRows = $pdo->query('SELECT * FROM questionnaire_section ORDER BY questionnaire_id, id')->fetchAll();
+    $sectionsMap = [];
+    foreach ($sectionsRows as $row) {
+        $qid = (int)$row['questionnaire_id'];
+        $sectionsMap[$qid][(int)$row['id']] = $row;
+    }
+
+    $itemsRows = $pdo->query('SELECT * FROM questionnaire_item ORDER BY questionnaire_id, id')->fetchAll();
+    $itemsMap = [];
+    foreach ($itemsRows as $row) {
+        $qid = (int)$row['questionnaire_id'];
+        $itemsMap[$qid][(int)$row['id']] = $row;
+    }
+
+    $questionnaireSeen = [];
+    $idMap = [
+        'questionnaires' => [],
+        'sections' => [],
+        'items' => [],
+    ];
+
+    $pdo->beginTransaction();
+    try {
+        $insertQuestionnaireStmt = $pdo->prepare('INSERT INTO questionnaire (title, description) VALUES (?, ?)');
+        $updateQuestionnaireStmt = $pdo->prepare('UPDATE questionnaire SET title=?, description=? WHERE id=?');
+
+        $insertSectionStmt = $pdo->prepare('INSERT INTO questionnaire_section (questionnaire_id, title, description, order_index) VALUES (?, ?, ?, ?)');
+        $updateSectionStmt = $pdo->prepare('UPDATE questionnaire_section SET title=?, description=?, order_index=? WHERE id=?');
+
+        $insertItemStmt = $pdo->prepare('INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent) VALUES (?, ?, ?, ?, ?, ?, ?)');
+        $updateItemStmt = $pdo->prepare('UPDATE questionnaire_item SET section_id=?, linkId=?, text=?, type=?, order_index=?, weight_percent=? WHERE id=?');
+
+        foreach ($structures as $qData) {
+            if (!is_array($qData)) {
+                continue;
+            }
+            $clientId = $qData['clientId'] ?? null;
+            $qid = isset($qData['id']) ? (int)$qData['id'] : null;
+            $title = trim((string)($qData['title'] ?? ''));
+            $description = $qData['description'] ?? null;
+
+            if ($qid && isset($questionnaireMap[$qid])) {
+                $updateQuestionnaireStmt->execute([$title, $description, $qid]);
+            } else {
+                $insertQuestionnaireStmt->execute([$title, $description]);
+                $qid = (int)$pdo->lastInsertId();
+                if ($clientId) {
+                    $idMap['questionnaires'][$clientId] = $qid;
+                }
+                $questionnaireMap[$qid] = [
+                    'id' => $qid,
+                    'title' => $title,
+                    'description' => $description,
+                ];
+            }
+            $questionnaireSeen[] = $qid;
+
+            $sectionSeen = [];
+            $itemSeen = [];
+
+            $existingSections = $sectionsMap[$qid] ?? [];
+            $existingItems = $itemsMap[$qid] ?? [];
+
+            $sectionsInput = $qData['sections'] ?? [];
+            if (!is_array($sectionsInput)) {
+                $sectionsInput = [];
+            }
+
+            $orderIndex = 1;
+            foreach ($sectionsInput as $sectionData) {
+                if (!is_array($sectionData)) {
+                    continue;
+                }
+                $sectionClientId = $sectionData['clientId'] ?? null;
+                $sectionId = isset($sectionData['id']) ? (int)$sectionData['id'] : null;
+                $sectionTitle = trim((string)($sectionData['title'] ?? ''));
+                $sectionDescription = $sectionData['description'] ?? null;
+
+                if ($sectionId && isset($existingSections[$sectionId])) {
+                    $updateSectionStmt->execute([$sectionTitle, $sectionDescription, $orderIndex, $sectionId]);
+                } else {
+                    $insertSectionStmt->execute([$qid, $sectionTitle, $sectionDescription, $orderIndex]);
+                    $sectionId = (int)$pdo->lastInsertId();
+                    if ($sectionClientId) {
+                        $idMap['sections'][$sectionClientId] = $sectionId;
+                    }
+                    $existingSections[$sectionId] = [
+                        'id' => $sectionId,
+                    ];
+                }
+                $sectionSeen[] = $sectionId;
+
+                $itemsInput = $sectionData['items'] ?? [];
+                if (!is_array($itemsInput)) {
+                    $itemsInput = [];
+                }
+                $itemOrder = 1;
+                foreach ($itemsInput as $itemData) {
+                    if (!is_array($itemData)) {
+                        continue;
+                    }
+                    $itemClientId = $itemData['clientId'] ?? null;
+                    $itemId = isset($itemData['id']) ? (int)$itemData['id'] : null;
+                    $linkId = trim((string)($itemData['linkId'] ?? ''));
+                    $text = trim((string)($itemData['text'] ?? ''));
+                    $type = $itemData['type'] ?? 'text';
+                    if (!in_array($type, ['text', 'textarea', 'boolean'], true)) {
+                        $type = 'text';
+                    }
+                    $weight = isset($itemData['weight_percent']) ? (int)$itemData['weight_percent'] : 0;
+
+                    if ($itemId && isset($existingItems[$itemId])) {
+                        $updateItemStmt->execute([$sectionId, $linkId, $text, $type, $itemOrder, $weight, $itemId]);
+                    } else {
+                        $insertItemStmt->execute([$qid, $sectionId, $linkId, $text, $type, $itemOrder, $weight]);
+                        $itemId = (int)$pdo->lastInsertId();
+                        if ($itemClientId) {
+                            $idMap['items'][$itemClientId] = $itemId;
+                        }
+                        $existingItems[$itemId] = [
+                            'id' => $itemId,
+                        ];
+                    }
+                    $itemSeen[] = $itemId;
+                    $itemOrder++;
+                }
+                $orderIndex++;
+            }
+
+            $rootItemsInput = $qData['items'] ?? [];
+            if (!is_array($rootItemsInput)) {
+                $rootItemsInput = [];
+            }
+            $rootOrder = 1;
+            foreach ($rootItemsInput as $itemData) {
+                if (!is_array($itemData)) {
+                    continue;
+                }
+                $itemClientId = $itemData['clientId'] ?? null;
+                $itemId = isset($itemData['id']) ? (int)$itemData['id'] : null;
+                $linkId = trim((string)($itemData['linkId'] ?? ''));
+                $text = trim((string)($itemData['text'] ?? ''));
+                $type = $itemData['type'] ?? 'text';
+                if (!in_array($type, ['text', 'textarea', 'boolean'], true)) {
+                    $type = 'text';
+                }
+                $weight = isset($itemData['weight_percent']) ? (int)$itemData['weight_percent'] : 0;
+
+                if ($itemId && isset($existingItems[$itemId])) {
+                    $updateItemStmt->execute([null, $linkId, $text, $type, $rootOrder, $weight, $itemId]);
+                } else {
+                    $insertItemStmt->execute([$qid, null, $linkId, $text, $type, $rootOrder, $weight]);
+                    $itemId = (int)$pdo->lastInsertId();
+                    if ($itemClientId) {
+                        $idMap['items'][$itemClientId] = $itemId;
+                    }
+                    $existingItems[$itemId] = [
+                        'id' => $itemId,
+                    ];
+                }
+                $itemSeen[] = $itemId;
+                $rootOrder++;
+            }
+
+            $itemsToDelete = array_diff(array_keys($existingItems), $itemSeen);
+            if ($itemsToDelete) {
+                $placeholders = implode(',', array_fill(0, count($itemsToDelete), '?'));
+                $stmt = $pdo->prepare("DELETE FROM questionnaire_item WHERE id IN ($placeholders)");
+                $stmt->execute(array_values($itemsToDelete));
+            }
+
+            $sectionsToDelete = array_diff(array_keys($existingSections), $sectionSeen);
+            if ($sectionsToDelete) {
+                $placeholders = implode(',', array_fill(0, count($sectionsToDelete), '?'));
+                $stmt = $pdo->prepare("DELETE FROM questionnaire_section WHERE id IN ($placeholders)");
+                $stmt->execute(array_values($sectionsToDelete));
+            }
+        }
+
+        $deleteQuestionnaires = array_diff(array_keys($questionnaireMap), $questionnaireSeen);
+        if ($deleteQuestionnaires) {
+            $placeholders = implode(',', array_fill(0, count($deleteQuestionnaires), '?'));
+            $stmt = $pdo->prepare("DELETE FROM questionnaire WHERE id IN ($placeholders)");
+            $stmt->execute(array_values($deleteQuestionnaires));
+        }
+
+        $pdo->commit();
+    } catch (Throwable $e) {
+        $pdo->rollBack();
+        send_json([
+            'status' => 'error',
+            'message' => 'Failed to persist questionnaire data',
+            'detail' => $e->getMessage(),
+        ], 500);
+    }
+
+    send_json([
+        'status' => 'ok',
+        'message' => $action === 'publish' ? 'Questionnaires published' : 'Questionnaires saved',
+        'idMap' => $idMap,
+        'csrf' => csrf_token(),
+    ]);
+}
+
+$msg = '';
+if (isset($_POST['import'])) {
+    csrf_check();
+    if (!empty($_FILES['file']['tmp_name'])) {
+        $raw = file_get_contents($_FILES['file']['tmp_name']);
+        $data = null;
+        if (stripos($_FILES['file']['name'], '.json') !== false) {
+            $data = json_decode($raw, true);
+        } else {
+            $xml = simplexml_load_string($raw, 'SimpleXMLElement', LIBXML_NOCDATA);
+            if ($xml !== false) {
+                $json = json_encode($xml);
+                $data = json_decode($json, true);
+            }
+        }
+        if ($data) {
+            $qs = [];
+            if (($data['resourceType'] ?? '') === 'Bundle') {
+                foreach ($data['entry'] ?? [] as $entry) {
+                    if (($entry['resource']['resourceType'] ?? '') === 'Questionnaire') {
+                        $qs[] = $entry['resource'];
+                    }
+                }
+            } elseif (($data['resourceType'] ?? '') === 'Questionnaire') {
+                $qs[] = $data;
+            }
+            foreach ($qs as $resource) {
+                $pdo->prepare('INSERT INTO questionnaire (title, description) VALUES (?, ?)')
+                    ->execute([
+                        $resource['title'] ?? 'FHIR Questionnaire',
+                        $resource['description'] ?? null,
+                    ]);
+                $qid = (int)$pdo->lastInsertId();
+                $order = 1;
+                foreach (($resource['item'] ?? []) as $it) {
+                    $type = $it['type'] ?? 'text';
+                    $text = $it['text'] ?? ($it['linkId'] ?? 'item');
+                    $pdo->prepare('INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent) VALUES (?,?,?,?,?,?,?)')
+                        ->execute([
+                            $qid,
+                            null,
+                            $it['linkId'] ?? ('i'.$order),
+                            $text,
+                            in_array($type, ['boolean', 'text', 'textarea'], true) ? $type : 'text',
+                            $order,
+                            0,
+                        ]);
+                    $order++;
+                }
+            }
+            $msg = 'FHIR import complete';
+        } else {
+            $msg = 'Invalid file';
+        }
+    } else {
+        $msg = 'No file';
+    }
+}
 ?>
-<!doctype html><html><head>
-<meta charset="utf-8"><title>Questionnaires</title>
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Questionnaires</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="csrf-token" content="<?=htmlspecialchars(csrf_token(), ENT_QUOTES)?>">
 <link rel="stylesheet" href="/assets/css/material.css">
 <link rel="stylesheet" href="/assets/css/styles.css">
-</head><body class="md-bg">
+<link rel="stylesheet" href="/assets/css/questionnaire-builder.css">
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js" defer></script>
+<script type="module" src="/assets/js/questionnaire-builder.js" defer></script>
+</head>
+<body class="md-bg">
 <?php include __DIR__.'/../templates/header.php'; ?>
 <section class="md-section">
-<?php if ($msg): ?><div class="md-alert"><?=$msg?></div><?php endif; ?>
+  <?php if ($msg): ?>
+    <div class="md-alert"><?=htmlspecialchars($msg)?></div>
+  <?php endif; ?>
+  <div class="md-card md-elev-2">
+    <div class="qb-toolbar">
+      <button class="md-button md-primary md-elev-2" id="qb-add-questionnaire">Add Questionnaire</button>
+      <div class="qb-toolbar-spacer"></div>
+      <button class="md-button md-elev-2" id="qb-save" disabled>Save</button>
+      <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled>Publish</button>
+    </div>
+    <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
+    <div id="qb-list" class="qb-list" aria-live="polite"></div>
+  </div>
 
-<div class="md-card md-elev-2">
-  <h2 class="md-card-title">Create Questionnaire</h2>
-  <form method="post">
-    <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-    <label class="md-field"><span>Title</span><input name="title" required></label>
-    <label class="md-field"><span>Description</span><textarea name="description"></textarea></label>
-    <button class="md-button md-primary md-elev-2" name="create_q">Create</button>
-  </form>
-</div>
-
-<div class="md-card md-elev-2">
-  <h2 class="md-card-title">Add Section</h2>
-  <form method="post">
-    <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-    <label class="md-field"><span>Questionnaire</span>
-      <select name="qid"><?php foreach ($qs as $q): ?><option value="<?=$q['id']?>"><?=$q['title']?></option><?php endforeach; ?></select>
-    </label>
-    <label class="md-field"><span>Title</span><input name="title" required></label>
-    <label class="md-field"><span>Description</span><textarea name="description"></textarea></label>
-    <label class="md-field"><span>Order</span><input type="number" name="order_index" value="1"></label>
-    <button class="md-button md-elev-2" name="create_s">Add Section</button>
-  </form>
-</div>
-
-<div class="md-card md-elev-2">
-  <h2 class="md-card-title">Add Item</h2>
-  <form method="post">
-    <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-    <label class="md-field"><span>Questionnaire</span>
-      <select name="qid"><?php foreach ($qs as $q): ?><option value="<?=$q['id']?>"><?=$q['title']?></option><?php endforeach; ?></select>
-    </label>
-    <label class="md-field"><span>Section</span>
-      <select name="section_id"><option value="">(no section)</option>
-        <?php foreach ($sections as $s): ?><option value="<?=$s['id']?>">Q<?=$s['questionnaire_id']?> - <?=$s['title']?></option><?php endforeach; ?>
-      </select>
-    </label>
-    <label class="md-field"><span>linkId</span><input name="linkId" required></label>
-    <label class="md-field"><span>Text</span><input name="text" required></label>
-    <label class="md-field"><span>Type</span><select name="type"><option>text</option><option>textarea</option><option>boolean</option></select></label>
-    <label class="md-field"><span>Order</span><input type="number" name="order_index" value="1"></label>
-    <label class="md-field"><span>Weight (%)</span><input type="number" name="weight_percent" value="0" min="0" max="100"></label>
-    <button class="md-button md-elev-2" name="create_i">Add Item</button>
-  </form>
-</div>
-
-<div class="md-card md-elev-2">
-  <h2 class="md-card-title">FHIR Import</h2>
-  <form method="post" enctype="multipart/form-data">
-    <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-    <label class="md-field"><span>File</span><input type="file" name="file" required></label>
-    <button class="md-button md-elev-2" name="import">Import</button>
-  </form>
-  <p>Download XML template: <a href="/samples/sample_questionnaire_template.xml">sample_questionnaire_template.xml</a></p>
-</div>
-
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title">FHIR Import</h2>
+    <form method="post" enctype="multipart/form-data" class="qb-import-form">
+      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <label class="md-field"><span>File</span><input type="file" name="file" required></label>
+      <button class="md-button md-elev-2" name="import">Import</button>
+    </form>
+    <p>Download XML template: <a href="/samples/sample_questionnaire_template.xml">sample_questionnaire_template.xml</a></p>
+  </div>
 </section>
 <?php include __DIR__.'/../templates/footer.php'; ?>
-</body></html>
+</body>
+</html>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -1,0 +1,191 @@
+.qb-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.qb-toolbar-spacer {
+  flex: 1 1 auto;
+}
+
+.qb-message {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  min-height: 1.5rem;
+}
+
+.qb-message[data-state="error"] {
+  color: #b00020;
+}
+
+.qb-message[data-state="success"] {
+  color: #0f7a0f;
+}
+
+.qb-list {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.qb-questionnaire {
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.qb-questionnaire-header,
+.qb-section-header,
+.qb-item {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.qb-questionnaire-header {
+  flex-wrap: wrap;
+}
+
+.qb-questionnaire-fields,
+.qb-section-fields {
+  flex: 1 1 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.qb-questionnaire-actions,
+.qb-section-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.qb-section {
+  border-left: 4px solid #4f80ff;
+  padding-left: 0.75rem;
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.qb-section:first-of-type {
+  margin-top: 0.5rem;
+}
+
+.qb-section-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.qb-item-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.qb-root-items {
+  margin-top: 1rem;
+}
+
+.qb-inline-heading {
+  font-weight: 600;
+  margin: 1rem 0 0.5rem;
+}
+
+.qb-input,
+.qb-textarea,
+.qb-select {
+  width: 100%;
+  font: inherit;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.qb-textarea {
+  min-height: 4.5rem;
+  resize: vertical;
+}
+
+.qb-select {
+  height: 2.5rem;
+}
+
+.qb-item {
+  align-items: center;
+  background: rgba(79, 128, 255, 0.05);
+  border: 1px solid rgba(79, 128, 255, 0.15);
+  border-radius: 6px;
+  padding: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.qb-item .qb-input,
+.qb-item .qb-select {
+  flex: 1 1 150px;
+}
+
+.qb-item .qb-weight {
+  max-width: 120px;
+}
+
+.qb-handle {
+  cursor: move;
+  user-select: none;
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 0.35rem 0.5rem;
+  color: rgba(0, 0, 0, 0.4);
+}
+
+.qb-card-handle::before,
+.qb-section .qb-handle::before,
+.qb-item .qb-handle::before {
+  content: '\2630';
+}
+
+.qb-danger {
+  background: #ffe4e4;
+  color: #b00020;
+}
+
+.qb-action {
+  background: #e7efff;
+  color: #2a4fbf;
+}
+
+.qb-import-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .qb-questionnaire-actions,
+  .qb-section-actions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .qb-item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .qb-item .qb-input,
+  .qb-item .qb-select,
+  .qb-item .qb-weight {
+    flex: 1 1 auto;
+    max-width: none;
+  }
+}

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1,0 +1,715 @@
+const Builder = (() => {
+  const state = {
+    questionnaires: [],
+    dirty: false,
+    loading: false,
+    saving: false,
+    csrfToken: '',
+  };
+
+  const selectors = {
+    addButton: '#qb-add-questionnaire',
+    saveButton: '#qb-save',
+    publishButton: '#qb-publish',
+    message: '#qb-message',
+    list: '#qb-list',
+    metaCsrf: 'meta[name="csrf-token"]',
+  };
+
+  function init() {
+    const meta = document.querySelector(selectors.metaCsrf);
+    if (!meta) return;
+    state.csrfToken = meta.getAttribute('content') || '';
+
+    const addBtn = document.querySelector(selectors.addButton);
+    const saveBtn = document.querySelector(selectors.saveButton);
+    const publishBtn = document.querySelector(selectors.publishButton);
+
+    if (!addBtn || !saveBtn || !publishBtn) {
+      return;
+    }
+
+    addBtn.addEventListener('click', () => {
+      addQuestionnaire();
+    });
+
+    saveBtn.addEventListener('click', () => saveStructure(false));
+    publishBtn.addEventListener('click', () => saveStructure(true));
+
+    const list = document.querySelector(selectors.list);
+    if (list) {
+      list.addEventListener('input', handleInputChange);
+      list.addEventListener('change', handleInputChange);
+      list.addEventListener('click', handleActionClick);
+    }
+
+    fetchData();
+  }
+
+  function uuid(prefix = 'tmp') {
+    if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+      return `${prefix}-${window.crypto.randomUUID()}`;
+    }
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  function handleInputChange(event) {
+    const target = event.target;
+    const role = target.dataset.role;
+    if (!role) return;
+    const qIndex = parseInt(target.dataset.qIndex ?? '-1', 10);
+    if (Number.isNaN(qIndex) || !state.questionnaires[qIndex]) return;
+
+    if (role === 'q-title') {
+      state.questionnaires[qIndex].title = target.value;
+    } else if (role === 'q-description') {
+      state.questionnaires[qIndex].description = target.value;
+    } else if (role === 'section-title' || role === 'section-description') {
+      const sectionIndex = parseSectionIndex(target.dataset.sectionIndex);
+      const section = getSection(qIndex, sectionIndex);
+      if (!section) return;
+      if (role === 'section-title') {
+        section.title = target.value;
+      } else {
+        section.description = target.value;
+      }
+    } else if (role.startsWith('item-')) {
+      const sectionIndex = parseSectionIndex(target.dataset.sectionIndex);
+      const itemIndex = parseInt(target.dataset.itemIndex ?? '-1', 10);
+      const list = getItemList(qIndex, sectionIndex);
+      if (!list || !list[itemIndex]) return;
+      const item = list[itemIndex];
+      if (role === 'item-linkId') {
+        item.linkId = target.value;
+      } else if (role === 'item-text') {
+        item.text = target.value;
+      } else if (role === 'item-type') {
+        item.type = target.value;
+      } else if (role === 'item-weight') {
+        item.weight_percent = parseInt(target.value || '0', 10) || 0;
+      }
+    }
+    markDirty();
+  }
+
+  function handleActionClick(event) {
+    const button = event.target.closest('[data-action]');
+    if (!button) return;
+    event.preventDefault();
+    const action = button.dataset.action;
+    const qIndex = parseInt(button.dataset.qIndex ?? '-1', 10);
+    if (Number.isNaN(qIndex) && action !== 'add-questionnaire') return;
+
+    if (action === 'delete-questionnaire') {
+      removeQuestionnaire(qIndex);
+    } else if (action === 'add-section') {
+      addSection(qIndex);
+    } else if (action === 'delete-section') {
+      const sectionIndex = parseSectionIndex(button.dataset.sectionIndex);
+      removeSection(qIndex, sectionIndex);
+    } else if (action === 'add-item') {
+      const sectionIndex = parseSectionIndex(button.dataset.sectionIndex);
+      addItem(qIndex, sectionIndex);
+    } else if (action === 'delete-item') {
+      const sectionIndex = parseSectionIndex(button.dataset.sectionIndex);
+      const itemIndex = parseInt(button.dataset.itemIndex ?? '-1', 10);
+      removeItem(qIndex, sectionIndex, itemIndex);
+    }
+  }
+
+  function parseSectionIndex(value) {
+    if (value === 'root') return 'root';
+    const parsed = parseInt(value ?? '-1', 10);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  function getSection(qIndex, sectionIndex) {
+    if (sectionIndex === 'root' || sectionIndex === null) return null;
+    return state.questionnaires[qIndex]?.sections?.[sectionIndex] ?? null;
+  }
+
+  function getItemList(qIndex, sectionIndex) {
+    const questionnaire = state.questionnaires[qIndex];
+    if (!questionnaire) return null;
+    if (sectionIndex === 'root' || sectionIndex === null) {
+      questionnaire.items = questionnaire.items || [];
+      return questionnaire.items;
+    }
+    questionnaire.sections = questionnaire.sections || [];
+    const section = questionnaire.sections[sectionIndex];
+    if (!section) return null;
+    section.items = section.items || [];
+    return section.items;
+  }
+
+  function addQuestionnaire() {
+    const questionnaire = {
+      id: null,
+      clientId: uuid('q'),
+      title: 'Untitled Questionnaire',
+      description: '',
+      sections: [],
+      items: [],
+    };
+    state.questionnaires.unshift(questionnaire);
+    markDirty();
+    render();
+  }
+
+  function removeQuestionnaire(qIndex) {
+    if (Number.isNaN(qIndex) || !state.questionnaires[qIndex]) return;
+    if (!window.confirm('Delete this questionnaire and all of its content?')) return;
+    state.questionnaires.splice(qIndex, 1);
+    markDirty();
+    render();
+  }
+
+  function addSection(qIndex) {
+    const questionnaire = state.questionnaires[qIndex];
+    if (!questionnaire) return;
+    questionnaire.sections = questionnaire.sections || [];
+    questionnaire.sections.push({
+      id: null,
+      clientId: uuid('s'),
+      title: 'New Section',
+      description: '',
+      items: [],
+    });
+    markDirty();
+    render();
+  }
+
+  function removeSection(qIndex, sectionIndex) {
+    const questionnaire = state.questionnaires[qIndex];
+    if (!questionnaire || sectionIndex === null || sectionIndex === 'root') return;
+    questionnaire.sections.splice(sectionIndex, 1);
+    markDirty();
+    render();
+  }
+
+  function addItem(qIndex, sectionIndex) {
+    const list = getItemList(qIndex, sectionIndex);
+    if (!list) return;
+    list.push({
+      id: null,
+      clientId: uuid('i'),
+      linkId: `item-${list.length + 1}`,
+      text: '',
+      type: 'text',
+      weight_percent: 0,
+    });
+    markDirty();
+    render();
+  }
+
+  function removeItem(qIndex, sectionIndex, itemIndex) {
+    const list = getItemList(qIndex, sectionIndex);
+    if (!list || Number.isNaN(itemIndex) || !list[itemIndex]) return;
+    list.splice(itemIndex, 1);
+    markDirty();
+    render();
+  }
+
+  async function fetchData(options = {}) {
+    const { silent = false } = options;
+    state.loading = true;
+    if (!silent) {
+      setMessage('Loading questionnaires...', 'info');
+    }
+    try {
+      const response = await fetch(`/admin/questionnaire_manage.php?action=fetch`, {
+        headers: {
+          'X-CSRF-Token': state.csrfToken,
+          'Accept': 'application/json',
+        },
+        credentials: 'same-origin',
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to load data (${response.status})`);
+      }
+      const data = await response.json();
+      if (data.csrf) {
+        updateCsrf(data.csrf);
+      }
+      const questionnaires = Array.isArray(data.questionnaires) ? data.questionnaires : [];
+      state.questionnaires = questionnaires.map(normalizeQuestionnaire);
+      state.dirty = false;
+      render();
+      if (!silent) {
+        setMessage('Loaded questionnaires', 'success');
+      }
+    } catch (error) {
+      console.error(error);
+      setMessage(error.message || 'Failed to load questionnaires', 'error');
+    } finally {
+      state.loading = false;
+      updateDirtyState();
+    }
+  }
+
+  function normalizeQuestionnaire(q) {
+    const questionnaire = {
+      id: q.id ?? null,
+      clientId: q.clientId || `q-${q.id ?? uuid('q')}`,
+      title: q.title ?? '',
+      description: q.description ?? '',
+      sections: [],
+      items: [],
+    };
+    const sections = Array.isArray(q.sections) ? q.sections : [];
+    questionnaire.sections = sections.map((section) => ({
+      id: section.id ?? null,
+      clientId: section.clientId || `s-${section.id ?? uuid('s')}`,
+      title: section.title ?? '',
+      description: section.description ?? '',
+      items: normalizeItems(section.items),
+    }));
+    questionnaire.items = normalizeItems(q.items);
+    return questionnaire;
+  }
+
+  function normalizeItems(items) {
+    if (!Array.isArray(items)) return [];
+    return items.map((item) => ({
+      id: item.id ?? null,
+      clientId: item.clientId || `i-${item.id ?? uuid('i')}`,
+      linkId: item.linkId ?? '',
+      text: item.text ?? '',
+      type: item.type ?? 'text',
+      weight_percent: Number.isFinite(item.weight_percent) ? item.weight_percent : parseInt(item.weight_percent || '0', 10) || 0,
+    }));
+  }
+
+  function updateCsrf(token) {
+    if (!token) return;
+    state.csrfToken = token;
+    const meta = document.querySelector(selectors.metaCsrf);
+    if (meta) {
+      meta.setAttribute('content', token);
+    }
+  }
+
+  function markDirty() {
+    state.dirty = true;
+    updateDirtyState();
+  }
+
+  function updateDirtyState() {
+    const saveBtn = document.querySelector(selectors.saveButton);
+    const publishBtn = document.querySelector(selectors.publishButton);
+    const disabled = state.loading || state.saving || !state.dirty;
+    if (saveBtn) saveBtn.disabled = disabled;
+    if (publishBtn) publishBtn.disabled = disabled;
+  }
+
+  function setMessage(message, type = 'info') {
+    const el = document.querySelector(selectors.message);
+    if (!el) return;
+    el.textContent = message;
+    el.dataset.state = type;
+  }
+
+  function keyFor(entity) {
+    if (!entity) return '';
+    if (entity.id) return `id:${entity.id}`;
+    return `client:${entity.clientId}`;
+  }
+
+  function render() {
+    const list = document.querySelector(selectors.list);
+    if (!list) return;
+    list.innerHTML = '';
+    state.questionnaires.forEach((questionnaire, qIndex) => {
+      const card = buildQuestionnaireCard(questionnaire, qIndex);
+      list.appendChild(card);
+    });
+    initSortable();
+    updateDirtyState();
+  }
+
+  function buildQuestionnaireCard(questionnaire, qIndex) {
+    const card = document.createElement('div');
+    card.className = 'qb-questionnaire';
+    card.dataset.key = keyFor(questionnaire);
+    card.dataset.qIndex = String(qIndex);
+
+    const header = document.createElement('div');
+    header.className = 'qb-questionnaire-header';
+
+    const handle = document.createElement('span');
+    handle.className = 'qb-handle qb-card-handle';
+    handle.setAttribute('title', 'Drag to reorder questionnaire');
+    handle.setAttribute('aria-hidden', 'true');
+    header.appendChild(handle);
+
+    const titleWrap = document.createElement('div');
+    titleWrap.className = 'qb-questionnaire-fields';
+    const titleInput = document.createElement('input');
+    titleInput.type = 'text';
+    titleInput.className = 'qb-input qb-title';
+    titleInput.value = questionnaire.title;
+    titleInput.placeholder = 'Questionnaire title';
+    titleInput.dataset.role = 'q-title';
+    titleInput.dataset.qIndex = String(qIndex);
+    titleWrap.appendChild(titleInput);
+
+    const desc = document.createElement('textarea');
+    desc.className = 'qb-textarea qb-description';
+    desc.value = questionnaire.description || '';
+    desc.placeholder = 'Description';
+    desc.dataset.role = 'q-description';
+    desc.dataset.qIndex = String(qIndex);
+    titleWrap.appendChild(desc);
+
+    header.appendChild(titleWrap);
+
+    const actions = document.createElement('div');
+    actions.className = 'qb-questionnaire-actions';
+
+    const addSectionBtn = document.createElement('button');
+    addSectionBtn.className = 'md-button qb-action';
+    addSectionBtn.textContent = 'Add Section';
+    addSectionBtn.dataset.action = 'add-section';
+    addSectionBtn.dataset.qIndex = String(qIndex);
+    actions.appendChild(addSectionBtn);
+
+    const addItemBtn = document.createElement('button');
+    addItemBtn.className = 'md-button qb-action';
+    addItemBtn.textContent = 'Add Item';
+    addItemBtn.dataset.action = 'add-item';
+    addItemBtn.dataset.qIndex = String(qIndex);
+    addItemBtn.dataset.sectionIndex = 'root';
+    actions.appendChild(addItemBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'md-button qb-danger';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.dataset.action = 'delete-questionnaire';
+    deleteBtn.dataset.qIndex = String(qIndex);
+    actions.appendChild(deleteBtn);
+
+    header.appendChild(actions);
+    card.appendChild(header);
+
+    const sectionsContainer = document.createElement('div');
+    sectionsContainer.className = 'qb-section-list';
+    sectionsContainer.dataset.sortable = 'sections';
+    sectionsContainer.dataset.qIndex = String(qIndex);
+    questionnaire.sections.forEach((section, sectionIndex) => {
+      const sectionEl = buildSection(section, qIndex, sectionIndex);
+      sectionsContainer.appendChild(sectionEl);
+    });
+    card.appendChild(sectionsContainer);
+
+    const rootItems = document.createElement('div');
+    rootItems.className = 'qb-item-list qb-root-items';
+    rootItems.dataset.sortable = 'items';
+    rootItems.dataset.qIndex = String(qIndex);
+    rootItems.dataset.sectionIndex = 'root';
+    questionnaire.items.forEach((item, itemIndex) => {
+      const itemEl = buildItem(item, qIndex, 'root', itemIndex);
+      rootItems.appendChild(itemEl);
+    });
+    if (questionnaire.items.length) {
+      const heading = document.createElement('div');
+      heading.className = 'qb-inline-heading';
+      heading.textContent = 'Items without a section';
+      card.appendChild(heading);
+    }
+    card.appendChild(rootItems);
+
+    return card;
+  }
+
+  function buildSection(section, qIndex, sectionIndex) {
+    const sectionEl = document.createElement('div');
+    sectionEl.className = 'qb-section';
+    sectionEl.dataset.key = keyFor(section);
+    sectionEl.dataset.qIndex = String(qIndex);
+    sectionEl.dataset.sectionIndex = String(sectionIndex);
+
+    const header = document.createElement('div');
+    header.className = 'qb-section-header';
+
+    const handle = document.createElement('span');
+    handle.className = 'qb-handle';
+    handle.setAttribute('title', 'Drag to reorder section');
+    handle.setAttribute('aria-hidden', 'true');
+    header.appendChild(handle);
+
+    const fields = document.createElement('div');
+    fields.className = 'qb-section-fields';
+
+    const title = document.createElement('input');
+    title.type = 'text';
+    title.className = 'qb-input qb-section-title';
+    title.value = section.title;
+    title.placeholder = 'Section title';
+    title.dataset.role = 'section-title';
+    title.dataset.qIndex = String(qIndex);
+    title.dataset.sectionIndex = String(sectionIndex);
+    fields.appendChild(title);
+
+    const desc = document.createElement('textarea');
+    desc.className = 'qb-textarea qb-section-description';
+    desc.value = section.description || '';
+    desc.placeholder = 'Description';
+    desc.dataset.role = 'section-description';
+    desc.dataset.qIndex = String(qIndex);
+    desc.dataset.sectionIndex = String(sectionIndex);
+    fields.appendChild(desc);
+
+    header.appendChild(fields);
+
+    const actions = document.createElement('div');
+    actions.className = 'qb-section-actions';
+
+    const addItemBtn = document.createElement('button');
+    addItemBtn.className = 'md-button qb-action';
+    addItemBtn.textContent = 'Add Item';
+    addItemBtn.dataset.action = 'add-item';
+    addItemBtn.dataset.qIndex = String(qIndex);
+    addItemBtn.dataset.sectionIndex = String(sectionIndex);
+    actions.appendChild(addItemBtn);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'md-button qb-danger';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.dataset.action = 'delete-section';
+    deleteBtn.dataset.qIndex = String(qIndex);
+    deleteBtn.dataset.sectionIndex = String(sectionIndex);
+    actions.appendChild(deleteBtn);
+
+    header.appendChild(actions);
+    sectionEl.appendChild(header);
+
+    const items = document.createElement('div');
+    items.className = 'qb-item-list';
+    items.dataset.sortable = 'items';
+    items.dataset.qIndex = String(qIndex);
+    items.dataset.sectionIndex = String(sectionIndex);
+    section.items.forEach((item, itemIndex) => {
+      const itemEl = buildItem(item, qIndex, sectionIndex, itemIndex);
+      items.appendChild(itemEl);
+    });
+    sectionEl.appendChild(items);
+
+    return sectionEl;
+  }
+
+  function buildItem(item, qIndex, sectionIndex, itemIndex) {
+    const itemEl = document.createElement('div');
+    itemEl.className = 'qb-item';
+    itemEl.dataset.key = keyFor(item);
+    itemEl.dataset.qIndex = String(qIndex);
+    itemEl.dataset.sectionIndex = sectionIndex === 'root' ? 'root' : String(sectionIndex);
+    itemEl.dataset.itemIndex = String(itemIndex);
+
+    const handle = document.createElement('span');
+    handle.className = 'qb-handle';
+    handle.setAttribute('title', 'Drag to reorder item');
+    handle.setAttribute('aria-hidden', 'true');
+    itemEl.appendChild(handle);
+
+    const linkId = document.createElement('input');
+    linkId.type = 'text';
+    linkId.className = 'qb-input qb-link-id';
+    linkId.placeholder = 'linkId';
+    linkId.value = item.linkId;
+    linkId.dataset.role = 'item-linkId';
+    linkId.dataset.qIndex = String(qIndex);
+    linkId.dataset.sectionIndex = sectionIndex === 'root' ? 'root' : String(sectionIndex);
+    linkId.dataset.itemIndex = String(itemIndex);
+    itemEl.appendChild(linkId);
+
+    const text = document.createElement('input');
+    text.type = 'text';
+    text.className = 'qb-input qb-item-text';
+    text.placeholder = 'Prompt text';
+    text.value = item.text;
+    text.dataset.role = 'item-text';
+    text.dataset.qIndex = String(qIndex);
+    text.dataset.sectionIndex = sectionIndex === 'root' ? 'root' : String(sectionIndex);
+    text.dataset.itemIndex = String(itemIndex);
+    itemEl.appendChild(text);
+
+    const type = document.createElement('select');
+    type.className = 'qb-select qb-item-type';
+    ['text', 'textarea', 'boolean'].forEach((optionValue) => {
+      const opt = document.createElement('option');
+      opt.value = optionValue;
+      opt.textContent = optionValue;
+      if (optionValue === item.type) {
+        opt.selected = true;
+      }
+      type.appendChild(opt);
+    });
+    type.dataset.role = 'item-type';
+    type.dataset.qIndex = String(qIndex);
+    type.dataset.sectionIndex = sectionIndex === 'root' ? 'root' : String(sectionIndex);
+    type.dataset.itemIndex = String(itemIndex);
+    itemEl.appendChild(type);
+
+    const weight = document.createElement('input');
+    weight.type = 'number';
+    weight.min = '0';
+    weight.max = '100';
+    weight.className = 'qb-input qb-weight';
+    weight.placeholder = 'Weight %';
+    weight.value = String(item.weight_percent ?? 0);
+    weight.dataset.role = 'item-weight';
+    weight.dataset.qIndex = String(qIndex);
+    weight.dataset.sectionIndex = sectionIndex === 'root' ? 'root' : String(sectionIndex);
+    weight.dataset.itemIndex = String(itemIndex);
+    itemEl.appendChild(weight);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'md-button qb-danger';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.dataset.action = 'delete-item';
+    deleteBtn.dataset.qIndex = String(qIndex);
+    deleteBtn.dataset.sectionIndex = sectionIndex === 'root' ? 'root' : String(sectionIndex);
+    deleteBtn.dataset.itemIndex = String(itemIndex);
+    itemEl.appendChild(deleteBtn);
+
+    return itemEl;
+  }
+
+  function initSortable() {
+    const list = document.querySelector(selectors.list);
+    if (list) {
+      makeSortable(list, {
+        handle: '.qb-card-handle',
+        animation: 120,
+        onEnd() {
+          const keys = Array.from(list.children).map((el) => el.dataset.key);
+          state.questionnaires.sort((a, b) => keys.indexOf(keyFor(a)) - keys.indexOf(keyFor(b)));
+          markDirty();
+          render();
+        },
+      });
+    }
+
+    document.querySelectorAll('[data-sortable="sections"]').forEach((container) => {
+      makeSortable(container, {
+        handle: '.qb-section-header > .qb-handle',
+        animation: 120,
+        onEnd() {
+          const qIndex = parseInt(container.dataset.qIndex ?? '-1', 10);
+          if (Number.isNaN(qIndex) || !state.questionnaires[qIndex]) return;
+          const sections = state.questionnaires[qIndex].sections;
+          const orderedKeys = Array.from(container.children).map((el) => el.dataset.key);
+          state.questionnaires[qIndex].sections = orderedKeys
+            .map((key) => sections.find((section) => keyFor(section) === key))
+            .filter(Boolean);
+          markDirty();
+          render();
+        },
+      });
+    });
+
+    document.querySelectorAll('[data-sortable="items"]').forEach((container) => {
+      makeSortable(container, {
+        handle: '.qb-item > .qb-handle',
+        animation: 120,
+        onEnd() {
+          const qIndex = parseInt(container.dataset.qIndex ?? '-1', 10);
+          const sectionIndex = parseSectionIndex(container.dataset.sectionIndex);
+          const listRef = getItemList(qIndex, sectionIndex);
+          if (!listRef) return;
+          const orderedKeys = Array.from(container.children).map((el) => el.dataset.key);
+          const sorted = orderedKeys
+            .map((key) => listRef.find((item) => keyFor(item) === key))
+            .filter(Boolean);
+          if (sorted.length === listRef.length) {
+            if (sectionIndex === 'root' || sectionIndex === null) {
+              state.questionnaires[qIndex].items = sorted;
+            } else if (state.questionnaires[qIndex].sections[sectionIndex]) {
+              state.questionnaires[qIndex].sections[sectionIndex].items = sorted;
+            }
+            markDirty();
+            render();
+          }
+        },
+      });
+    });
+  }
+
+  function makeSortable(element, options) {
+    if (!window.Sortable || !element) return;
+    const existing = window.Sortable.get(element);
+    if (existing) existing.destroy();
+    window.Sortable.create(element, options);
+  }
+
+  async function saveStructure(publish = false) {
+    if (state.loading || state.saving) return;
+    state.saving = true;
+    updateDirtyState();
+    setMessage(publish ? 'Publishing...' : 'Saving...', 'info');
+    try {
+      const response = await fetch(`/admin/questionnaire_manage.php?action=${publish ? 'publish' : 'save'}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': state.csrfToken,
+          'Accept': 'application/json',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ questionnaires: state.questionnaires }),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to ${publish ? 'publish' : 'save'} (${response.status})`);
+      }
+      const data = await response.json();
+      if (data.csrf) {
+        updateCsrf(data.csrf);
+      }
+      if (data.idMap) {
+        applyIdMap(data.idMap);
+      }
+      state.dirty = false;
+      setMessage(data.message || (publish ? 'Published successfully' : 'Saved successfully'), 'success');
+      await fetchData({ silent: true });
+    } catch (error) {
+      console.error(error);
+      setMessage(error.message || 'Failed to save questionnaires', 'error');
+    } finally {
+      state.saving = false;
+      updateDirtyState();
+    }
+  }
+
+  function applyIdMap(idMap) {
+    if (!idMap) return;
+    const qMap = idMap.questionnaires || {};
+    const sMap = idMap.sections || {};
+    const iMap = idMap.items || {};
+    state.questionnaires.forEach((q) => {
+      if (!q.id && qMap[q.clientId]) {
+        q.id = qMap[q.clientId];
+      }
+      q.sections.forEach((section) => {
+        if (!section.id && sMap[section.clientId]) {
+          section.id = sMap[section.clientId];
+        }
+        section.items.forEach((item) => {
+          if (!item.id && iMap[item.clientId]) {
+            item.id = iMap[item.clientId];
+          }
+        });
+      });
+      q.items.forEach((item) => {
+        if (!item.id && iMap[item.clientId]) {
+          item.id = iMap[item.clientId];
+        }
+      });
+    });
+  }
+
+  return { init };
+})();
+
+window.addEventListener('DOMContentLoaded', () => {
+  Builder.init();
+});


### PR DESCRIPTION
## Summary
- replace the admin questionnaire management forms with a single-page builder backed by JSON endpoints and CSRF validation
- add a JavaScript module that renders questionnaire cards with drag-and-drop ordering, inline editing, and save/publish actions
- introduce supporting styles while keeping the FHIR import workflow available

## Testing
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_68db4a014fa0832d94ebbc0b788d0aa3