### PR TITLE
Add cleanRedirect helper for safe redirects

### DIFF
--- a/lib/path.php
+++ b/lib/path.php
@@ -16,4 +16,90 @@ function url_for(string $path = ''): string {
     }
     return ($base === '' ? '' : $base) . '/' . $trimmed;
 }
+
+function cleanRedirect(?string $target, ?string $default = null): string {
+    $fallback = $default;
+    if ($fallback === null || trim($fallback) === '') {
+        $fallback = url_for('');
+    }
+
+    $target = trim((string)($target ?? ''));
+    if ($target === '') {
+        return $fallback;
+    }
+
+    $target = str_replace(["\r", "\n"], '', $target);
+    $parsed = @parse_url($target);
+    if ($parsed === false) {
+        return $fallback;
+    }
+
+    $scheme = $parsed['scheme'] ?? '';
+    if ($scheme !== '' && !in_array(strtolower($scheme), ['http', 'https'], true)) {
+        return $fallback;
+    }
+
+    $base = rtrim(BASE_URL, '/');
+    $baseForParse = $base === '' ? '/' : $base;
+    $baseParts = @parse_url($baseForParse);
+    $allowedHost = $baseParts['host'] ?? ($_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? ''));
+    $allowedPort = $baseParts['port'] ?? (isset($_SERVER['SERVER_PORT']) ? (int)$_SERVER['SERVER_PORT'] : null);
+
+    if (isset($parsed['host'])) {
+        if ($allowedHost === '' || strcasecmp($parsed['host'], $allowedHost) !== 0) {
+            return $fallback;
+        }
+        if (isset($parsed['port']) && $allowedPort !== null && (int)$parsed['port'] !== $allowedPort) {
+            return $fallback;
+        }
+        if ($scheme === '') {
+            return $fallback;
+        }
+    } elseif ($scheme !== '') {
+        return $fallback;
+    }
+
+    $path = $parsed['path'] ?? '';
+    $segments = [];
+    foreach (explode('/', $path) as $segment) {
+        if ($segment === '' || $segment === '.') {
+            continue;
+        }
+        if ($segment === '..') {
+            array_pop($segments);
+            continue;
+        }
+        $segments[] = $segment;
+    }
+
+    $cleanPath = '/' . implode('/', $segments);
+    if ($path === '' || $path === '/') {
+        $cleanPath = '/';
+    }
+
+    $query = isset($parsed['query']) ? '?' . $parsed['query'] : '';
+    $fragment = isset($parsed['fragment']) ? '#' . $parsed['fragment'] : '';
+
+    $basePath = $baseParts['path'] ?? '';
+    if ($basePath !== '' && $basePath !== '/') {
+        if ($basePath[0] !== '/') {
+            $basePath = '/' . $basePath;
+        }
+        $normalizedBase = rtrim($basePath, '/');
+        if ($normalizedBase !== '' && strpos($cleanPath, $normalizedBase) !== 0) {
+            if ($cleanPath === '/') {
+                $cleanPath = $normalizedBase . '/';
+            } else {
+                $cleanPath = $normalizedBase . $cleanPath;
+            }
+        }
+    }
+
+    $result = $cleanPath . $query . $fragment;
+    if ($result === '' || $result[0] !== '/') {
+        return $fallback;
+    }
+
+    return $result;
+}
 ?>

--- a/set_lang.php
+++ b/set_lang.php
@@ -9,17 +9,7 @@ if (!empty($_SESSION['user']['id'])) {
     $stmt->execute([$lang, $_SESSION['user']['id']]);
     refresh_current_user($pdo);
 }
-$redirect = $_SERVER['HTTP_REFERER'] ?? '';
-if ($redirect !== '') {
-    $parts = parse_url($redirect);
-    $host = $_SERVER['HTTP_HOST'] ?? '';
-    if (!empty($parts['host']) && strcasecmp($parts['host'], $host) !== 0) {
-        $redirect = '';
-    }
-}
-if ($redirect === '') {
-    $redirect = url_for('dashboard.php');
-}
+$redirect = cleanRedirect($_SERVER['HTTP_REFERER'] ?? '', url_for('dashboard.php'));
 header('Location: ' . $redirect);
 exit;
 ?>


### PR DESCRIPTION
## Summary
- add a cleanRedirect helper that normalises redirect targets and rejects unsafe URLs
- use the helper when switching languages to prevent cross-site redirects

## Testing
- php -l lib/path.php
- php -l set_lang.php

------
https://chatgpt.com/codex/tasks/task_e_68e841ddad88832d88b45c8c45259916