### PR TITLE
Add configurable OAuth SSO and update navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Environment variables are read directly via `getenv`. Set them in your shell or 
 - `BASE_URL` (defaults to `/`)
 - `APP_DEBUG` (`1` to show errors in development, otherwise disable display of errors)
 
+### Single sign-on
+
+Administrators can configure Google Workspace or Microsoft Entra ID (Azure AD) authentication under **Administration → Branding & Landing**. Provide the client ID, client secret, and (for Microsoft) the tenant identifier. The OAuth redirect URL is `<BASE_URL>/oauth.php?provider=<google|microsoft>&action=callback`; ensure this is registered with each provider. When enabled, the login page renders "Sign in with Google" or "Sign in with Microsoft" buttons alongside the classic username/password form.
+
 ## Internationalisation
 
 Translations live in `lang/*.json`. Users can switch between English, French, and Amharic via the language selector. Preferences persist in the session and a cookie. To add a language:
@@ -65,7 +69,7 @@ delivery workflow with ISO/IEC 12207 (software life cycle), ISO/IEC 25010
 ## Default navigation
 
 - `/index.php` – login
-- `/dashboard.php` – user dashboard
+- `/my_performance.php` – personal performance hub (default landing page after login)
 - `/submit_assessment.php` – assessment submission
 - `/admin/*` – administration
 

--- a/admin/branding.php
+++ b/admin/branding.php
@@ -24,6 +24,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $footer_hotline_label = trim($_POST['footer_hotline_label'] ?? '');
     $footer_hotline_number = trim($_POST['footer_hotline_number'] ?? '');
     $footer_rights = trim($_POST['footer_rights'] ?? '');
+    $google_oauth_enabled = isset($_POST['google_oauth_enabled']) ? 1 : 0;
+    $google_oauth_client_id = trim($_POST['google_oauth_client_id'] ?? '');
+    $google_oauth_client_secret = trim($_POST['google_oauth_client_secret'] ?? '');
+    $microsoft_oauth_enabled = isset($_POST['microsoft_oauth_enabled']) ? 1 : 0;
+    $microsoft_oauth_client_id = trim($_POST['microsoft_oauth_client_id'] ?? '');
+    $microsoft_oauth_client_secret = trim($_POST['microsoft_oauth_client_secret'] ?? '');
+    $microsoft_oauth_tenant = trim($_POST['microsoft_oauth_tenant'] ?? '');
+    if ($microsoft_oauth_tenant === '') {
+        $microsoft_oauth_tenant = 'common';
+    }
 
     if ($footer_website_url && !preg_match('#^https?://#i', $footer_website_url)) {
         $footer_website_url = 'https://' . ltrim($footer_website_url, '/');
@@ -66,6 +76,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'footer_hotline_label' => $footer_hotline_label,
         'footer_hotline_number' => $footer_hotline_number,
         'footer_rights' => $footer_rights,
+        'google_oauth_enabled' => $google_oauth_enabled,
+        'google_oauth_client_id' => $google_oauth_client_id,
+        'google_oauth_client_secret' => $google_oauth_client_secret,
+        'microsoft_oauth_enabled' => $microsoft_oauth_enabled,
+        'microsoft_oauth_client_id' => $microsoft_oauth_client_id,
+        'microsoft_oauth_client_secret' => $microsoft_oauth_client_secret,
+        'microsoft_oauth_tenant' => $microsoft_oauth_tenant,
     ];
 
     $assignments = [];
@@ -114,6 +131,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <label class="md-field"><span><?=t($t,'footer_hotline_label_label','Hotline Label')?></span><input name="footer_hotline_label" value="<?=htmlspecialchars($cfg['footer_hotline_label'] ?? '')?>"></label>
       <label class="md-field"><span><?=t($t,'footer_hotline_number_label','Hotline Number')?></span><input name="footer_hotline_number" value="<?=htmlspecialchars($cfg['footer_hotline_number'] ?? '')?>"></label>
       <label class="md-field"><span><?=t($t,'footer_rights_label','Rights Statement')?></span><input name="footer_rights" value="<?=htmlspecialchars($cfg['footer_rights'] ?? '')?>"></label>
