### PR TITLE
Add security headers and ISO-aligned quality guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Translations live in `lang/*.json`. Users can switch between English, French, an
 - `make lint` – run `php -l` across all PHP files.
 - GitHub Actions workflow `.github/workflows/ci.yml` lints PHP and checks MySQL availability.
 
+## Quality and compliance
+
+Refer to [`docs/quality_assurance.md`](docs/quality_assurance.md) for the
+project's quality management and compliance framework. The checklist aligns the
+delivery workflow with ISO/IEC 12207 (software life cycle), ISO/IEC 25010
+(product quality), ISO/IEC 27001 (information security), and related standards.
+
 ## Default navigation
 
 - `/index.php` – login

--- a/config.php
+++ b/config.php
@@ -22,11 +22,14 @@ if (!defined('APP_BOOTSTRAPPED')) {
 
     require_once __DIR__ . '/i18n.php';
     require_once __DIR__ . '/lib/path.php';
+    require_once __DIR__ . '/lib/security.php';
 
     $locale = ensure_locale();
     if (!isset($_SESSION['lang']) || $_SESSION['lang'] !== $locale) {
         $_SESSION['lang'] = $locale;
     }
+
+    apply_security_headers($appDebug);
 
     $dbHost = getenv('DB_HOST') ?: '127.0.0.1';
     $dbName = getenv('DB_NAME') ?: 'epss_v300';

--- a/docs/quality_assurance.md
+++ b/docs/quality_assurance.md
@@ -1,0 +1,72 @@
+# Quality and Compliance Framework
+
+This project adopts a quality management approach inspired by internationally
+recognised standards to ensure that engineering activities remain reliable,
+secure, and maintainable.
+
+## Governance and Life Cycle (ISO/IEC 12207 & ISO/IEC 90003)
+
+- Maintain documented requirements, architecture decisions, and verification
+  artefacts for each release.
+- Track changes through version control with peer reviews before merging into
+  mainline branches.
+- Record configuration baselines for infrastructure, application settings, and
+  dependencies.
+
+## Product Quality (ISO/IEC 25010)
+
+- Reliability: include automated smoke tests in the CI pipeline and ensure that
+  database migrations are reversible.
+- Maintainability: follow PSR-12 for PHP and use static analysis (PHPStan or
+  Psalm) on every merge request.
+- Security: conduct dependency scanning and review access controls every
+  quarter.
+
+## Information Security (ISO/IEC 27001 & 27002)
+
+- Enforce least privilege for database credentials and rotate secrets at least
+  every 90 days.
+- Apply transport security (TLS), HTTP security headers, and continuous
+  monitoring of failed logins.
+- Perform annual risk assessments and update the Statement of Applicability to
+  reflect implemented controls.
+
+## Service Management (ISO/IEC 20000-1)
+
+- Define service level objectives for availability and response times.
+- Document incident response procedures, including communication templates and
+  escalation matrices.
+- Review post-incident action items within 10 business days of closure.
+
+## Accessibility and Usability (ISO 9241 & ISO/IEC 40500)
+
+- Ensure colour contrast ratios meet WCAG 2.1 AA requirements.
+- Provide keyboard navigable interfaces and descriptive alternative text for
+  imagery.
+- Perform usability evaluations with representative users each release cycle.
+
+## Continuous Improvement (ISO 9001)
+
+- Capture lessons learned after each iteration and feed them into a living
+  improvement backlog.
+- Measure process effectiveness via defect density, mean time to recovery, and
+  customer satisfaction indices.
+- Audit compliance quarterly and track corrective actions to closure.
+
+## Documentation and Training (ISO/IEC 19770 & ISO/IEC 24748)
+
+- Maintain an asset registry of deployed components, including licence and
+  support details.
+- Provide onboarding material covering architecture, secure coding guidelines,
+  and operations runbooks.
+- Review documentation every six months to keep procedures current.
+
+## Verification Checklist
+
+Use the following checklist prior to each release:
+
+- [ ] Automated tests pass locally and in CI.
+- [ ] Security headers and TLS configuration validated.
+- [ ] Accessibility review completed.
+- [ ] Backups verified and restoration drill performed within the last quarter.
+- [ ] Compliance evidence stored in the project knowledge base.

--- a/index.php
+++ b/index.php
@@ -84,7 +84,8 @@ $contact = htmlspecialchars($cfg['contact'] ?? '');
       </div>
     </div>
   </div>
-  <script>window.APP_BASE_URL = <?=json_encode(BASE_URL, JSON_THROW_ON_ERROR)?>;</script>
+  <script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">window.APP_BASE_URL = <?=json_encode(BASE_URL, JSON_THROW_ON_ERROR)?>;</script>
   <script src="<?=asset_url('assets/js/app.js')?>"></script>
 </body>
 </html>
+

--- a/lib/security.php
+++ b/lib/security.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Apply security headers aligned with ISO/IEC 27001 control objectives
+ * and OWASP application security guidelines.
+ */
+function apply_security_headers(bool $isDebugMode = false): void
+{
+    if (headers_sent()) {
+        return;
+    }
+
+    $nonce = csp_nonce();
+
+    $scriptSrc = [
+        "'self'",
+        sprintf("'nonce-%s'", $nonce),
+        'https://cdn.jsdelivr.net',
+    ];
+
+    if ($isDebugMode) {
+        // Allow eval in debug mode so that developer tools continue working.
+        $scriptSrc[] = "'unsafe-eval'";
+    }
+
+    $styleSrc = [
+        "'self'",
+        "'unsafe-inline'", // legacy support for third-party stylesheets.
+    ];
+
+    $directives = [
+        'default-src' => "'self'",
+        'base-uri' => "'self'",
+        'form-action' => "'self'",
+        'frame-ancestors' => "'self'",
+        'connect-src' => "'self'",
+        'img-src' => "'self' data: https:",
+        'script-src' => implode(' ', $scriptSrc),
+        'style-src' => implode(' ', $styleSrc),
+        'font-src' => "'self' data:",
+        'object-src' => "'none'",
+    ];
+
+    $csp = [];
+    foreach ($directives as $name => $value) {
+        $csp[] = $name . ' ' . $value;
+    }
+
+    header('Content-Security-Policy: ' . implode('; ', $csp));
+    header('X-Content-Type-Options: nosniff');
+    header('X-Frame-Options: SAMEORIGIN');
+    header('Referrer-Policy: strict-origin-when-cross-origin');
+    header('Cross-Origin-Opener-Policy: same-origin');
+    header('Cross-Origin-Resource-Policy: same-origin');
+    header('Permissions-Policy: geolocation=(), microphone=(), camera=()');
+
+    if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+        header('Strict-Transport-Security: max-age=31536000; includeSubDomains; preload');
+    }
+}
+
+/**
+ * Retrieve a nonce for inline scripts so they comply with the CSP header.
+ */
+function csp_nonce(): string
+{
+    static $nonce;
+    if ($nonce === null) {
+        $nonce = bin2hex(random_bytes(16));
+    }
+
+    return $nonce;
+}

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -7,5 +7,6 @@ $t = load_lang($locale);
 <footer class="md-footer">
   <div class="md-small text-center"><?=htmlspecialchars(t($t, 'footer_note', 'My Performance — Material-inspired UI. Admin can update logo, site name, landing text, address, and contact.'), ENT_QUOTES, 'UTF-8')?></div>
 </footer>
-<script>window.APP_BASE_URL = <?=json_encode(BASE_URL, JSON_THROW_ON_ERROR)?>;</script>
+<script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">window.APP_BASE_URL = <?=json_encode(BASE_URL, JSON_THROW_ON_ERROR)?>;</script>
 <script src="<?=asset_url('assets/js/app.js')?>"></script>
+


### PR DESCRIPTION
## Summary
- introduce a reusable security header helper that emits CSP, transport and privacy controls aligned with ISO/IEC 27001
- update bootstrap and templates to consume CSP nonces for inline scripts
- document the ISO-focused quality management approach and reference it from the README

## Testing
- php -l config.php
- php -l lib/security.php
- php -l index.php
- php -l templates/footer.php

------
https://chatgpt.com/codex/tasks/task_e_68e84793a4e4832da397bfa807ea615c