### PR TITLE
Add Likert questionnaire defaults and performance trend chart

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -74,6 +74,9 @@ Import the schema and seed data:
 
 ```bash
 mysql -u epss_user -p epss_v300 < init.sql
+
+# Optional: load realistic demo data (populates every work function with five years of scores)
+mysql -u epss_user -p epss_v300 < dummy_data.sql
 ```
 
 Additional SQL utilities:
@@ -159,13 +162,14 @@ Certbot automatically configures the HTTPS virtual host and renewals (`systemctl
 
 ## 7. Post-Deployment Checklist
 
-1. **Login** with the seeded admin account (`admin / password from init.sql`) and immediately change the password from the Profile page.
+1. **Login** with the seeded admin account (`admin / Admin123`) and immediately change the password from the Profile page.
 2. **Complete the admin profile** so that other pages are accessible (profile completion is required).
 3. **Update branding** under **Admin → Branding & Landing** to set the landing text, address, contact, and logo.
 4. **Configure questionnaires** and performance periods as needed.
 5. **Create additional users** via **Admin → Manage Users**.
 6. **Verify FHIR endpoints** by hitting `https://epss.example.org/fhir/metadata.php` (should return JSON bundle).
 7. **Check browser offline support** (service worker) by loading the dashboard and toggling offline mode.
+8. **Review the performance trend chart** on **My Performance** to ensure Chart.js renders and the Likert-derived scores plot as expected (use the demo data for a quick smoke test).
 
 ---
 
@@ -239,7 +243,7 @@ Visit http://127.0.0.1:8000/index.php, log in with the seeded credentials, and e
 
 ## 12. Reference Accounts & Defaults
 
-* Admin login: `admin` / (hash defined in `init.sql`).
+* Admin login: `admin` / `Admin123`.
 * Supervisor login: `super` / same placeholder hash.
 * Staff login: `staff` / same placeholder hash.
 * Default branding: “My Performance” with EPSS logo at `assets/img/epss-logo.svg`.

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -175,6 +175,22 @@
   padding: 0.35rem 0.5rem;
 }
 
+.qb-option-readonly {
+  background: rgba(42, 79, 191, 0.12);
+  cursor: default;
+}
+
+.qb-option-list[data-locked="true"] .qb-handle {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.qb-likert-note {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  color: #2a4fbf;
+}
+
 .qb-option .qb-input {
   flex: 1 1 auto;
 }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -651,3 +651,43 @@ body.theme-dark .md-button.md-primary {
     justify-content: flex-end;
   }
 }
+
+.likert-scale {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.likert-scale__option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(13, 112, 56, 0.08);
+  min-width: 110px;
+}
+
+.likert-scale__option input[type="radio"] {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.likert-scale__option span {
+  font-size: 0.85rem;
+  text-align: center;
+  color: var(--app-muted);
+}
+
+.trend-chart-wrap {
+  width: 100%;
+  height: 260px;
+  margin-bottom: 1rem;
+}
+
+.trend-chart-wrap canvas {
+  max-height: 100%;
+}

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -1,39 +1,65 @@
--- dummy_data.sql: seed 10 demo users and 100 submissions between 2021 and 2025
+-- dummy_data.sql: seed demo users per work function and five years of submissions
 SET @password := '$2y$10$Pj9m0H6b8K2ZyQe7p0k1TOeGq1bqfP3QO3Y6b5g1YQb1J2lL8mJxC';
-DELETE FROM questionnaire_response WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'demo_user_%');
-DELETE FROM users WHERE username LIKE 'demo_user_%';
+
+DELETE FROM questionnaire_response
+WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+DELETE FROM users WHERE username LIKE 'demo_%';
 
 INSERT INTO users (username,password,role,full_name,email,gender,date_of_birth,phone,department,cadre,work_function,profile_completed)
 VALUES
