### PR TITLE
Prevent service worker from caching protected admin pages

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'my-performance-cache-v1';
+const CACHE_NAME = 'my-performance-cache-v2';
 const BASE_SCOPE = (self.registration && self.registration.scope) ? self.registration.scope.replace(/\/+$/, '') : '';
 
 function withBase(path) {
@@ -8,21 +8,31 @@ function withBase(path) {
   return `${BASE_SCOPE}${path}`;
 }
 
-const OFFLINE_URLS = [
-  withBase(''),
-  withBase('dashboard.php'),
-  withBase('submit_assessment.php'),
-  withBase('my_performance.php'),
-  withBase('profile.php'),
+const PRECACHE_URLS = [
+  withBase('index.php'),
   withBase('assets/css/material.css'),
   withBase('assets/css/styles.css'),
   withBase('assets/js/app.js')
 ];
 
-self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
+async function precacheStaticAssets() {
+  const cache = await caches.open(CACHE_NAME);
+  await Promise.all(
+    PRECACHE_URLS.map(async (url) => {
+      try {
+        const response = await fetch(url, { cache: 'no-store' });
+        if (response && response.ok) {
+          await cache.put(url, response.clone());
+        }
+      } catch (err) {
+        // Ignore failures so one protected resource does not break install
+      }
+    })
   );
+}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(precacheStaticAssets());
   self.skipWaiting();
 });
 
@@ -39,6 +49,16 @@ self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') {
     return;
   }
+
+  const requestURL = new URL(event.request.url);
+  if (requestURL.origin !== self.location.origin) {
+    return;
+  }
+
+  const isNavigation = event.request.mode === 'navigate';
+  if (isNavigation && !requestURL.href.startsWith(BASE_SCOPE)) {
+    return;
+  }
   event.respondWith(
     caches.match(event.request).then((cached) => {
       if (cached) {
@@ -46,11 +66,18 @@ self.addEventListener('fetch', (event) => {
       }
       return fetch(event.request)
         .then((response) => {
-          const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          if (!isNavigation && response && response.ok && event.request.url.startsWith(self.location.origin)) {
+            const copy = response.clone();
+            caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+          }
           return response;
         })
-        .catch(() => caches.match(withBase('')));
+        .catch((err) => {
+          if (isNavigation) {
+            return caches.match(withBase('index.php'));
+          }
+          throw err;
+        });
     })
   );
 });


### PR DESCRIPTION
## Summary
- restrict the service worker precache list to public assets and handle fetch failures without aborting install
- avoid caching authenticated navigation responses while still providing an offline fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7dcf2c700832d96313d65038fd367