### PR TITLE
Add admin role management and expand analytics/export data

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -7,9 +7,34 @@ $locale = ensure_locale();
 $t = load_lang($locale);
 $cfg = get_site_config($pdo);
 
-$avg = $pdo->query("SELECT u.username, AVG(score) avg_score, COUNT(*) cnt FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id GROUP BY u.id ORDER BY avg_score DESC")->fetchAll();
+$avg = $pdo->query("SELECT u.username, u.full_name, AVG(score) avg_score, COUNT(*) cnt FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id GROUP BY u.id ORDER BY avg_score DESC")->fetchAll();
 $time = $pdo->query("SELECT DATE(created_at) d, COUNT(*) c FROM questionnaire_response GROUP BY DATE(created_at) ORDER BY d ASC")->fetchAll();
-$looker_sql = "SELECT qr.id as response_id, u.username, u.role, qr.questionnaire_id, qr.status, qr.score, qr.created_at, qr.reviewed_at, (qr.status='approved') as approved_flag FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id";
+$workFunctionStats = $pdo->query("SELECT u.work_function, COUNT(*) total_responses, SUM(qr.status='approved') approved_count, AVG(qr.score) avg_score FROM questionnaire_response qr JOIN users u ON u.id = qr.user_id GROUP BY u.work_function ORDER BY avg_score DESC")->fetchAll();
+$looker_sql = <<<SQL
+SELECT
+  qr.id AS response_id,
+  u.username,
+  u.full_name,
+  u.email,
+  u.role,
+  u.work_function,
+  u.account_status,
+  qr.questionnaire_id,
+  q.title AS questionnaire_title,
+  qr.status,
+  qr.score,
+  qr.created_at,
+  qr.reviewed_at,
+  qr.review_comment,
+  reviewer.username AS reviewer_username,
+  reviewer.full_name AS reviewer_name,
+  pp.label AS performance_period_label
+FROM questionnaire_response qr
+JOIN users u ON u.id = qr.user_id
+LEFT JOIN questionnaire q ON q.id = qr.questionnaire_id
+LEFT JOIN users reviewer ON reviewer.id = qr.reviewed_by
+LEFT JOIN performance_period pp ON pp.id = qr.performance_period_id;
+SQL;
 ?>
 <!doctype html>
 <html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
@@ -29,14 +54,48 @@ $looker_sql = "SELECT qr.id as response_id, u.username, u.role, qr.questionnaire
     <h2 class="md-card-title"><?=t($t,'avg_score_per_user','Average Score per User')?></h2>
     <table class="md-table">
       <thead>
-        <tr><th><?=t($t,'user','User')?></th><th><?=t($t,'average_score','Average Score (%)')?></th><th><?=t($t,'count','Count')?></th></tr>
+        <tr>
+          <th><?=t($t,'user','User')?></th>
+          <th><?=t($t,'full_name','Full Name')?></th>
+          <th><?=t($t,'average_score','Average Score (%)')?></th>
+          <th><?=t($t,'count','Count')?></th>
+        </tr>
       </thead>
       <tbody>
         <?php foreach ($avg as $r): ?>
+          <?php $fullName = trim((string)($r['full_name'] ?? '')); ?>
           <tr>
             <td><?=htmlspecialchars($r['username'])?></td>
+            <td><?= $fullName !== '' ? htmlspecialchars($fullName, ENT_QUOTES, 'UTF-8') : '—' ?></td>
             <td><?=number_format((float)$r['avg_score'], 2)?></td>
             <td><?=$r['cnt']?></td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t,'avg_score_per_work_function','Average Score per Work Function')?></h2>
+    <table class="md-table">
+      <thead>
+        <tr>
+          <th><?=t($t,'work_function','Work Function / Cadre')?></th>
+          <th><?=t($t,'count','Responses')?></th>
+          <th><?=t($t,'approved','Approved')?></th>
+          <th><?=t($t,'average_score','Average Score (%)')?></th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($workFunctionStats as $row): ?>
+          <?php
+            $wfKey = $row['work_function'] ?? '';
+            $wfLabel = WORK_FUNCTION_LABELS[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t,'unknown','Unknown'));
+          ?>
+          <tr>
+            <td><?=htmlspecialchars($wfLabel, ENT_QUOTES, 'UTF-8')?></td>
+            <td><?= (int)$row['total_responses'] ?></td>
+            <td><?= (int)$row['approved_count'] ?></td>
+            <td><?=number_format((float)$row['avg_score'], 2)?></td>
           </tr>
         <?php endforeach; ?>
       </tbody>

