### PR TITLE
Fix admin role management schema

### DIFF
--- a/config.php
+++ b/config.php
@@ -323,12 +323,20 @@ function ensure_users_schema(PDO $pdo): void
         error_log('ensure_users_schema: ' . $e->getMessage());
         return;
     }
+    $roleColumn = null;
     if ($columns) {
         while ($col = $columns->fetch(PDO::FETCH_ASSOC)) {
             if (isset($col['Field'])) {
                 $existing[$col['Field']] = true;
             }
+            if (($col['Field'] ?? '') === 'role') {
+                $roleColumn = $col;
+            }
         }
+    }
+
+    if ($roleColumn && isset($roleColumn['Type']) && stripos((string)$roleColumn['Type'], 'enum(') !== false) {
+        $pdo->exec("ALTER TABLE users MODIFY COLUMN role VARCHAR(50) NOT NULL DEFAULT 'staff'");
     }
 
     $changes = [

--- a/init.sql
+++ b/init.sql
@@ -10,6 +10,7 @@ DROP TABLE IF EXISTS questionnaire_section;
 DROP TABLE IF EXISTS questionnaire;
 DROP TABLE IF EXISTS logs;
 DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS user_role;
 DROP TABLE IF EXISTS performance_period;
 DROP TABLE IF EXISTS site_config;
 
@@ -48,11 +49,27 @@ CREATE TABLE site_config (
   smtp_timeout INT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE user_role (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  role_key VARCHAR(50) NOT NULL UNIQUE,
+  label VARCHAR(100) NOT NULL,
+  description TEXT NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  is_protected TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO user_role (role_key, label, description, sort_order, is_protected) VALUES
+('admin', 'Administrator', 'Full administrative access to manage the platform.', 0, 1),
+('supervisor', 'Supervisor', 'Can review assessments and manage assigned staff.', 10, 1),
+('staff', 'Staff', 'Standard access for employees completing assessments.', 20, 1);
+
 CREATE TABLE users (
   id INT AUTO_INCREMENT PRIMARY KEY,
   username VARCHAR(100) UNIQUE NOT NULL,
   password VARCHAR(255) NOT NULL,
-  role ENUM('admin','supervisor','staff') NOT NULL DEFAULT 'staff',
+  role VARCHAR(50) NOT NULL DEFAULT 'staff',
   full_name VARCHAR(200) NULL,
   email VARCHAR(200) NULL,
   gender ENUM('female','male','other','prefer_not_say') DEFAULT NULL,
@@ -70,6 +87,7 @@ CREATE TABLE users (
   approved_at DATETIME NULL,
   sso_provider VARCHAR(50) NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (role) REFERENCES user_role(role_key) ON UPDATE CASCADE,
   FOREIGN KEY (approved_by) REFERENCES users(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/migration.sql
+++ b/migration.sql
@@ -4,6 +4,27 @@ ALTER TABLE questionnaire_item ADD COLUMN weight_percent INT NOT NULL DEFAULT 0;
 ALTER TABLE questionnaire_item ADD COLUMN allow_multiple TINYINT(1) NOT NULL DEFAULT 0;
 ALTER TABLE questionnaire_item MODIFY COLUMN type ENUM('likert','text','textarea','boolean','choice') NOT NULL DEFAULT 'likert';
 
+CREATE TABLE IF NOT EXISTS user_role (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  role_key VARCHAR(50) NOT NULL UNIQUE,
+  label VARCHAR(100) NOT NULL,
+  description TEXT NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  is_protected TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO user_role (role_key, label, description, sort_order, is_protected) VALUES
+('admin', 'Administrator', 'Full administrative access to manage the platform.', 0, 1),
+('supervisor', 'Supervisor', 'Can review assessments and manage assigned staff.', 10, 1),
+('staff', 'Staff', 'Standard access for employees completing assessments.', 20, 1)
+ON DUPLICATE KEY UPDATE
+  label=VALUES(label),
+  description=VALUES(description),
+  sort_order=VALUES(sort_order),
+  is_protected=VALUES(is_protected);
+
 CREATE TABLE IF NOT EXISTS questionnaire_item_option (
   id INT AUTO_INCREMENT PRIMARY KEY,
   questionnaire_item_id INT NOT NULL,
@@ -114,6 +135,7 @@ INSERT IGNORE INTO site_config (
 );
 
 ALTER TABLE users
+  MODIFY COLUMN role VARCHAR(50) NOT NULL DEFAULT 'staff',
   ADD COLUMN gender ENUM('female','male','other','prefer_not_say') NULL AFTER email,
   ADD COLUMN date_of_birth DATE NULL AFTER gender,
   ADD COLUMN phone VARCHAR(50) NULL AFTER date_of_birth,


### PR DESCRIPTION
## Summary
- add the missing user_role table and seed data to the database initialization script
- allow the users.role column to store custom roles and keep it in sync via runtime migrations
- ensure migrations create or update role metadata so admin/users.php and metadata_roles.php work again

## Testing
- not run (schema-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68eb2a7fcd88832d8fbbae0225d769f2