### PR TITLE
Add SQLite fallback for local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+storage/


### PR DESCRIPTION
## Summary
- add environment-aware database bootstrap that creates a local SQLite database when MySQL isn’t configured
- extend schema migration helpers to support SQLite-specific introspection and insert syntax while retaining MySQL behaviour
- ignore the runtime storage directory so generated SQLite files aren’t committed

## Testing
- php -l config.php
- curl -i http://127.0.0.1:8080/index.php


------
https://chatgpt.com/codex/tasks/task_e_68eb364c5e2c832d85e9ad3a781f9cb5