--- a/admin/branding.php
+++ b/admin/branding.php
@@ -48,8 +48,21 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     finfo_close($finfo);
                 }
                 $allowedMimes = ['image/png', 'image/jpeg', 'image/svg+xml', 'image/svg'];
-                if (in_array($mime, $allowedMimes, true)) {
-                    if (move_uploaded_file($logoFile['tmp_name'], $dest)) {
+                $allowedExtensions = ['png', 'jpg', 'jpeg', 'svg', 'svgz'];
+                $extension = strtolower(pathinfo($original, PATHINFO_EXTENSION));
+                if ($mime === null || $mime === false || $mime === 'application/octet-stream') {
+                    if (in_array($extension, $allowedExtensions, true)) {
+                        $mime = match ($extension) {
+                            'png' => 'image/png',
+                            'jpg', 'jpeg' => 'image/jpeg',
+                            'svg', 'svgz' => 'image/svg+xml',
+                            default => $mime,
+                        };
+                    }
+                }
+                if (in_array($mime, $allowedMimes, true) && in_array($extension, $allowedExtensions, true)) {
+                    if (is_uploaded_file($logoFile['tmp_name']) && move_uploaded_file($logoFile['tmp_name'], $dest)) {
+                        @chmod($dest, 0644);
                         $logo_path = 'assets/uploads/' . $fn;
                     } else {
                         $logoError = t($t, 'logo_upload_failed', 'Logo upload failed. Other changes were saved.');

--- a/admin/export.php
+++ b/admin/export.php
@@ -6,10 +6,46 @@ require_profile_completion($pdo);
 header('Content-Type: text/csv');
 header('Content-Disposition: attachment; filename="responses.csv"');
 $out = fopen('php://output', 'w');
-fputcsv($out, ['response_id','user','questionnaire_id','status','score_percent','performance_period','created_at']);
-$sql = "SELECT qr.id, u.username, qr.questionnaire_id, qr.status, qr.score, qr.created_at, pp.label AS period_label FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id JOIN performance_period pp ON pp.id = qr.performance_period_id ORDER BY qr.id DESC";
+fputcsv($out, [
+  'response_id',
+  'username',
+  'full_name',
+  'email',
+  'role',
+  'work_function',
+  'account_status',
+  'questionnaire_id',
+  'questionnaire_title',
+  'status',
+  'score_percent',
+  'performance_period',
+  'created_at',
+  'reviewed_at',
+  'reviewer_username',
+  'reviewer_full_name',
+  'review_comment',
+]);
+$sql = "SELECT qr.id, u.username, u.full_name, u.email, u.role, u.work_function, u.account_status, qr.questionnaire_id, q.title AS questionnaire_title, qr.status, qr.score, qr.created_at, qr.reviewed_at, reviewer.username AS reviewer_username, reviewer.full_name AS reviewer_full_name, qr.review_comment, pp.label AS period_label FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id LEFT JOIN questionnaire q ON q.id = qr.questionnaire_id LEFT JOIN users reviewer ON reviewer.id = qr.reviewed_by LEFT JOIN performance_period pp ON pp.id = qr.performance_period_id ORDER BY qr.id DESC";
 foreach ($pdo->query($sql) as $r) {
-  fputcsv($out, [$r['id'],$r['username'],$r['questionnaire_id'],$r['status'],$r['score'],$r['period_label'],$r['created_at']]);
+  fputcsv($out, [
+    $r['id'],
+    $r['username'],
+    $r['full_name'],
+    $r['email'],
+    $r['role'],
+    $r['work_function'],
+    $r['account_status'],
+    $r['questionnaire_id'],
+    $r['questionnaire_title'],
+    $r['status'],
+    $r['score'],
+    $r['period_label'],
+    $r['created_at'],
+    $r['reviewed_at'],
+    $r['reviewer_username'],
+    $r['reviewer_full_name'],
+    $r['review_comment'],
+  ]);
 }
 fclose($out);
 exit;

--- a/admin/metadata_roles.php
+++ b/admin/metadata_roles.php
@@ -1,0 +1,250 @@
+<?php
+require_once __DIR__ . '/../config.php';
+auth_required(['admin']);
+refresh_current_user($pdo);
+require_profile_completion($pdo);
+$locale = ensure_locale();
+$t = load_lang($locale);
+$cfg = get_site_config($pdo);
+
+$flash = $_SESSION['admin_role_flash'] ?? null;
+if ($flash) {
+    unset($_SESSION['admin_role_flash']);
+}
+$msg = $flash['message'] ?? '';
+$msgType = $flash['type'] ?? 'info';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check();
+    $action = $_POST['action'] ?? '';
+    $message = '';
+    $type = 'success';
+    try {
+        if ($action === 'create') {
+            $roleKey = strtolower(trim((string)($_POST['role_key'] ?? '')));
+            $label = trim((string)($_POST['label'] ?? ''));
+            $description = trim((string)($_POST['description'] ?? ''));
+            $sortOrderInput = trim((string)($_POST['sort_order'] ?? ''));
+            if ($roleKey === '' || !preg_match('/^[a-z0-9_]+$/', $roleKey)) {
+                throw new RuntimeException(t($t, 'invalid_role_key', 'Role key must contain only lowercase letters, numbers, or underscores.'));
+            }
+            if ($label === '') {
+                throw new RuntimeException(t($t, 'role_label_required', 'Role label is required.'));
+            }
+            $roleMap = get_user_role_map($pdo);
+            if (isset($roleMap[$roleKey])) {
+                throw new RuntimeException(t($t, 'role_key_exists', 'That role key is already defined.'));
+            }
+            if ($sortOrderInput !== '' && filter_var($sortOrderInput, FILTER_VALIDATE_INT) !== false) {
+                $sortOrder = (int)$sortOrderInput;
+            } else {
+                $sortOrder = (int)$pdo->query('SELECT COALESCE(MAX(sort_order), 0) + 10 FROM user_role')->fetchColumn();
+            }
+            $stmt = $pdo->prepare('INSERT INTO user_role (role_key, label, description, sort_order, is_protected) VALUES (?,?,?,?,0)');
+            $stmt->execute([$roleKey, $label, $description !== '' ? $description : null, $sortOrder]);
+            $message = t($t, 'role_created', 'Role added successfully.');
+        } elseif ($action === 'update') {
+            $id = (int)($_POST['id'] ?? 0);
+            if ($id <= 0) {
+                throw new RuntimeException(t($t, 'invalid_role', 'Unable to locate the requested role.'));
+            }
+            $currentStmt = $pdo->prepare('SELECT * FROM user_role WHERE id = ?');
+            $currentStmt->execute([$id]);
+            $current = $currentStmt->fetch();
+            if (!$current) {
+                throw new RuntimeException(t($t, 'invalid_role', 'Unable to locate the requested role.'));
+            }
+            $label = trim((string)($_POST['label'] ?? ''));
+            $description = trim((string)($_POST['description'] ?? ''));
+            $sortOrderInput = trim((string)($_POST['sort_order'] ?? ''));
+            if ($label === '') {
+                throw new RuntimeException(t($t, 'role_label_required', 'Role label is required.'));
+            }
+            $sortOrder = $current['sort_order'];
+            if ($sortOrderInput !== '' && filter_var($sortOrderInput, FILTER_VALIDATE_INT) !== false) {
+                $sortOrder = (int)$sortOrderInput;
+            }
+            $stmt = $pdo->prepare('UPDATE user_role SET label=?, description=?, sort_order=? WHERE id=?');
+            $stmt->execute([
+                $label,
+                $description !== '' ? $description : null,
+                $sortOrder,
+                $id,
+            ]);
+            $message = t($t, 'role_updated', 'Role updated successfully.');
+        } elseif ($action === 'delete') {
+            $id = (int)($_POST['id'] ?? 0);
+            if ($id <= 0) {
+                throw new RuntimeException(t($t, 'invalid_role', 'Unable to locate the requested role.'));
+            }
+            $currentStmt = $pdo->prepare('SELECT * FROM user_role WHERE id = ?');
+            $currentStmt->execute([$id]);
+            $current = $currentStmt->fetch();
+            if (!$current) {
+                throw new RuntimeException(t($t, 'invalid_role', 'Unable to locate the requested role.'));
+            }
+            if ((int)$current['is_protected'] === 1) {
+                throw new RuntimeException(t($t, 'role_delete_protected', 'Protected roles cannot be deleted.'));
+            }
+            $usageStmt = $pdo->prepare('SELECT COUNT(*) FROM users WHERE role = ?');
+            $usageStmt->execute([(string)$current['role_key']]);
+            $usage = (int)$usageStmt->fetchColumn();
+            if ($usage > 0) {
+                throw new RuntimeException(t($t, 'role_delete_in_use', 'This role is assigned to existing users and cannot be deleted.'));
+            }
+            $del = $pdo->prepare('DELETE FROM user_role WHERE id = ?');
+            $del->execute([$id]);
+            $message = t($t, 'role_deleted', 'Role deleted successfully.');
+        } else {
+            throw new RuntimeException(t($t, 'invalid_action', 'Unsupported action.'));
+        }
+        refresh_user_role_cache($pdo);
+    } catch (Throwable $e) {
+        $message = $e->getMessage();
+        $type = 'error';
+    }
+
+    $_SESSION['admin_role_flash'] = [
+        'message' => $message,
+        'type' => $type,
+    ];
+    header('Location: ' . url_for('admin/metadata_roles.php'));
+    exit;
+}
+
+$roles = get_user_roles($pdo);
+?>
+<!doctype html>
+<html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+<head>
+  <meta charset="utf-8">
+  <title><?=htmlspecialchars(t($t,'role_metadata','Role Metadata'), ENT_QUOTES, 'UTF-8')?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="app-base-url" content="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+  <link rel="manifest" href="<?=asset_url('manifest.webmanifest')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
+  <style>
+    .md-inline-form {
+      display: block;
+    }
+    .md-role-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+    .md-role-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-top: 0.75rem;
+    }
+    .md-alert--error {
+      background: rgba(220, 53, 69, 0.12);
+      color: #7f1d1d;
+      border-left: 4px solid #b91c1c;
+    }
+  </style>
+</head>
+<body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
+<?php include __DIR__.'/../templates/header.php'; ?>
+<section class="md-section">
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t,'add_role','Add Role')?></h2>
+    <?php if ($msg): ?>
+      <div class="md-alert <?=$msgType==='error'?'md-alert--error':''?>"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div>
+    <?php endif; ?>
+    <form method="post" class="md-form-grid" action="<?=htmlspecialchars(url_for('admin/metadata_roles.php'), ENT_QUOTES, 'UTF-8')?>">
+      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <input type="hidden" name="action" value="create">
+      <label class="md-field"><span><?=t($t,'role_key','Role Key')?></span><input name="role_key" pattern="[a-z0-9_]+" required placeholder="<?=htmlspecialchars(t($t,'role_key_placeholder','e.g. regional_manager'), ENT_QUOTES, 'UTF-8')?>"></label>
+      <label class="md-field"><span><?=t($t,'role_label','Role Label')?></span><input name="label" required></label>
+      <label class="md-field"><span><?=t($t,'role_description','Description (optional)')?></span><textarea name="description" rows="2"></textarea></label>
+      <label class="md-field"><span><?=t($t,'sort_order','Sort Order')?></span><input type="number" name="sort_order" placeholder="<?=htmlspecialchars(t($t,'sort_order_hint','Leave blank to append to the end'), ENT_QUOTES, 'UTF-8')?>"></label>
+      <button class="md-button md-primary md-elev-2"><?=t($t,'add','Add')?></button>
+    </form>
+  </div>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t,'manage_roles','Manage Roles')?></h2>
+    <?php if (!$roles): ?>
+      <p class="md-empty-state"><?=t($t,'no_roles_defined','No roles have been defined yet.')?></p>
+    <?php else: ?>
+      <div class="md-table-scroll">
+        <table class="md-table">
+          <thead>
+            <tr>
+              <th><?=t($t,'role_key','Role Key')?></th>
+              <th><?=t($t,'role_label','Role Label')?></th>
+              <th><?=t($t,'role_description','Description')?></th>
+              <th><?=t($t,'sort_order','Sort Order')?></th>
+              <th><?=t($t,'actions','Actions')?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($roles as $role): ?>
+              <tr>
+                <td>
+                  <strong><?=htmlspecialchars($role['role_key'], ENT_QUOTES, 'UTF-8')?></strong><br>
+                  <?php if ((int)$role['is_protected'] === 1): ?>
+                    <span class="md-chip md-chip--small"><?=t($t,'protected_role','Protected')?></span>
+                  <?php endif; ?>
+                </td>
+                <td colspan="4">
+                  <form method="post" class="md-inline-form" action="<?=htmlspecialchars(url_for('admin/metadata_roles.php'), ENT_QUOTES, 'UTF-8')?>">
+                    <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+                    <input type="hidden" name="action" value="update">
+                    <input type="hidden" name="id" value="<?=$role['id']?>">
+                    <div class="md-role-grid">
+                      <label class="md-field md-field--compact">
+                        <span><?=t($t,'role_label','Role Label')?></span>
+                        <input name="label" value="<?=htmlspecialchars($role['label'], ENT_QUOTES, 'UTF-8')?>" required>
+                      </label>
+                      <label class="md-field md-field--compact">
+                        <span><?=t($t,'role_description','Description (optional)')?></span>
+                        <textarea name="description" rows="2" placeholder="<?=htmlspecialchars(t($t,'role_description_hint','Optional description for admins'), ENT_QUOTES, 'UTF-8')?>"><?=
+htmlspecialchars((string)($role['description'] ?? ''), ENT_QUOTES, 'UTF-8')?></textarea>
+                      </label>
+                      <label class="md-field md-field--compact">
+                        <span><?=t($t,'sort_order','Sort Order')?></span>
+                        <input type="number" name="sort_order" value="<?=htmlspecialchars((string)($role['sort_order'] ?? 0), ENT_QUOTES, 'UTF-8')?>">
+                      </label>
+                    </div>
+                    <div class="md-role-actions">
+                      <button class="md-button md-elev-1" type="submit"><?=t($t,'save','Save')?></button>
+                      <?php if ((int)$role['is_protected'] === 0): ?>
+                        <button class="md-button md-danger md-elev-1" type="submit" data-confirm="<?=htmlspecialchars(t($t,'confirm_delete_role','Delete this role? This action cannot be undone.'), ENT_QUOTES, 'UTF-8')?>" data-role-id="<?=$role['id']?>" data-role-label="<?=htmlspecialchars($role['label'], ENT_QUOTES, 'UTF-8')?>"><?=t($t,'delete','Delete')?></button>
+                      <?php endif; ?>
+                    </div>
+                  </form>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </div>
+</section>
+<?php include __DIR__.'/../templates/footer.php'; ?>
+<script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
+(function() {
+  const deleteButtons = document.querySelectorAll('button[data-confirm][data-role-id]');
+  deleteButtons.forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      const message = btn.dataset.confirm || 'Delete this role?';
+      if (!window.confirm(message)) {
+        event.preventDefault();
+        event.stopPropagation();
+      } else {
+        const form = btn.closest('form');
+        if (form) {
+          form.elements.action.value = 'delete';
+        }
+      }
+    });
+  });
+})();
+</script>
+</body>
+</html>