+      <h3 class="md-subhead"><?=t($t,'sso_settings','Single Sign-On (SSO)')?></h3>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="google_oauth_enabled" value="1" <?=((int)($cfg['google_oauth_enabled'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'enable_google_sign_in','Enable Google sign-in')?></span>
+        </label>
+      </div>
+      <label class="md-field"><span><?=t($t,'google_client_id','Google Client ID')?></span><input name="google_oauth_client_id" value="<?=htmlspecialchars($cfg['google_oauth_client_id'] ?? '')?>"></label>
+      <label class="md-field"><span><?=t($t,'google_client_secret','Google Client Secret')?></span><input type="password" name="google_oauth_client_secret" value="<?=htmlspecialchars($cfg['google_oauth_client_secret'] ?? '')?>"></label>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="microsoft_oauth_enabled" value="1" <?=((int)($cfg['microsoft_oauth_enabled'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'enable_microsoft_sign_in','Enable Microsoft sign-in')?></span>
+        </label>
+      </div>
+      <label class="md-field"><span><?=t($t,'microsoft_client_id','Microsoft Client ID')?></span><input name="microsoft_oauth_client_id" value="<?=htmlspecialchars($cfg['microsoft_oauth_client_id'] ?? '')?>"></label>
+      <label class="md-field"><span><?=t($t,'microsoft_client_secret','Microsoft Client Secret')?></span><input type="password" name="microsoft_oauth_client_secret" value="<?=htmlspecialchars($cfg['microsoft_oauth_client_secret'] ?? '')?>"></label>
+      <label class="md-field"><span><?=t($t,'microsoft_tenant','Microsoft Tenant (directory)')?></span><input name="microsoft_oauth_tenant" value="<?=htmlspecialchars($cfg['microsoft_oauth_tenant'] ?? 'common')?>"></label>
       <div class="md-field">
         <span><?=t($t,'logo','Logo')?></span>
         <input type="file" name="logo" accept="image/*">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -276,6 +276,60 @@ body.md-bg {
   box-shadow: 0 0 0 3px rgba(42, 182, 115, 0.2);
 }
 
+.md-control {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0 0.2rem;
+}
+
+.md-control label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--app-muted);
+}
+
+.md-control input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--app-secondary);
+}
+
+.md-sso-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.md-sso-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  text-align: center;
+}
+
+.md-sso-btn.google {
+  background: #ffffff;
+  border: 1px solid rgba(66, 133, 244, 0.35);
+  color: #0b4684;
+}
+
+.md-sso-btn.microsoft {
+  background: #ffffff;
+  border: 1px solid rgba(0, 120, 212, 0.35);
+  color: #0a3e82;
+}
+
+.md-sso-btn.google:hover,
+.md-sso-btn.microsoft:hover {
+  background: rgba(255, 255, 255, 0.92);
+}
+
 .md-form-actions {
   display: flex;
   justify-content: flex-end;

--- a/config.php
+++ b/config.php
@@ -189,6 +189,13 @@ function ensure_site_config_schema(PDO $pdo): void {
         'footer_hotline_label' => 'ALTER TABLE site_config ADD COLUMN footer_hotline_label VARCHAR(255) NULL',
         'footer_hotline_number' => 'ALTER TABLE site_config ADD COLUMN footer_hotline_number VARCHAR(50) NULL',
         'footer_rights' => 'ALTER TABLE site_config ADD COLUMN footer_rights VARCHAR(255) NULL',
+        'google_oauth_enabled' => 'ALTER TABLE site_config ADD COLUMN google_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0',
+        'google_oauth_client_id' => 'ALTER TABLE site_config ADD COLUMN google_oauth_client_id VARCHAR(255) NULL',
+        'google_oauth_client_secret' => 'ALTER TABLE site_config ADD COLUMN google_oauth_client_secret VARCHAR(255) NULL',
+        'microsoft_oauth_enabled' => 'ALTER TABLE site_config ADD COLUMN microsoft_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0',
+        'microsoft_oauth_client_id' => 'ALTER TABLE site_config ADD COLUMN microsoft_oauth_client_id VARCHAR(255) NULL',
+        'microsoft_oauth_client_secret' => 'ALTER TABLE site_config ADD COLUMN microsoft_oauth_client_secret VARCHAR(255) NULL',
+        'microsoft_oauth_tenant' => 'ALTER TABLE site_config ADD COLUMN microsoft_oauth_tenant VARCHAR(255) NULL'
     ];
 
     foreach ($schema as $field => $sql) {
@@ -216,11 +223,18 @@ function get_site_config(PDO $pdo): array {
         'footer_hotline_label' => 'Hotline 939',
         'footer_hotline_number' => '939',
         'footer_rights' => 'All rights reserved.',
+        'google_oauth_enabled' => 0,
+        'google_oauth_client_id' => null,
+        'google_oauth_client_secret' => null,
+        'microsoft_oauth_enabled' => 0,
+        'microsoft_oauth_client_id' => null,
+        'microsoft_oauth_client_secret' => null,
+        'microsoft_oauth_tenant' => 'common',
     ];
 
     try {
         ensure_site_config_schema($pdo);
-        $pdo->exec("INSERT IGNORE INTO site_config (id, site_name, landing_text, address, contact, logo_path, footer_org_name, footer_org_short, footer_website_label, footer_website_url, footer_email, footer_phone, footer_hotline_label, footer_hotline_number, footer_rights) VALUES (1, 'My Performance', NULL, NULL, NULL, NULL, 'Ethiopian Pharmaceutical Supply Service', 'EPSS / EPS', 'epss.gov.et', 'https://epss.gov.et', 'info@epss.gov.et', '+251 11 155 9900', 'Hotline 939', '939', 'All rights reserved.')");
+        $pdo->exec("INSERT IGNORE INTO site_config (id, site_name, landing_text, address, contact, logo_path, footer_org_name, footer_org_short, footer_website_label, footer_website_url, footer_email, footer_phone, footer_hotline_label, footer_hotline_number, footer_rights, google_oauth_enabled, google_oauth_client_id, google_oauth_client_secret, microsoft_oauth_enabled, microsoft_oauth_client_id, microsoft_oauth_client_secret, microsoft_oauth_tenant) VALUES (1, 'My Performance', NULL, NULL, NULL, NULL, 'Ethiopian Pharmaceutical Supply Service', 'EPSS / EPS', 'epss.gov.et', 'https://epss.gov.et', 'info@epss.gov.et', '+251 11 155 9900', 'Hotline 939', '939', 'All rights reserved.', 0, NULL, NULL, 0, NULL, NULL, 'common')");
         $cfg = $pdo->query('SELECT * FROM site_config WHERE id=1')->fetch(PDO::FETCH_ASSOC);
     } catch (PDOException $e) {
         error_log('get_site_config failed: ' . $e->getMessage());

--- a/dashboard.php
+++ b/dashboard.php
@@ -3,25 +3,7 @@ require_once __DIR__ . '/config.php';
 auth_required();
 refresh_current_user($pdo);
 require_profile_completion($pdo);
-$locale = ensure_locale();
-$t = load_lang($locale);
-$user = current_user();
-$cfg = get_site_config($pdo);
-?>
-<!doctype html><html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>"><head>
-<meta charset="utf-8"><title><?=htmlspecialchars(t($t,'dashboard','Dashboard'), ENT_QUOTES, 'UTF-8')?></title>
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="app-base-url" content="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
-<link rel="manifest" href="<?=asset_url('manifest.webmanifest')?>">
-<link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
-<link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
-</head><body class="md-bg">
-<?php include __DIR__.'/templates/header.php'; ?>
-<section class="md-section">
-  <div class="md-card md-elev-2">
-    <h2 class="md-card-title"><?=t($t,'welcome','Welcome')?>, <?=htmlspecialchars($user['full_name'] ?? $user['username'])?></h2>
-    <p><?=t($t,'dashboard_intro','Use the menu to submit self-assessments, track performance, or administer the system.')?></p>
-  </div>
-</section>
-<?php include __DIR__.'/templates/footer.php'; ?>
-</body></html>
+
+$redirectTarget = url_for('my_performance.php');
+header('Location: ' . $redirectTarget);
+exit;

--- a/init.sql
+++ b/init.sql
@@ -27,7 +27,14 @@ CREATE TABLE site_config (
   footer_phone VARCHAR(255) NULL,
   footer_hotline_label VARCHAR(255) NULL,
   footer_hotline_number VARCHAR(50) NULL,
-  footer_rights VARCHAR(255) NULL
+  footer_rights VARCHAR(255) NULL,
+  google_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  google_oauth_client_id VARCHAR(255) NULL,
+  google_oauth_client_secret VARCHAR(255) NULL,
+  microsoft_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  microsoft_oauth_client_id VARCHAR(255) NULL,
+  microsoft_oauth_client_secret VARCHAR(255) NULL,
+  microsoft_oauth_tenant VARCHAR(255) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE users (
@@ -164,7 +171,14 @@ INSERT INTO site_config (
   footer_phone,
   footer_hotline_label,
   footer_hotline_number,
-  footer_rights
+  footer_rights,
+  google_oauth_enabled,
+  google_oauth_client_id,
+  google_oauth_client_secret,
+  microsoft_oauth_enabled,
+  microsoft_oauth_client_id,
+  microsoft_oauth_client_secret,
+  microsoft_oauth_tenant
 ) VALUES (
   1,
   'My Performance',
@@ -180,7 +194,14 @@ INSERT INTO site_config (
   '+251 11 155 9900',
   'Hotline 939',
   '939',
-  'All rights reserved.'
+  'All rights reserved.',
+  0,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  'common'
 );
 
 -- default users (bcrypt hashes should be set during runtime; using demo placeholder hashes)

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "My Performance",
   "short_name": "Performance",
-  "start_url": "dashboard.php",
+  "start_url": "my_performance.php",
   "display": "standalone",
   "background_color": "#f5f5f5",
   "theme_color": "#3949ab",

--- a/migration.sql
+++ b/migration.sql
@@ -16,7 +16,14 @@ CREATE TABLE IF NOT EXISTS site_config (
   footer_phone VARCHAR(255) NULL,
   footer_hotline_label VARCHAR(255) NULL,
   footer_hotline_number VARCHAR(50) NULL,
-  footer_rights VARCHAR(255) NULL
+  footer_rights VARCHAR(255) NULL,
+  google_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  google_oauth_client_id VARCHAR(255) NULL,
+  google_oauth_client_secret VARCHAR(255) NULL,
+  microsoft_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0,
+  microsoft_oauth_client_id VARCHAR(255) NULL,
+  microsoft_oauth_client_secret VARCHAR(255) NULL,
+  microsoft_oauth_tenant VARCHAR(255) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS footer_org_name VARCHAR(255) NULL AFTER logo_path,
@@ -27,7 +34,14 @@ ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS footer_phone VARCHAR(255) NULL AFTER footer_email,
   ADD COLUMN IF NOT EXISTS footer_hotline_label VARCHAR(255) NULL AFTER footer_phone,
   ADD COLUMN IF NOT EXISTS footer_hotline_number VARCHAR(50) NULL AFTER footer_hotline_label,
-  ADD COLUMN IF NOT EXISTS footer_rights VARCHAR(255) NULL AFTER footer_hotline_number;
+  ADD COLUMN IF NOT EXISTS footer_rights VARCHAR(255) NULL AFTER footer_hotline_number,
+  ADD COLUMN IF NOT EXISTS google_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0 AFTER footer_rights,
+  ADD COLUMN IF NOT EXISTS google_oauth_client_id VARCHAR(255) NULL AFTER google_oauth_enabled,
+  ADD COLUMN IF NOT EXISTS google_oauth_client_secret VARCHAR(255) NULL AFTER google_oauth_client_id,
+  ADD COLUMN IF NOT EXISTS microsoft_oauth_enabled TINYINT(1) NOT NULL DEFAULT 0 AFTER google_oauth_client_secret,
+  ADD COLUMN IF NOT EXISTS microsoft_oauth_client_id VARCHAR(255) NULL AFTER microsoft_oauth_enabled,
+  ADD COLUMN IF NOT EXISTS microsoft_oauth_client_secret VARCHAR(255) NULL AFTER microsoft_oauth_client_id,
+  ADD COLUMN IF NOT EXISTS microsoft_oauth_tenant VARCHAR(255) NULL AFTER microsoft_oauth_client_secret;
 INSERT IGNORE INTO site_config (
   id,
   site_name,
@@ -43,7 +57,14 @@ INSERT IGNORE INTO site_config (
   footer_phone,
   footer_hotline_label,
   footer_hotline_number,
-  footer_rights
+  footer_rights,
+  google_oauth_enabled,
+  google_oauth_client_id,
+  google_oauth_client_secret,
+  microsoft_oauth_enabled,
+  microsoft_oauth_client_id,
+  microsoft_oauth_client_secret,
+  microsoft_oauth_tenant
 ) VALUES (
   1,
   'My Performance',
@@ -59,7 +80,14 @@ INSERT IGNORE INTO site_config (
   '+251 11 155 9900',
   'Hotline 939',
   '939',
-  'All rights reserved.'
+  'All rights reserved.',
+  0,
+  NULL,
+  NULL,
+  0,
+  NULL,
+  NULL,
+  'common'
 );
 
 ALTER TABLE users

--- a/oauth.php
+++ b/oauth.php
@@ -1,0 +1,308 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$provider = strtolower(trim((string)($_GET['provider'] ?? '')));
+$allowedProviders = ['google', 'microsoft'];
+if (!in_array($provider, $allowedProviders, true)) {
+    http_response_code(400);
+    echo 'Unknown provider.';
+    exit;
+}
+
+$cfg = get_site_config($pdo);
+$action = strtolower((string)($_GET['action'] ?? 'start'));
+if ($action !== 'callback') {
+    $action = 'start';
+}
+
+$providerConfig = build_provider_config($cfg, $provider);
+if (!$providerConfig['enabled']) {
+    oauth_fail('This sign-in method is not currently available. Please use the standard login form.', $provider);
+}
+
+if ($action === 'start') {
+    $state = bin2hex(random_bytes(24));
+    if (!isset($_SESSION['oauth_state']) || !is_array($_SESSION['oauth_state'])) {
+        $_SESSION['oauth_state'] = [];
+    }
+    $_SESSION['oauth_state'][$provider] = $state;
+
+    $redirectUri = oauth_redirect_uri($provider);
+    $params = [
+        'client_id' => $providerConfig['client_id'],
+        'redirect_uri' => $redirectUri,
+        'response_type' => 'code',
+        'scope' => implode(' ', $providerConfig['scopes']),
+        'state' => $state,
+    ];
+    $authParams = array_merge($params, $providerConfig['authorize_params']);
+    $authUrl = $providerConfig['authorize_url'] . '?' . http_build_query($authParams, '', '&', PHP_QUERY_RFC3986);
+    header('Location: ' . $authUrl);
+    exit;
+}
+
+if (isset($_GET['error'])) {
+    oauth_fail('Sign-in was cancelled or denied. Please try again.', $provider);
+}
+
+$expectedState = $_SESSION['oauth_state'][$provider] ?? '';
+$receivedState = (string)($_GET['state'] ?? '');
+if ($expectedState === '' || $receivedState === '' || !hash_equals($expectedState, $receivedState)) {
+    unset($_SESSION['oauth_state'][$provider]);
+    oauth_fail('Authentication attempt could not be validated. Please try again.', $provider);
+}
+unset($_SESSION['oauth_state'][$provider]);
+
+$code = trim((string)($_GET['code'] ?? ''));
+if ($code === '') {
+    oauth_fail('Missing authorization code from the identity provider.', $provider);
+}
+
+$redirectUri = oauth_redirect_uri($provider);
+$tokenPayload = [
+    'client_id' => $providerConfig['client_id'],
+    'client_secret' => $providerConfig['client_secret'],
+    'code' => $code,
+    'grant_type' => 'authorization_code',
+    'redirect_uri' => $redirectUri,
+    'scope' => implode(' ', $providerConfig['scopes']),
+];
+
+try {
+    [$tokenStatus, $tokenData] = oauth_post_json($providerConfig['token_url'], $tokenPayload);
+} catch (RuntimeException $e) {
+    oauth_fail('Could not complete authentication: ' . oauth_sanitize($e->getMessage()), $provider);
+}
+
+if ($tokenStatus >= 400) {
+    $errorMessage = isset($tokenData['error_description']) ? $tokenData['error_description'] : ($tokenData['error'] ?? 'Authentication failed.');
+    oauth_fail('Authentication failed: ' . oauth_sanitize((string)$errorMessage), $provider);
+}
+
+$accessToken = (string)($tokenData['access_token'] ?? '');
+if ($accessToken === '') {
+    oauth_fail('The identity provider did not return an access token.', $provider);
+}
+
+try {
+    [$profileStatus, $profileData] = oauth_get_json($providerConfig['userinfo_url'], $accessToken, $providerConfig['userinfo_headers']);
+} catch (RuntimeException $e) {
+    oauth_fail('Unable to retrieve your profile information: ' . oauth_sanitize($e->getMessage()), $provider);
+}
+
+if ($profileStatus >= 400) {
+    oauth_fail('Unable to retrieve your profile information. Please try again.', $provider);
+}
+
+[$email, $displayName] = extract_identity($profileData, $provider);
+if ($email === '') {
+    oauth_fail('Unable to determine your account email address from the identity provider.', $provider);
+}
+
+$user = lookup_user_by_identity($pdo, $email, $displayName);
+if (!$user) {
+    oauth_fail('No user account is linked to ' . $email . '. Please contact your administrator.', $provider);
+}
+
+if (empty($user['first_login_at'])) {
+    $pdo->prepare('UPDATE users SET first_login_at = NOW() WHERE id = ?')->execute([$user['id']]);
+}
+
+$_SESSION['user'] = $user;
+refresh_current_user($pdo);
+if (isset($_SESSION['user']['language']) && $_SESSION['user']['language'] !== '') {
+    $_SESSION['lang'] = $_SESSION['user']['language'];
+}
+
+header('Location: ' . url_for('my_performance.php'));
+exit;
+
+function oauth_fail(string $message, string $provider): void
+{
+    $_SESSION['oauth_error'] = $message;
+    header('Location: ' . url_for('index.php'));
+    exit;
+}
+
+function oauth_redirect_uri(string $provider): string
+{
+    $base = rtrim(BASE_URL, '/');
+    $path = $base === '' ? '/oauth.php' : $base . '/oauth.php';
+    if (!preg_match('#^https?://#i', $path)) {
+        $scheme = (!empty($_SERVER['HTTPS']) && strtolower((string)$_SERVER['HTTPS']) !== 'off') ? 'https' : 'http';
+        $host = $_SERVER['HTTP_HOST'] ?? ($_SERVER['SERVER_NAME'] ?? 'localhost');
+        $path = $scheme . '://' . $host . $path;
+    }
+    return $path . '?provider=' . rawurlencode($provider) . '&action=callback';
+}
+
+function build_provider_config(array $cfg, string $provider): array
+{
+    $defaults = [
+        'enabled' => false,
+        'client_id' => null,
+        'client_secret' => null,
+        'authorize_url' => '',
+        'authorize_params' => [],
+        'token_url' => '',
+        'userinfo_url' => '',
+        'userinfo_headers' => ['Accept: application/json'],
+        'scopes' => [],
+    ];
+
+    if ($provider === 'google') {
+        $clientId = trim((string)($cfg['google_oauth_client_id'] ?? ''));
+        $clientSecret = trim((string)($cfg['google_oauth_client_secret'] ?? ''));
+        return array_merge($defaults, [
+            'enabled' => ((int)($cfg['google_oauth_enabled'] ?? 0) === 1) && $clientId !== '' && $clientSecret !== '',
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'authorize_url' => 'https://accounts.google.com/o/oauth2/v2/auth',
+            'authorize_params' => ['prompt' => 'select_account', 'access_type' => 'online'],
+            'token_url' => 'https://oauth2.googleapis.com/token',
+            'userinfo_url' => 'https://openidconnect.googleapis.com/v1/userinfo',
+            'scopes' => ['openid', 'email', 'profile'],
+        ]);
+    }
+
+    $clientId = trim((string)($cfg['microsoft_oauth_client_id'] ?? ''));
+    $clientSecret = trim((string)($cfg['microsoft_oauth_client_secret'] ?? ''));
+    $tenant = trim((string)($cfg['microsoft_oauth_tenant'] ?? 'common'));
+    if ($tenant === '') {
+        $tenant = 'common';
+    }
+    $tenantSafe = preg_replace('/[^A-Za-z0-9\.-]/', '', $tenant) ?: 'common';
+    $tenantSafe = strtolower($tenantSafe);
+
+    return array_merge($defaults, [
+        'enabled' => ((int)($cfg['microsoft_oauth_enabled'] ?? 0) === 1) && $clientId !== '' && $clientSecret !== '',
+        'client_id' => $clientId,
+        'client_secret' => $clientSecret,
+        'authorize_url' => 'https://login.microsoftonline.com/' . rawurlencode($tenantSafe) . '/oauth2/v2.0/authorize',
+        'authorize_params' => ['response_mode' => 'query'],
+        'token_url' => 'https://login.microsoftonline.com/' . rawurlencode($tenantSafe) . '/oauth2/v2.0/token',
+        'userinfo_url' => 'https://graph.microsoft.com/v1.0/me?$select=displayName,mail,userPrincipalName',
+        'userinfo_headers' => ['Accept: application/json; charset=utf-8'],
+        'scopes' => ['openid', 'email', 'profile', 'User.Read'],
+    ]);
+}
+
+function oauth_post_json(string $url, array $params): array
+{
+    $ch = curl_init($url);
+    if ($ch === false) {
+        throw new RuntimeException('Unable to initialise HTTP client.');
+    }
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POSTFIELDS => http_build_query($params, '', '&', PHP_QUERY_RFC3986),
+        CURLOPT_HTTPHEADER => ['Content-Type: application/x-www-form-urlencoded'],
+        CURLOPT_TIMEOUT => 20,
+    ]);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException('HTTP request failed: ' . $err);
+    }
+    $status = (int)curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+    $data = json_decode($response, true);
+    if (!is_array($data)) {
+        throw new RuntimeException('Unexpected response from identity provider.');
+    }
+    return [$status, $data];
+}
+
+function oauth_get_json(string $url, string $accessToken, array $extraHeaders = []): array
+{
+    $ch = curl_init($url);
+    if ($ch === false) {
+        throw new RuntimeException('Unable to initialise HTTP client.');
+    }
+    $headers = array_merge($extraHeaders, ['Authorization: Bearer ' . $accessToken]);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => $headers,
+        CURLOPT_TIMEOUT => 20,
+    ]);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException('HTTP request failed: ' . $err);
+    }
+    $status = (int)curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+    $data = json_decode($response, true);
+    if (!is_array($data)) {
+        throw new RuntimeException('Unexpected response from identity provider.');
+    }
+    return [$status, $data];
+}
+
+function extract_identity(array $profile, string $provider): array
+{
+    $email = '';
+    $name = '';
+    if ($provider === 'google') {
+        $email = strtolower(trim((string)($profile['email'] ?? '')));
+        $name = trim((string)($profile['name'] ?? ''));
+    } else {
+        $emailRaw = (string)($profile['mail'] ?? '');
+        if ($emailRaw === '') {
+            $emailRaw = (string)($profile['userPrincipalName'] ?? '');
+        }
+        $email = strtolower(trim($emailRaw));
+        $name = trim((string)($profile['displayName'] ?? ''));
+    }
+    return [$email, $name];
+}
+
+function lookup_user_by_identity(PDO $pdo, string $email, string $displayName)
+{
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE LOWER(email) = LOWER(?) LIMIT 1');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if ($user) {
+        return $user;
+    }
+
+    $stmt = $pdo->prepare('SELECT * FROM users WHERE LOWER(username) = LOWER(?) LIMIT 1');
+    $stmt->execute([$email]);
+    $user = $stmt->fetch();
+    if ($user) {
+        return $user;
+    }
+
+    if (str_contains($email, '@')) {
+        $local = substr($email, 0, strpos($email, '@'));
+        if ($local !== '') {
+            $stmt = $pdo->prepare('SELECT * FROM users WHERE LOWER(username) = LOWER(?) LIMIT 1');
+            $stmt->execute([$local]);
+            $user = $stmt->fetch();
+            if ($user) {
+                return $user;
+            }
+        }
+    }
+
+    if ($displayName !== '') {
+        $stmt = $pdo->prepare('SELECT * FROM users WHERE LOWER(full_name) = LOWER(?) LIMIT 1');
+        $stmt->execute([$displayName]);
+        $user = $stmt->fetch();
+        if ($user) {
+            return $user;
+        }
+    }
+
+    return false;
+}
+
+function oauth_sanitize(string $message): string
+{
+    $clean = strip_tags($message);
+    $clean = preg_replace('/\s+/', ' ', $clean ?? '');
+    return trim((string)$clean);
+}

--- a/set_lang.php
+++ b/set_lang.php
@@ -9,7 +9,7 @@ if (!empty($_SESSION['user']['id'])) {
     $stmt->execute([$lang, $_SESSION['user']['id']]);
     refresh_current_user($pdo);
 }
-$redirect = cleanRedirect($_SERVER['HTTP_REFERER'] ?? '', url_for('dashboard.php'));
+$redirect = cleanRedirect($_SERVER['HTTP_REFERER'] ?? '', url_for('my_performance.php'));
 header('Location: ' . $redirect);
 exit;
 ?>

--- a/templates/header.php
+++ b/templates/header.php
@@ -41,21 +41,24 @@ $availableLocales = available_locales();
   </div>
   <nav class="md-drawer-nav">
     <div class="md-drawer-section">
-      <span class="md-drawer-label"><?=t($t, 'main_navigation', 'Main Navigation')?></span>
-      <a href="<?=htmlspecialchars(url_for('dashboard.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'dashboard', 'Dashboard')?></a>
-      <a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'submit_assessment', 'Submit Assessment')?></a>
+      <span class="md-drawer-label"><?=t($t, 'my_workspace', 'My Workspace')?></span>
       <a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'my_performance', 'My Performance')?></a>
