### PR TITLE
Restrict logo uploads to standard image formats

### DIFF
--- a/admin/branding.php
+++ b/admin/branding.php
@@ -58,7 +58,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($finfo) {
                     finfo_close($finfo);
                 }
-                if (in_array($mime, ['image/png', 'image/jpeg', 'image/svg+xml', 'image/gif'], true)) {
+                $allowedMimes = ['image/png', 'image/jpeg', 'image/svg+xml', 'image/svg'];
+                if (in_array($mime, $allowedMimes, true)) {
                     if (move_uploaded_file($logoFile['tmp_name'], $dest)) {
                         $logo_path = 'assets/uploads/' . $fn;
                     } else {
@@ -167,7 +168,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <label class="md-field"><span><?=t($t,'microsoft_tenant','Microsoft Tenant (directory)')?></span><input name="microsoft_oauth_tenant" value="<?=htmlspecialchars($cfg['microsoft_oauth_tenant'] ?? 'common')?>"></label>
       <div class="md-field">
         <span><?=t($t,'logo','Logo')?></span>
-        <input type="file" name="logo" accept="image/*">
+        <input type="file" name="logo" accept=".png,.jpg,.jpeg,.svg,image/png,image/jpeg,image/svg+xml">
         <?php if (!empty($cfg['logo_path'])): ?>
           <?php $logoSrc = $cfg['logo_path'];
           if (!preg_match('#^https?://#i', (string)$logoSrc)) {


### PR DESCRIPTION
## Summary
- limit logo uploads to PNG, JPEG, and SVG MIME types to prevent unsupported files
- align the logo file input accept list with the allowed image formats

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea987daa9c832d93ab9fe7ed0bef67