--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -671,7 +671,7 @@ if (isset($_POST['import'])) {
     </form>
     <div class="qb-import-actions">
       <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
-        <?=t($t,'download_excel_template','Download Excel template')?>
+        <?=t($t,'download_xml_template','Download XML template')?>
       </a>
       <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
         <?=t($t,'download_import_guide','Download Import Guide')?>

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -399,6 +399,7 @@ const Builder = (() => {
           'Accept': 'application/json',
         },
         credentials: 'same-origin',
+        cache: 'no-store',
       });
       if (!response.ok) {
         throw new Error(`Failed to load data (${response.status})`);

--- a/docs/questionnaire-template.xml
+++ b/docs/questionnaire-template.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Questionnaire xmlns="http://hl7.org/fhir">
+  <id value="sample-questionnaire"/>
+  <title value="Sample Performance Questionnaire"/>
+  <status value="draft"/>
+  <item>
+    <linkId value="section-1"/>
+    <text value="General Performance"/>
+    <type value="group"/>
+    <item>
+      <linkId value="q1"/>
+      <text value="Completes assigned tasks on time."/>
+      <type value="choice"/>
+      <answerOption>
+        <valueString value="Strongly Disagree"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Disagree"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Neutral"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Agree"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Strongly Agree"/>
+      </answerOption>
+    </item>
+    <item>
+      <linkId value="q2"/>
+      <text value="Communicates effectively with the team."/>
+      <type value="choice"/>
+      <answerOption>
+        <valueString value="Strongly Disagree"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Disagree"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Neutral"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Agree"/>
+      </answerOption>
+      <answerOption>
+        <valueString value="Strongly Agree"/>
+      </answerOption>
+    </item>
+  </item>
+</Questionnaire>

--- a/scripts/download_questionnaire_template.php
+++ b/scripts/download_questionnaire_template.php
@@ -1,63 +1,24 @@
 <?php
 require_once __DIR__ . '/../config.php';
 
-const QUESTIONNAIRE_TEMPLATE_B64 = <<<'B64'
-UEsDBBQAAAAIANoLTFvwbmQ+DQEAALgCAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbK1SO0/DMBDe
-+yu8eahqtwwIoSQdeIzAUH7A4Vwaq37J55bk3+O4PCREgaHT6fQ9dbpqPVjDDhhJe1fzlVhyhk75
-VrttzZ8394srziiBa8F4hzUfkfi6mVWbMSCxLHZU8z6lcC0lqR4tkPABXUY6Hy2kvMatDKB2sEV5
-sVxeSuVdQpcWafLgzYyx6hY72JvE7oaMHLtENMTZzZE7xdUcQjBaQcq4PLj2W9DiPURkZeFQrwPN
-M4HLUyETeDrjS/qYTxR1i+wJYnoAm4lyMPLVx92L9zvxu88PXX3XaYWtV3ubJYJCRGipR0zWiDKF
-Be3m/6pQ+CTLWJ25y6f/31UojQbp3Lcoph/hlSyP17wBUEsDBBQAAAAIANoLTFtMBRKOtAAAACwB
-AAALAAAAX3JlbHMvLnJlbHONz78OgjAQBvCdp+h2kxQcjDEUFmPCavABajn+hNJr2qrw9nYU4+B4
-uft+l6+ollmzJzo/khGQpxkwNIra0fQCbs1ldwTmgzSt1GRQwIoeqjIprqhliBk/jNaziBgvYAjB
-njj3asBZ+pQsmrjpyM0yxNH13Eo1yR75PssO3H0aUCaMbVhWtwJc3ebAmtXiPzx13ajwTOoxowk/
-vnxdRFm6HoOARfMXuelONKURBR478k3J8g1QSwMEFAAAAAgA2gtMW4zkItfLAAAArwEAABoAAAB4
-bC9fcmVscy93b3JrYm9vay54bWwucmVsc62QTYvCQAyG7/6KueVk03oQWTr1IoJXcX/AME0/sJ0Z
-JvGj/34HRVlBYQ97Cm9CnjykXF/HQZ0pcu+dhiLLQZGzvu5dq+H7sJ2vQLEYV5vBO9IwEcO6mpV7
-GoykHe76wCpBHGvoRMIXItuORsOZD+TSpPFxNJJibDEYezQt4SLPlxh/M6CaKfWCVbtaQ9zVBajD
-FOgveN80vaWNt6eRnLy5ghcfj9wRSYKa2JJoeLYYb6XIEhXwo8/iP31YpiG99Clzzw+DEl/+XP0A
-UEsDBBQAAAAIANoLTFv4XCLu5QAAAGoBAAAPAAAAeGwvd29ya2Jvb2sueG1sjZDNTsNADITvfYq9
-+UQ3QQhBlaQXhNQLAgm4m6zTrLp/srdQ3p5N0ty52RrNN2M3+4t36ptYbAwt1NsKFIU+GhuOLXy8
-P988gJKMwaCLgVr4JYF9t2l+Ip++Yjyp4g/Swphz2mkt/UgeZRsThaIMkT3msvJRS2JCIyNR9k7f
-VtW99mgDLIQd/4cRh8H29BT7s6eQFwiTw1zay2iTQLdRqhmso8/lJoUpvaAvzS8O9Kyu1V9ZGcxU
-P1Z3LVRXce4n07guKsz2tzPJFBPQMpWfTNLBlJeB4p0tAx9MfYXoldLoNaz7A1BLAwQUAAAACADa
-C0xbAXIvizIBAAB7AgAADQAAAHhsL3N0eWxlcy54bWylkj1vwyAQhvf8CrabGpIMVVUZR1ksdemS
-VOpKbZwgHQcCHNn99QWTpInUrRN37x3Pe3xU29EgOysftCUB6+UKmKLWdpqOAj4OzdMLsBAldRIt
-KQGTCrCtF1WIE6r9SanIEoGCgFOM7pXz0J6UkWFpnaJU6a03MqbUH3lwXsku5E0G+Wa1euZGaoJ6
-wVjVW4qBtXagmOaAehbqiqRR7CxRwM5ricBTQRqNUxE3WQjfJVmvc8bLxnkJBa0RH9FJqCsnY1Se
-mpSwS3yYXDojpZMW0tw3L4X0ZX2X7uqeVaTcfSnOja1C3Ocr+uwfusee0WAaE986Aemu85DXMLlc
-wkIqSSbf0274f5OZdA6nxhbC1efeYvZ8cLmpLD+MgPf8vAhs7K8Gg8ao6Y/ZE7biv9+m/gFQSwME
-FAAAAAgA2gtMW2RbWQ82AgAAsAYAABgAAAB4bC93b3Jrc2hlZXRzL3NoZWV0MS54bWydVVFv2jAQ
-fu+vuDdvUoeBrt00hVRdabc+bB2Frc8mORKLxI7so8C/3yUQNCqcTZPycHfO933OffE5ut6UBbyg
-89qakRj0+gLQJDbVJhuJn7P7dx8FeFImVYU1OBJb9OI6PovW1i19jkjABMaPRE5UfZLSJzmWyvds
-hYZXFtaVijh1mfSVQ5U2oLKQw37/SpZKGxGfAURN+ZfGta/TPwtAaj7FAhPClHcooJaeW7usFx+4
-1BeyoZDHHDuG+2YDPxykuFCrgp7s+ivqLCemutwDE1u0qhxCqU2jU6rNSFyxnk4pH4nhewHJypMt
-n3eFQavb4neKY0Vqz+bsGlz94i6v+ev8hslZX5tCG5ySE3GkfRxRPOWPZB8iSXEk65JMjpGfQ8jJ
-Cn0NhVubYhh/+1f8DDcUxo9D+Cf0lTUeYbatOvTvQvjHqlb38CaxZanAY6WcYsOBfyBIcqsTlIVe
-oqO3Yfb7EPtz4zhImCbWndheJNmpY8+Grz0bBri/oEGnig7PQsjJoMOoEGiMPnF6jkA5AjerQuLz
-uoU58okF5T3yk3Y4GCLedbfDuhCQY2uyYgup9ipziOfjNviOK+LenN802eHFZrHDxpDSiX6dcO7i
-tXMX/+1cCDkZdjgXAj2uqC4BbqpmlgG+6JS96+jEOMRFnaf0LgTr6Pm/Qw4t3w/cdt5Flcrwm3KZ
-5nNc4ILp+r0PAtxu2jYx2aqJLgXMLfEobbOcbwZ0dcYbWVhLbcIjNpKHyyb+DVBLAQIUAxQAAAAI
-ANoLTFvwbmQ+DQEAALgCAAATAAAAAAAAAAAAAACAAQAAAABbQ29udGVudF9UeXBlc10ueG1sUEsB
-AhQDFAAAAAgA2gtMW0wFEo60AAAALAEAAAsAAAAAAAAAAAAAAIABPgEAAF9yZWxzLy5yZWxzUEsB
-AhQDFAAAAAgA2gtMW4zkItfLAAAArwEAABoAAAAAAAAAAAAAAIABGwIAAHhsL19yZWxzL3dvcmti
-b29rLnhtbC5yZWxzUEsBAhQDFAAAAAgA2gtMW/hcIu7lAAAAagEAAA8AAAAAAAAAAAAAAIABHgMA
-AHhsL3dvcmtib29rLnhtbFBLAQIUAxQAAAAIANoLTFsBci+LMgEAAHsCAAANAAAAAAAAAAAAAACA
-ATAEAAB4bC9zdHlsZXMueG1sUEsBAhQDFAAAAAgA2gtMW2RbWQ82AgAAsAYAABgAAAAAAAAAAAAA
-AIABjQUAAHhsL3dvcmtzaGVldHMvc2hlZXQxLnhtbFBLBQYAAAAABgAGAIABAAD5BwAAAAA=
-B64;
-
-$clean = str_replace(["\r", "\n"], '', QUESTIONNAIRE_TEMPLATE_B64);
-$data = base64_decode($clean, true);
-if ($data === false) {
-    http_response_code(500);
+$templatePath = base_path('docs/questionnaire-template.xml');
+if (!is_file($templatePath)) {
+    http_response_code(503);
     header('Content-Type: text/plain; charset=UTF-8');
-    echo 'Questionnaire template is currently unavailable.';
+    echo 'Questionnaire template is currently unavailable. Please upload the XML template to docs/questionnaire-template.xml.';
     exit;
 }
 
-header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-header('Content-Disposition: attachment; filename="questionnaire_template.xlsx"');
+$data = file_get_contents($templatePath);
+if ($data === false) {
+    http_response_code(500);
+    header('Content-Type: text/plain; charset=UTF-8');
+    echo 'Unable to read the questionnaire template.';
+    exit;
+}
+
+header('Content-Type: application/xml');
+header('Content-Disposition: attachment; filename="questionnaire_template.xml"');
 header('Content-Length: ' . strlen($data));
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Pragma: no-cache');

--- a/swagger.php
+++ b/swagger.php
@@ -25,6 +25,7 @@ $openapiUrl = asset_url('docs/openapi.json');
       color: inherit;
       border-radius: 0 0 12px 12px;
       overflow: hidden;
+      min-height: 480px;
     }
     .swagger-ui .topbar {
       background: linear-gradient(92deg, var(--app-primary-dark), var(--app-primary));
@@ -117,7 +118,7 @@ $openapiUrl = asset_url('docs/openapi.json');
 <?php include __DIR__.'/templates/footer.php'; ?>
 <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js" integrity="sha384-VnuG1v7rmDdGztJ32thSWfW5i8ubrSMVqGpfR+L5/TrF4iAfDdc0AGJi/7luWUv" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js" integrity="sha384-lhDX2PD6o642kvJy3ocHxVhdkIJfnddFktKI1IvY2ag6GLZ35Xwqr7zaCDW8Vh6u" crossorigin="anonymous"></script>
-<script>
+<script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
   window.addEventListener('DOMContentLoaded', function () {
     window.ui = SwaggerUIBundle({
       url: '<?=htmlspecialchars($openapiUrl, ENT_QUOTES, 'UTF-8')?>',

--- a/templates/header.php
+++ b/templates/header.php
@@ -67,6 +67,7 @@ $brandStyle = site_brand_style($cfg);
         <span class="md-drawer-label"><?=t($t, 'admin_navigation', 'Administration')?></span>
         <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'admin_dashboard', 'Admin Dashboard')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'manage_users', 'Manage Users')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/metadata_roles.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'role_metadata', 'Role Metadata')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'analytics', 'Analytics')?></a>
         <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'export_data', 'Export Data')?></a>


### PR DESCRIPTION
## Summary
- add database support for configurable user roles and expose a new admin metadata page to manage them
- enhance user management with optional password updates, live last-name search, and role dropdown sourced from metadata
- improve analytics, exports, questionnaire tools, branding upload resilience, and API viewer initialization

## Testing
- php -l config.php
- php -l admin/users.php
- php -l admin/metadata_roles.php
- php -l admin/branding.php
- php -l admin/analytics.php
- php -l admin/export.php
- php -l scripts/download_questionnaire_template.php
- php -l swagger.php
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_68eb17bd22d8832d8a21c72f00ecaa2c