+      <a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'submit_assessment', 'Submit Assessment')?></a>
       <a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'profile', 'Profile')?></a>
-      <?php if (in_array($role, ['admin', 'supervisor'], true)): ?>
-        <a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'review_queue', 'Review Queue')?></a>
-      <?php endif; ?>
     </div>
+    <?php if (in_array($role, ['admin', 'supervisor'], true)): ?>
+      <div class="md-drawer-section">
+        <span class="md-drawer-label"><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
+        <a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'review_queue', 'Review Queue')?></a>
+      </div>
+    <?php endif; ?>
     <?php if ($role === 'admin'): ?>
       <div class="md-drawer-section">
         <span class="md-drawer-label"><?=t($t, 'admin_navigation', 'Administration')?></span>
         <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'admin_dashboard', 'Admin Dashboard')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'manage_users', 'Manage Users')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'analytics', 'Analytics')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'export_data', 'Export Data')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'branding', 'Branding & Landing')?></a>
       </div>


### PR DESCRIPTION
## Summary
- add database schema support and admin controls to configure Google and Microsoft OAuth login
- implement unified OAuth handler, surface SSO buttons on the login page, and document setup
- streamline navigation so My Performance is the default landing page and reorganize the drawer for admins and supervisors

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68e943f4f44c832d929d3ac6afe11d4a