### PR TITLE
Load local .env configuration during bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ git clone https://github.com/your-org/HRassessv300.git /var/www/hrassess
 cp /var/www/hrassess/.env.example /var/www/hrassess/.env
 ```
 
-Populate the `.env` file with the production database connection, base URL, and SMTP settings. When deploying behind a
-reverse proxy or subdirectory, adjust `BASE_URL` accordingly. Ensure writable directories exist for uploads:
+Populate the `.env` file with the production database connection, base URL, and SMTP settings. The application bootstrap
+loads `/var/www/hrassess/.env` automatically so both Apache and CLI commands inherit the same configuration. When
+deploying behind a reverse proxy or subdirectory, adjust `BASE_URL` accordingly. Ensure writable directories exist for
+uploads:
 
 ```sh
 mkdir -p /var/www/hrassess/assets/uploads/branding
@@ -150,7 +152,8 @@ and backups for future releases.
 
 ## Configuration
 
-Environment variables are read directly via `getenv`. Set them in your shell or a `.env` file (loaded by your web server):
+Environment variables are read directly via `getenv`. The bootstrap loads a project-local `.env` file if present, so the
+values apply consistently to web requests and CLI scripts:
 
 - `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASS`
 - `BASE_URL` (defaults to `/`)

--- a/config.php
+++ b/config.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 if (!defined('APP_BOOTSTRAPPED')) {
     define('APP_BOOTSTRAPPED', true);
 
+    $envPath = __DIR__ . '/.env';
+    if (is_readable($envPath)) {
+        load_env_file($envPath);
+    }
+
     $appDebug = filter_var(getenv('APP_DEBUG') ?: '0', FILTER_VALIDATE_BOOLEAN);
     ini_set('display_errors', $appDebug ? '1' : '0');
     error_reporting(E_ALL);
@@ -71,6 +76,59 @@ if (!defined('APP_BOOTSTRAPPED')) {
         echo '<h1>Service unavailable</h1><p>' . $friendly . '</p>';
         echo '</body></html>';
         exit;
+    }
+}
+
+if (!function_exists('load_env_file')) {
+    function load_env_file(string $path): void
+    {
+        static $loadedPaths = [];
+
+        if (isset($loadedPaths[$path])) {
+            return;
+        }
+
+        $loadedPaths[$path] = true;
+
+        $lines = @file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false) {
+            return;
+        }
+
+        foreach ($lines as $rawLine) {
+            $line = trim($rawLine);
+            if ($line === '' || $line[0] === '#' || $line[0] === ';') {
+                continue;
+            }
+
+            $delimiterPos = strpos($line, '=');
+            if ($delimiterPos === false) {
+                continue;
+            }
+
+            $key = trim(substr($line, 0, $delimiterPos));
+            if ($key === '') {
+                continue;
+            }
+
+            $value = trim(substr($line, $delimiterPos + 1));
+            if ($value !== '') {
+                $firstChar = $value[0];
+                $lastChar = $value[strlen($value) - 1];
+                if (($firstChar === '"' && $lastChar === '"') || ($firstChar === "'" && $lastChar === "'")) {
+                    $value = substr($value, 1, -1);
+                }
+            }
+
+            if (getenv($key) === false) {
+                putenv($key . '=' . $value);
+                if (!isset($_ENV) || !is_array($_ENV)) {
+                    $_ENV = [];
+                }
+                $_ENV[$key] = $value;
+                $_SERVER[$key] = $value;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- load project-local .env files during bootstrap so documented deployment values are applied
- document that the LAMP guide's .env file is now automatically consumed by both CLI scripts and Apache

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_68ec09fcd3e0832d8ac2fa7a5607df43