-('demo_user_01',@password,'staff','Demo User 01','demo01@example.com','female','1990-01-01','+251900000001','Pharmacy','Officer','general_service',1),
-('demo_user_02',@password,'staff','Demo User 02','demo02@example.com','male','1989-02-01','+251900000002','Finance','Officer','finance',1),
-('demo_user_03',@password,'staff','Demo User 03','demo03@example.com','female','1991-03-01','+251900000003','ICT','Specialist','ict',1),
-('demo_user_04',@password,'staff','Demo User 04','demo04@example.com','female','1992-04-01','+251900000004','HR','Officer','hrm',1),
-('demo_user_05',@password,'staff','Demo User 05','demo05@example.com','male','1985-05-01','+251900000005','Leadership','Coordinator','leadership_tn',1),
-('demo_user_06',@password,'staff','Demo User 06','demo06@example.com','male','1988-06-01','+251900000006','Security','Guard','security',1),
-('demo_user_07',@password,'staff','Demo User 07','demo07@example.com','female','1993-07-01','+251900000007','Records','Officer','records_documentation',1),
-('demo_user_08',@password,'staff','Demo User 08','demo08@example.com','female','1994-08-01','+251900000008','Quantification','Analyst','quantification',1),
-('demo_user_09',@password,'staff','Demo User 09','demo09@example.com','male','1986-09-01','+251900000009','Transport','Driver','driver',1),
-('demo_user_10',@password,'staff','Demo User 10','demo10@example.com','female','1987-10-01','+251900000010','Ethics','Advisor','ethics',1);
+('demo_finance', @password, 'staff', 'Finance Demo', 'demo.finance@example.com', 'female', '1986-01-01', '+251910000001', 'Finance', 'Officer', 'finance', 1),
+('demo_general_service', @password, 'staff', 'General Service Demo', 'demo.general@example.com', 'male', '1987-02-01', '+251910000002', 'General Services', 'Officer', 'general_service', 1),
+('demo_hrm', @password, 'staff', 'HRM Demo', 'demo.hrm@example.com', 'female', '1988-03-01', '+251910000003', 'Human Resources', 'Specialist', 'hrm', 1),
+('demo_ict', @password, 'staff', 'ICT Demo', 'demo.ict@example.com', 'male', '1989-04-01', '+251910000004', 'ICT', 'Specialist', 'ict', 1),
+('demo_leadership', @password, 'staff', 'Leadership Demo', 'demo.leadership@example.com', 'female', '1985-05-01', '+251910000005', 'Leadership', 'Coordinator', 'leadership_tn', 1),
+('demo_legal', @password, 'staff', 'Legal Service Demo', 'demo.legal@example.com', 'female', '1984-06-01', '+251910000006', 'Legal Service', 'Advisor', 'legal_service', 1),
+('demo_pme', @password, 'staff', 'PME Demo', 'demo.pme@example.com', 'male', '1983-07-01', '+251910000007', 'Planning & Evaluation', 'Analyst', 'pme', 1),
+('demo_quant', @password, 'staff', 'Quantification Demo', 'demo.quant@example.com', 'female', '1982-08-01', '+251910000008', 'Quantification', 'Analyst', 'quantification', 1),
+('demo_records', @password, 'staff', 'Records Demo', 'demo.records@example.com', 'female', '1981-09-01', '+251910000009', 'Records Management', 'Officer', 'records_documentation', 1),
+('demo_security_driver', @password, 'staff', 'Security Driver Demo', 'demo.secdriver@example.com', 'male', '1980-10-01', '+251910000010', 'Security & Driver', 'Supervisor', 'security_driver', 1),
+('demo_security', @password, 'staff', 'Security Demo', 'demo.security@example.com', 'male', '1979-11-01', '+251910000011', 'Security', 'Officer', 'security', 1),
+('demo_tmd', @password, 'staff', 'TMD Demo', 'demo.tmd@example.com', 'female', '1978-12-01', '+251910000012', 'TMD', 'Officer', 'tmd', 1),
+('demo_wim', @password, 'staff', 'WIM Demo', 'demo.wim@example.com', 'female', '1977-01-15', '+251910000013', 'WIM', 'Officer', 'wim', 1),
+('demo_cmd', @password, 'staff', 'CMD Demo', 'demo.cmd@example.com', 'male', '1976-02-15', '+251910000014', 'CMD', 'Officer', 'cmd', 1),
+('demo_comm', @password, 'staff', 'Communication Demo', 'demo.communication@example.com', 'female', '1975-03-15', '+251910000015', 'Communication', 'Officer', 'communication', 1),
+('demo_dfm', @password, 'staff', 'DFM Demo', 'demo.dfm@example.com', 'male', '1974-04-15', '+251910000016', 'DFM', 'Officer', 'dfm', 1),
+('demo_driver', @password, 'staff', 'Driver Demo', 'demo.driver@example.com', 'male', '1973-05-15', '+251910000017', 'Transport', 'Driver', 'driver', 1),
+('demo_ethics', @password, 'staff', 'Ethics Demo', 'demo.ethics@example.com', 'female', '1972-06-15', '+251910000018', 'Ethics', 'Advisor', 'ethics', 1);
 
