### PR TITLE
Ensure questionnaire work function table exists for legacy databases

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -60,7 +60,12 @@ if ($action === 'fetch') {
     $sectionsRows = $pdo->query('SELECT * FROM questionnaire_section ORDER BY questionnaire_id, order_index, id')->fetchAll();
     $itemsRows = $pdo->query('SELECT * FROM questionnaire_item ORDER BY questionnaire_id, order_index, id')->fetchAll();
     $optionsRows = $pdo->query('SELECT * FROM questionnaire_item_option ORDER BY questionnaire_item_id, order_index, id')->fetchAll();
-    $wfRows = $pdo->query('SELECT questionnaire_id, work_function FROM questionnaire_work_function')->fetchAll();
+    try {
+        $wfRows = $pdo->query('SELECT questionnaire_id, work_function FROM questionnaire_work_function')->fetchAll();
+    } catch (PDOException $e) {
+        error_log('questionnaire_manage work function fetch failed: ' . $e->getMessage());
+        $wfRows = [];
+    }
 
     $sectionsByQuestionnaire = [];
     foreach ($sectionsRows as $section) {


### PR DESCRIPTION
## Summary
- ensure questionnaire work function mappings are created during bootstrap and backfill existing questionnaires
- protect staff questionnaire lookup from failing when the mapping table is missing and log the fallback
- guard the questionnaire manager fetch endpoint so it tolerates absent mappings instead of crashing

## Testing
- php -l config.php
- php -l submit_assessment.php
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_68ebf4cfacb4832da9541756008d526a