### PR TITLE
Add section radar charts and harden admin upgrade workflow

### DIFF
--- a/admin/export.php
+++ b/admin/export.php
@@ -1,51 +1,150 @@
 <?php
-require_once __DIR__.'/../config.php';
+require_once __DIR__ . '/../config.php';
 auth_required(['admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);
-header('Content-Type: text/csv');
-header('Content-Disposition: attachment; filename="responses.csv"');
-$out = fopen('php://output', 'w');
-fputcsv($out, [
-  'response_id',
-  'username',
-  'full_name',
-  'email',
-  'role',
-  'work_function',
-  'account_status',
-  'questionnaire_id',
-  'questionnaire_title',
-  'status',
-  'score_percent',
-  'performance_period',
-  'created_at',
-  'reviewed_at',
-  'reviewer_username',
-  'reviewer_full_name',
-  'review_comment',
-]);
-$sql = "SELECT qr.id, u.username, u.full_name, u.email, u.role, u.work_function, u.account_status, qr.questionnaire_id, q.title AS questionnaire_title, qr.status, qr.score, qr.created_at, qr.reviewed_at, reviewer.username AS reviewer_username, reviewer.full_name AS reviewer_full_name, qr.review_comment, pp.label AS period_label FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id LEFT JOIN questionnaire q ON q.id = qr.questionnaire_id LEFT JOIN users reviewer ON reviewer.id = qr.reviewed_by LEFT JOIN performance_period pp ON pp.id = qr.performance_period_id ORDER BY qr.id DESC";
-foreach ($pdo->query($sql) as $r) {
-  fputcsv($out, [
-    $r['id'],
-    $r['username'],
-    $r['full_name'],
-    $r['email'],
-    $r['role'],
-    $r['work_function'],
-    $r['account_status'],
-    $r['questionnaire_id'],
-    $r['questionnaire_title'],
-    $r['status'],
-    $r['score'],
-    $r['period_label'],
-    $r['created_at'],
-    $r['reviewed_at'],
-    $r['reviewer_username'],
-    $r['reviewer_full_name'],
-    $r['review_comment'],
-  ]);
+$locale = ensure_locale();
+$t = load_lang($locale);
+$cfg = get_site_config($pdo);
+
+$downloadRequested = isset($_GET['download']) && $_GET['download'] === '1';
+
+if ($downloadRequested) {
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="responses.csv"');
+    $out = fopen('php://output', 'w');
+    fputcsv($out, [
+        'response_id',
+        'username',
+        'full_name',
+        'email',
+        'role',
+        'work_function',
+        'account_status',
+        'questionnaire_id',
+        'questionnaire_title',
+        'status',
+        'score_percent',
+        'performance_period',
+        'created_at',
+        'reviewed_at',
+        'reviewer_username',
+        'reviewer_full_name',
+        'review_comment',
+    ]);
+    $sql = "SELECT qr.id, u.username, u.full_name, u.email, u.role, u.work_function, u.account_status, qr.questionnaire_id, q.title AS questionnaire_title, qr.status, qr.score, pp.label AS period_label, qr.created_at, qr.reviewed_at, reviewer.username AS reviewer_username, reviewer.full_name AS reviewer_full_name, qr.review_comment FROM questionnaire_response qr JOIN users u ON u.id = qr.user_id LEFT JOIN questionnaire q ON q.id = qr.questionnaire_id LEFT JOIN users reviewer ON reviewer.id = qr.reviewed_by LEFT JOIN performance_period pp ON pp.id = qr.performance_period_id ORDER BY qr.id DESC";
+    foreach ($pdo->query($sql) as $row) {
+        fputcsv($out, [
+            $row['id'],
+            $row['username'],
+            $row['full_name'],
+            $row['email'],
+            $row['role'],
+            $row['work_function'],
+            $row['account_status'],
+            $row['questionnaire_id'],
+            $row['questionnaire_title'],
+            $row['status'],
+            $row['score'],
+            $row['period_label'],
+            $row['created_at'],
+            $row['reviewed_at'],
+            $row['reviewer_username'],
+            $row['reviewer_full_name'],
+            $row['review_comment'],
+        ]);
+    }
+    fclose($out);
+    exit;
 }
-fclose($out);
-exit;
+
+$totalResponses = 0;
+$latestSubmission = null;
+try {
+    $totalResponses = (int)$pdo->query('SELECT COUNT(*) FROM questionnaire_response')->fetchColumn();
+    $latestSubmission = $pdo->query('SELECT MAX(created_at) FROM questionnaire_response')->fetchColumn();
+} catch (PDOException $e) {
+    error_log('export.php stats failed: ' . $e->getMessage());
+}
+
+$latestSubmissionDisplay = '—';
+if ($latestSubmission) {
+    try {
+        $dt = new DateTime((string)$latestSubmission);
+        $latestSubmissionDisplay = $dt->format('M j, Y g:i a');
+    } catch (Throwable $ignored) {
+        $latestSubmissionDisplay = (string)$latestSubmission;
+    }
+}
+?>
+<!doctype html>
+<html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+<head>
+  <meta charset="utf-8">
+  <title><?=htmlspecialchars(t($t, 'export_data', 'Export Assessment Data'), ENT_QUOTES, 'UTF-8')?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="app-base-url" content="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+  <link rel="manifest" href="<?=asset_url('manifest.webmanifest')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
+</head>
+<body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
+<?php include __DIR__.'/../templates/header.php'; ?>
+<section class="md-section">
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'export_assessments_title', 'Export questionnaire responses')?></h2>
+    <p><?=t($t, 'export_assessments_intro', 'Download all recorded assessment responses as a CSV file for offline analysis or archival.')?></p>
+    <ul class="md-stat-list">
+      <li class="md-stat-item"><span class="md-stat-label"><?=t($t, 'responses_available', 'Responses available')?></span><span class="md-stat-value"><?=$totalResponses?></span></li>
+      <li class="md-stat-item"><span class="md-stat-label"><?=t($t, 'latest_submission', 'Latest submission')?></span><span class="md-stat-value"><?=htmlspecialchars($latestSubmissionDisplay, ENT_QUOTES, 'UTF-8')?></span></li>
+    </ul>
+    <div class="md-form-actions md-form-actions--center md-form-actions--stack">
+      <a class="md-button md-primary md-elev-2" href="<?=htmlspecialchars(url_for('admin/export.php?download=1'), ENT_QUOTES, 'UTF-8')?>">
+        <?=t($t, 'download_csv', 'Download CSV')?></a>
+    </div>
+    <p class="md-upgrade-meta"><?=t($t, 'export_notice', 'The export includes reviewer information, status changes, and performance period details for each response.')?></p>
+  </div>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'export_columns', 'Columns included in the export')?></h2>
+    <table class="md-table">
+      <thead>
+        <tr>
+          <th><?=t($t, 'column_name', 'Column')?></th>
+          <th><?=t($t, 'column_description', 'Description')?></th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php
+        $columns = [
+            ['response_id', t($t, 'col_response_id', 'Unique identifier of the questionnaire response')],
+            ['username', t($t, 'col_username', 'Username of the staff member')],
+            ['full_name', t($t, 'col_full_name', 'Full name, if provided')],
+            ['email', t($t, 'col_email', 'Email address on record')],
+            ['role', t($t, 'col_role', 'User role at the time of submission')],
+            ['work_function', t($t, 'col_work_function', 'Assigned work function / cadre')],
+            ['account_status', t($t, 'col_account_status', 'Account status when the export was generated')],
+            ['questionnaire_id', t($t, 'col_questionnaire_id', 'Identifier of the questionnaire template')],
+            ['questionnaire_title', t($t, 'col_questionnaire_title', 'Title of the questionnaire')],
+            ['status', t($t, 'col_status', 'Submission status (draft, submitted, approved, rejected)')],
+            ['score_percent', t($t, 'col_score', 'Overall weighted score (percent)')],
+            ['performance_period', t($t, 'col_period', 'Performance period label linked to the response')],
+            ['created_at', t($t, 'col_created_at', 'Date and time the response was saved')],
+            ['reviewed_at', t($t, 'col_reviewed_at', 'Date and time of the latest review, if any')],
+            ['reviewer_username', t($t, 'col_reviewer_username', 'Username of the reviewer who provided feedback')],
+            ['reviewer_full_name', t($t, 'col_reviewer_full_name', 'Full name of the reviewer, if available')],
+            ['review_comment', t($t, 'col_review_comment', 'Supervisor or admin review comment')],
+        ];
+        foreach ($columns as [$column, $description]): ?>
+        <tr>
+          <td><code><?=htmlspecialchars($column, ENT_QUOTES, 'UTF-8')?></code></td>
+          <td><?=htmlspecialchars($description, ENT_QUOTES, 'UTF-8')?></td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+</section>
+<?php include __DIR__.'/../templates/footer.php'; ?>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -778,7 +778,7 @@ body.theme-dark .md-field.md-field--compact select {
 }
 
 .md-login .md-form .md-button {
-  margin: 1.25rem auto 0;
+  margin: 0;
   display: inline-flex;
 }
 .md-button.md-compact {
@@ -804,6 +804,10 @@ body.theme-dark .md-field.md-field--compact select {
   flex-wrap: wrap;
 }
 
+.md-form-actions--center {
+  justify-content: center;
+}
+
 .md-form-actions--stack {
   flex-direction: column;
   align-items: stretch;
@@ -814,6 +818,56 @@ body.theme-dark .md-field.md-field--compact select {
     flex-direction: row;
     align-items: center;
   }
+}
+
+.md-login-actions {
+  margin-top: 1.25rem;
+}
+
+.md-login-actions .md-button {
+  min-width: 9rem;
+}
+
+.md-radar-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.md-radar-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.md-radar-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.md-radar-meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--app-muted-light);
+}
+
+.md-radar-canvas {
+  position: relative;
+  width: 100%;
+  height: 280px;
+}
+
+@media (min-width: 768px) {
+  .md-radar-canvas {
+    height: 320px;
+  }
+}
+
+.md-radar-canvas canvas {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .md-assessment-form {
@@ -1246,6 +1300,10 @@ body.theme-dark .md-button.md-primary {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.md-dashboard-card--upgrade {
+  margin-bottom: 1.5rem;
 }
 
 .md-stat-list {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -552,27 +552,47 @@ const Builder = (() => {
       tabs.innerHTML = '';
     }
     list.innerHTML = '';
+    const tabEntries = [];
     state.questionnaires.forEach((questionnaire, qIndex) => {
       const card = buildQuestionnaireCard(questionnaire, qIndex);
       list.appendChild(card);
       if (tabs) {
         const key = keyFor(questionnaire);
+        const label = questionnaire.title && questionnaire.title.trim() !== ''
+          ? questionnaire.title
+          : `Questionnaire ${qIndex + 1}`;
+        tabEntries.push({
+          key,
+          label,
+          qIndex,
+          isActive: key === state.activeKey,
+        });
+      }
+    });
+    if (tabs && tabEntries.length) {
+      const collator = (typeof Intl !== 'undefined' && typeof Intl.Collator === 'function')
+        ? new Intl.Collator(undefined, { sensitivity: 'base', usage: 'sort' })
+        : null;
+      tabEntries.sort((a, b) => {
+        if (collator) {
+          return collator.compare(a.label, b.label);
+        }
+        return a.label.localeCompare(b.label);
+      });
+      tabEntries.forEach((entry) => {
         const tab = document.createElement('button');
         tab.type = 'button';
         tab.className = 'qb-tab';
         tab.setAttribute('role', 'tab');
-        tab.setAttribute('data-q-key', key);
-        tab.dataset.qIndex = String(qIndex);
-        const label = questionnaire.title && questionnaire.title.trim() !== ''
-          ? questionnaire.title
-          : `Questionnaire ${qIndex + 1}`;
-        tab.textContent = label;
-        const isActive = key === state.activeKey;
+        tab.setAttribute('data-q-key', entry.key);
+        tab.dataset.qIndex = String(entry.qIndex);
+        tab.textContent = entry.label;
+        const isActive = entry.isActive;
         tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
         tab.setAttribute('tabindex', isActive ? '0' : '-1');
         tabs.appendChild(tab);
-      }
-    });
+      });
+    }
     initSortable();
     updateDirtyState();
   }

--- a/index.php
+++ b/index.php
@@ -106,7 +106,7 @@ $contact = htmlspecialchars($cfg['contact'] ?? '');
           <input type="password" name="password" required>
         </label>
         <?php if (!empty($err)): ?><div class="md-alert"><?=htmlspecialchars($err, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
-        <div class="d-flex justify-content-center">
+        <div class="md-form-actions md-form-actions--center md-login-actions">
           <button class="md-button md-primary md-elev-2"><?=t($t,'sign_in','Sign In')?></button>
         </div>
       </form>

--- a/my_performance.php
+++ b/my_performance.php
@@ -8,6 +8,243 @@ $t = load_lang($locale);
 $cfg = get_site_config($pdo);
 $user = current_user();
 
+function compute_section_breakdowns(PDO $pdo, array $responses, array $translations): array
+{
+    if (!$responses) {
+        return [];
+    }
+
+    $questionnaireIds = [];
+    $responseMeta = [];
+    foreach ($responses as $response) {
+        if (!is_array($response)) {
+            continue;
+        }
+        $responseId = isset($response['id']) ? (int)$response['id'] : 0;
+        $questionnaireId = isset($response['questionnaire_id']) ? (int)$response['questionnaire_id'] : 0;
+        if ($responseId <= 0 || $questionnaireId <= 0) {
+            continue;
+        }
+        $questionnaireIds[$questionnaireId] = true;
+        $responseMeta[$responseId] = [
+            'questionnaire_id' => $questionnaireId,
+            'title' => (string)($response['title'] ?? ''),
+            'period' => $response['period_label'] ?? null,
+        ];
+    }
+
+    if (!$responseMeta) {
+        return [];
+    }
+
+    $qidList = array_keys($questionnaireIds);
+    $placeholder = implode(',', array_fill(0, count($qidList), '?'));
+
+    $sectionsByQuestionnaire = [];
+    if ($placeholder !== '') {
+        $sectionsStmt = $pdo->prepare(
+            "SELECT id, questionnaire_id, title, order_index FROM questionnaire_section " .
+            "WHERE questionnaire_id IN ($placeholder) ORDER BY questionnaire_id, order_index, id"
+        );
+        $sectionsStmt->execute($qidList);
+        foreach ($sectionsStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $qid = (int)$row['questionnaire_id'];
+            $sectionsByQuestionnaire[$qid][] = [
+                'id' => (int)$row['id'],
+                'title' => $row['title'] ?? '',
+            ];
+        }
+
+        $itemsStmt = $pdo->prepare(
+            "SELECT questionnaire_id, section_id, linkId, type, allow_multiple, " .
+            "COALESCE(weight_percent,0) AS weight FROM questionnaire_item " .
+            "WHERE questionnaire_id IN ($placeholder) ORDER BY questionnaire_id, order_index, id"
+        );
+        $itemsStmt->execute($qidList);
+    } else {
+        $itemsStmt = $pdo->prepare('SELECT 1 WHERE 0');
+        $itemsStmt->execute();
+    }
+
+    $itemsByQuestionnaire = [];
+    foreach ($itemsStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $qid = (int)$row['questionnaire_id'];
+        $sectionId = $row['section_id'] !== null ? (int)$row['section_id'] : null;
+        $itemsByQuestionnaire[$qid][] = [
+            'section_id' => $sectionId,
+            'linkId' => (string)$row['linkId'],
+            'type' => (string)$row['type'],
+            'allow_multiple' => (bool)$row['allow_multiple'],
+            'weight' => (float)$row['weight'],
+        ];
+    }
+
+    $responseIds = array_keys($responseMeta);
+    $answersByResponse = [];
+    if ($responseIds) {
+        $answerPlaceholder = implode(',', array_fill(0, count($responseIds), '?'));
+        $answerStmt = $pdo->prepare(
+            "SELECT response_id, linkId, answer FROM questionnaire_response_item " .
+            "WHERE response_id IN ($answerPlaceholder)"
+        );
+        $answerStmt->execute($responseIds);
+        foreach ($answerStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $rid = (int)$row['response_id'];
+            $decoded = json_decode($row['answer'] ?? '[]', true);
+            if (!is_array($decoded)) {
+                $decoded = [];
+            }
+            $answersByResponse[$rid][$row['linkId']] = $decoded;
+        }
+    }
+
+    $sectionBreakdowns = [];
+    $generalLabel = t($translations, 'unassigned_section_label', 'General');
+    $sectionFallback = t($translations, 'section_placeholder', 'Section');
+    $questionnaireFallback = t($translations, 'questionnaire_placeholder', 'Questionnaire');
+
+    $scoreCalculator = static function (array $item, array $answerSet, float $weight): float {
+        $type = (string)($item['type'] ?? 'text');
+        if ($weight <= 0) {
+            return 0.0;
+        }
+        if ($type === 'boolean') {
+            foreach ($answerSet as $entry) {
+                if ((isset($entry['valueBoolean']) && $entry['valueBoolean']) ||
+                    (isset($entry['valueString']) && strtolower((string)$entry['valueString']) === 'true')) {
+                    return $weight;
+                }
+            }
+            return 0.0;
+        }
+        if ($type === 'likert') {
+            $score = null;
+            foreach ($answerSet as $entry) {
+                if (isset($entry['valueInteger']) && is_numeric($entry['valueInteger'])) {
+                    $score = (int)$entry['valueInteger'];
+                    break;
+                }
+                if (isset($entry['valueString'])) {
+                    $candidate = trim((string)$entry['valueString']);
+                    if (preg_match('/^([1-5])/', $candidate, $matches)) {
+                        $score = (int)$matches[1];
+                        break;
+                    }
+                    if (is_numeric($candidate)) {
+                        $value = (int)$candidate;
+                        if ($value >= 1 && $value <= 5) {
+                            $score = $value;
+                            break;
+                        }
+                    }
+                }
+            }
+            if ($score !== null && $score >= 1 && $score <= 5) {
+                return $weight * $score / 5.0;
+            }
+            return 0.0;
+        }
+        if ($type === 'choice') {
+            foreach ($answerSet as $entry) {
+                if (isset($entry['valueString']) && trim((string)$entry['valueString']) !== '') {
+                    return $weight;
+                }
+            }
+            return 0.0;
+        }
+        foreach ($answerSet as $entry) {
+            if (isset($entry['valueString']) && trim((string)$entry['valueString']) !== '') {
+                return $weight;
+            }
+        }
+        return 0.0;
+    };
+
+    foreach ($responseMeta as $responseId => $meta) {
+        $qid = $meta['questionnaire_id'];
+        $items = $itemsByQuestionnaire[$qid] ?? [];
+        if (!$items) {
+            continue;
+        }
+        $sectionStats = [];
+        $orderedSections = [];
+        foreach ($sectionsByQuestionnaire[$qid] ?? [] as $section) {
+            $sid = $section['id'];
+            $sectionStats[$sid] = [
+                'label' => (string)$section['title'],
+                'weight' => 0.0,
+                'achieved' => 0.0,
+            ];
+            $orderedSections[] = $sid;
+        }
+        $unassignedKey = 'unassigned';
+        $sectionStats[$unassignedKey] = [
+            'label' => $generalLabel,
+            'weight' => 0.0,
+            'achieved' => 0.0,
+        ];
+
+        $answers = $answersByResponse[$responseId] ?? [];
+        foreach ($items as $item) {
+            $sectionKey = $item['section_id'] ?? $unassignedKey;
+            if (!isset($sectionStats[$sectionKey])) {
+                $sectionStats[$sectionKey] = [
+                    'label' => $sectionFallback,
+                    'weight' => 0.0,
+                    'achieved' => 0.0,
+                ];
+                if ($sectionKey !== $unassignedKey) {
+                    $orderedSections[] = $sectionKey;
+                }
+            }
+            $weight = (float)$item['weight'];
+            if ($weight <= 0) {
+                continue;
+            }
+            $sectionStats[$sectionKey]['weight'] += $weight;
+            $answerSet = $answers[$item['linkId']] ?? [];
+            $sectionStats[$sectionKey]['achieved'] += $scoreCalculator($item, $answerSet, $weight);
+        }
+
+        $sections = [];
+        foreach ($orderedSections as $sid) {
+            $stat = $sectionStats[$sid] ?? null;
+            if (!$stat || $stat['weight'] <= 0) {
+                continue;
+            }
+            $label = trim((string)$stat['label']);
+            if ($label === '') {
+                $label = $sectionFallback;
+            }
+            $sections[] = [
+                'label' => $label,
+                'score' => round(($stat['achieved'] / $stat['weight']) * 100, 1),
+            ];
+        }
+
+        if ($sectionStats[$unassignedKey]['weight'] > 0) {
+            $sections[] = [
+                'label' => $sectionStats[$unassignedKey]['label'],
+                'score' => round(($sectionStats[$unassignedKey]['achieved'] / $sectionStats[$unassignedKey]['weight']) * 100, 1),
+            ];
+        }
+
+        if ($sections) {
+            $title = trim($meta['title']);
+            if ($title === '') {
+                $title = $questionnaireFallback;
+            }
+            $sectionBreakdowns[$qid] = [
+                'title' => $title,
+                'period' => $meta['period'] ? (string)$meta['period'] : null,
+                'sections' => $sections,
+            ];
+        }
+    }
+
+    return $sectionBreakdowns;
+}
+
 $stmt = $pdo->prepare("SELECT qr.*, q.title, pp.label AS period_label FROM questionnaire_response qr JOIN questionnaire q ON q.id=qr.questionnaire_id JOIN performance_period pp ON pp.id = qr.performance_period_id WHERE qr.user_id=? ORDER BY qr.created_at ASC");
 $stmt->execute([$user['id']]);
 $rows = $stmt->fetchAll();
@@ -30,6 +267,12 @@ foreach ($rows as $row) {
     if ($latestEntry === null || strtotime($row['created_at']) > strtotime($latestEntry['created_at'])) {
         $latestEntry = $row;
     }
+}
+
+$sectionBreakdowns = compute_section_breakdowns($pdo, array_values($latestScores), $t);
+$radarJsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+if (defined('JSON_THROW_ON_ERROR')) {
+    $radarJsonFlags |= JSON_THROW_ON_ERROR;
 }
 
 $belowThreshold = array_values(array_filter($rows, static function ($row) {
@@ -111,6 +354,25 @@ if ($flash === 'submitted') {
       </div>
     <?php endif; ?>
   </div>
+  <?php if ($sectionBreakdowns): ?>
+    <div class="md-card md-elev-2">
+      <h2 class="md-card-title"><?=t($t,'section_breakdown','Section score radar')?></h2>
+      <p><?=t($t,'section_breakdown_hint','Each radar shows how your latest submission performed across questionnaire sections.')?></p>
+      <div class="md-radar-grid">
+        <?php foreach ($sectionBreakdowns as $qid => $radar): ?>
+          <div class="md-radar-card">
+            <h3 class="md-radar-title"><?=htmlspecialchars($radar['title'], ENT_QUOTES, 'UTF-8')?></h3>
+            <?php if (!empty($radar['period'])): ?>
+              <p class="md-radar-meta"><?=htmlspecialchars($radar['period'], ENT_QUOTES, 'UTF-8')?></p>
+            <?php endif; ?>
+            <div class="md-radar-canvas">
+              <canvas id="radar-chart-<?=$qid?>" role="img" aria-label="<?=htmlspecialchars(sprintf(t($t,'section_score_chart_alt','Section scores for %s'), $radar['title']), ENT_QUOTES, 'UTF-8')?>"></canvas>
+            </div>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    </div>
+  <?php endif; ?>
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t,'your_trend','Your Score Trend')?></h2>
     <?php if ($chartLabels): ?>
@@ -187,5 +449,98 @@ if ($flash === 'submitted') {
     <?php endif; ?>
   </div>
 </section>
+<?php if ($sectionBreakdowns): ?>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js" integrity="sha384-EtBsuD6bYDI7ilMWVT09G/1nHQRE8PbtY7TIn4lZG3Fjm1fvcDUoJ7Sm9Ua+bJOy" crossorigin="anonymous"></script>
+<script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
+  (function () {
+    const radarData = <?=json_encode($sectionBreakdowns, $radarJsonFlags)?>;
+    const palette = [
+      { bg: 'rgba(32, 115, 191, 0.18)', border: 'rgba(32, 115, 191, 0.85)' },
+      { bg: 'rgba(97, 179, 236, 0.18)', border: 'rgba(97, 179, 236, 0.85)' },
+      { bg: 'rgba(246, 181, 17, 0.18)', border: 'rgba(246, 181, 17, 0.85)' },
+      { bg: 'rgba(80, 180, 99, 0.18)', border: 'rgba(80, 180, 99, 0.85)' },
+      { bg: 'rgba(171, 71, 188, 0.18)', border: 'rgba(171, 71, 188, 0.85)' }
+    ];
+
+    function formatLabel(label, value) {
+      const rounded = typeof value === 'number' ? value.toFixed(1) : value;
+      return `${label}: ${rounded}%`;
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      if (!window.Chart || !radarData) {
+        return;
+      }
+      let paletteIndex = 0;
+      Object.keys(radarData).forEach(function (qid) {
+        const canvas = document.getElementById(`radar-chart-${qid}`);
+        if (!canvas) {
+          return;
+        }
+        const dataset = radarData[qid];
+        if (!dataset || !Array.isArray(dataset.sections) || !dataset.sections.length) {
+          return;
+        }
+        const labels = dataset.sections.map(function (section) { return section.label; });
+        const values = dataset.sections.map(function (section) { return Number(section.score) || 0; });
+        const colors = palette[paletteIndex % palette.length];
+        paletteIndex += 1;
+        new Chart(canvas, {
+          type: 'radar',
+          data: {
+            labels,
+            datasets: [{
+              label: dataset.title,
+              data: values,
+              fill: true,
+              backgroundColor: colors.bg,
+              borderColor: colors.border,
+              borderWidth: 2,
+              pointBackgroundColor: colors.border,
+              pointBorderColor: '#ffffff',
+              pointRadius: 4,
+              pointHoverRadius: 5
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: function (context) {
+                    const raw = context.parsed && typeof context.parsed.r === 'number' ? context.parsed.r : context.parsed;
+                    return formatLabel(context.label, raw);
+                  }
+                }
+              }
+            },
+            scales: {
+              r: {
+                suggestedMin: 0,
+                suggestedMax: 100,
+                ticks: {
+                  stepSize: 20,
+                  showLabelBackdrop: false,
+                  callback: function (value) {
+                    return `${value}%`;
+                  }
+                },
+                grid: {
+                  color: 'rgba(32, 115, 191, 0.15)'
+                },
+                angleLines: {
+                  color: 'rgba(32, 115, 191, 0.2)'
+                }
+              }
+            }
+          }
+        });
+      });
+    });
+  })();
+</script>
+<?php endif; ?>
 <?php include __DIR__.'/templates/footer.php'; ?>
 </body></html>


### PR DESCRIPTION
## Summary
- run the migration script and refresh schema helpers when applying an admin system upgrade
- reposition the system upgrade card, center the login button, and alphabetize questionnaire builder tabs
- add an admin export landing page with header plus radar section score visualizations for the performance dashboard

## Testing
- php -l admin/dashboard.php
- php -l admin/export.php
- php -l index.php
- php -l my_performance.php

------
https://chatgpt.com/codex/tasks/task_e_68eb2564c518832db3bcc167ade334a8