-SET @demo_q := (SELECT id FROM questionnaire LIMIT 1);
-WITH RECURSIVE seq AS (
-  SELECT 0 AS n
-  UNION ALL
-  SELECT n+1 FROM seq WHERE n < 99
-)
+SET @demo_q := (SELECT id FROM questionnaire ORDER BY id LIMIT 1);
+
+INSERT IGNORE INTO questionnaire_work_function (questionnaire_id, work_function)
+SELECT @demo_q, wf
+FROM (
+  SELECT 'finance' AS wf UNION ALL
+  SELECT 'general_service' UNION ALL
+  SELECT 'hrm' UNION ALL
+  SELECT 'ict' UNION ALL
+  SELECT 'leadership_tn' UNION ALL
+  SELECT 'legal_service' UNION ALL
+  SELECT 'pme' UNION ALL
+  SELECT 'quantification' UNION ALL
+  SELECT 'records_documentation' UNION ALL
+  SELECT 'security_driver' UNION ALL
+  SELECT 'security' UNION ALL
+  SELECT 'tmd' UNION ALL
+  SELECT 'wim' UNION ALL
+  SELECT 'cmd' UNION ALL
+  SELECT 'communication' UNION ALL
+  SELECT 'dfm' UNION ALL
+  SELECT 'driver' UNION ALL
+  SELECT 'ethics'
+) AS functions
+WHERE @demo_q IS NOT NULL;
+
 INSERT INTO questionnaire_response (user_id, questionnaire_id, performance_period_id, status, score, created_at)
 SELECT
-  (SELECT id FROM users WHERE username = CONCAT('demo_user_', LPAD((n % 10) + 1, 2, '0'))),
+  u.id,
   @demo_q,
-  CASE n % 5
-    WHEN 0 THEN (SELECT id FROM performance_period WHERE label='2021')
-    WHEN 1 THEN (SELECT id FROM performance_period WHERE label='2022')
-    WHEN 2 THEN (SELECT id FROM performance_period WHERE label='2023')
-    WHEN 3 THEN (SELECT id FROM performance_period WHERE label='2024')
-    ELSE (SELECT id FROM performance_period WHERE label='2025')
-  END,
+  pp.id,
   'submitted',
-  FLOOR(60 + RAND(n)*40),
-  DATE_ADD('2021-01-01', INTERVAL n DAY)
-FROM seq;
+  ROUND(55 + RAND(u.id * 13 + pp.id) * 45),
+  DATE_ADD(pp.period_start, INTERVAL ((u.id + pp.id) % 28) DAY)
+FROM users u
+JOIN performance_period pp ON pp.label IN ('2021','2022','2023','2024','2025')
+WHERE u.username LIKE 'demo_%' AND @demo_q IS NOT NULL;

--- a/dummy_data_cleanup.sql
+++ b/dummy_data_cleanup.sql
@@ -1,3 +1,3 @@
 -- dummy_data_cleanup.sql: remove seeded demo users and their submissions
-DELETE qr FROM questionnaire_response qr JOIN users u ON u.id = qr.user_id WHERE u.username LIKE 'demo_user_%';
-DELETE FROM users WHERE username LIKE 'demo_user_%';
+DELETE qr FROM questionnaire_response qr JOIN users u ON u.id = qr.user_id WHERE u.username LIKE 'demo_%';
+DELETE FROM users WHERE username LIKE 'demo_%';

--- a/fhir/Questionnaire.php
+++ b/fhir/Questionnaire.php
@@ -24,6 +24,8 @@ foreach ($qs as $q) {
         $type = $it['type'];
         if ($type === 'textarea') {
             $type = 'text';
+        } elseif ($type === 'likert') {
+            $type = 'choice';
         }
         $entry = array(
             'linkId' => $it['linkId'],
@@ -34,7 +36,7 @@ foreach ($qs as $q) {
                 'valueInteger' => (int)$it['weight_percent'],
             )),
         );
-        if ($it['type'] === 'choice') {
+        if ($it['type'] === 'choice' || $it['type'] === 'likert') {
             if (!empty($it['allow_multiple'])) {
                 $entry['repeats'] = true;
             }
@@ -44,6 +46,12 @@ foreach ($qs as $q) {
                 $entry['answerOption'] = array_map(static function ($value) {
                     return array('valueString' => $value);
                 }, $opts);
+            }
+            if ($it['type'] === 'likert') {
+                $entry['extension'][] = array(
+                    'url' => 'http://example.org/fhir/StructureDefinition/questionnaire-item-scale',
+                    'valueString' => 'likert-1-5'
+                );
             }
         }
         return $entry;

--- a/init.sql
+++ b/init.sql
@@ -97,7 +97,7 @@ CREATE TABLE questionnaire_item (
   section_id INT NULL,
   linkId VARCHAR(64) NOT NULL,
   text VARCHAR(500) NOT NULL,
-  type ENUM('text','textarea','boolean','choice') NOT NULL DEFAULT 'text',
+  type ENUM('likert','text','textarea','boolean','choice') NOT NULL DEFAULT 'likert',
   order_index INT NOT NULL DEFAULT 0,
   weight_percent INT NOT NULL DEFAULT 0,
   allow_multiple TINYINT(1) NOT NULL DEFAULT 0,
@@ -219,7 +219,7 @@ INSERT INTO site_config (
 
 -- default users (bcrypt hashes should be set during runtime; using demo placeholder hashes)
 INSERT INTO users (username,password,role,full_name,email) VALUES
-('admin', '$2y$10$9VQpYQ6k1cP6m0Wkq6YJTe1cW5Hc0yQ8Gm3qGf0j6Qj0M4jY3P4wW', 'admin', 'System Admin', 'admin@example.com'),
+('admin', '$2y$12$XN2nF1L1uUah/ESe7CO4f.Dwnx/C8J91JINMz4jXTtLDXPWlzBzGe', 'admin', 'System Admin', 'admin@example.com'),
 ('super', '$2y$10$Pj9m0H6b8K2ZyQe7p0k1TOeGq1bqfP3QO3Y6b5g1YQb1J2lL8mJxC', 'supervisor', 'Default Supervisor', 'super@example.com'),
 ('staff', '$2y$10$Pj9m0H6b8K2ZyQe7p0k1TOeGq1bqfP3QO3Y6b5g1YQb1J2lL8mJxC', 'staff', 'Sample Staff', 'staff@example.com');
 

--- a/migration.sql
+++ b/migration.sql
@@ -2,6 +2,7 @@
 -- migration.sql: upgrade existing DB to enhanced schema
 ALTER TABLE questionnaire_item ADD COLUMN weight_percent INT NOT NULL DEFAULT 0;
 ALTER TABLE questionnaire_item ADD COLUMN allow_multiple TINYINT(1) NOT NULL DEFAULT 0;
+ALTER TABLE questionnaire_item MODIFY COLUMN type ENUM('likert','text','textarea','boolean','choice') NOT NULL DEFAULT 'likert';
 
 CREATE TABLE IF NOT EXISTS questionnaire_item_option (
   id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- add a 1–5 Likert scale item type as the default in the questionnaire builder, backend validation, and FHIR export
- refresh demo seed data across all work functions and document the new default admin password in the deployment guide
- surface a performance timeline chart and supporting styles to visualise submission scores over time

## Testing
- php -l admin/questionnaire_manage.php
- php -l submit_assessment.php
- php -l my_performance.php
- php -l fhir/Questionnaire.php

------
https://chatgpt.com/codex/tasks/task_e_68eaa86871d0832d882c15e0f1d98da3