### PR TITLE
Simplify login page rendering

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,22 +1,24 @@
 <?php
 require_once __DIR__ . '/config.php';
+
 $locale = ensure_locale();
 $t = load_lang($locale);
 $cfg = get_site_config($pdo);
 $err = '';
 
 $oauthProviders = [];
-$googleEnabled = ((int)($cfg['google_oauth_enabled'] ?? 0) === 1)
+if (
+    (int)($cfg['google_oauth_enabled'] ?? 0) === 1
     && !empty($cfg['google_oauth_client_id'])
-    && !empty($cfg['google_oauth_client_secret']);
-if ($googleEnabled) {
+    && !empty($cfg['google_oauth_client_secret'])
+) {
     $oauthProviders['google'] = t($t, 'sign_in_with_google', 'Sign in with Google');
 }
-
-$microsoftEnabled = ((int)($cfg['microsoft_oauth_enabled'] ?? 0) === 1)
+if (
+    (int)($cfg['microsoft_oauth_enabled'] ?? 0) === 1
     && !empty($cfg['microsoft_oauth_client_id'])
-    && !empty($cfg['microsoft_oauth_client_secret']);
-if ($microsoftEnabled) {
+    && !empty($cfg['microsoft_oauth_client_secret'])
+) {
     $oauthProviders['microsoft'] = t($t, 'sign_in_with_microsoft', 'Sign in with Microsoft');
 }
 
@@ -33,9 +35,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     csrf_check();
     $username = trim($_POST['username'] ?? '');
     $password = $_POST['password'] ?? '';
+
     $stmt = $pdo->prepare('SELECT * FROM users WHERE username = ?');
     $stmt->execute([$username]);
     $u = $stmt->fetch();
+
     if ($u && password_verify($password, $u['password'])) {
         if (($u['account_status'] ?? 'active') === 'disabled') {
             $err = t($t, 'account_disabled', 'Your account has been disabled. Please contact your administrator.');
@@ -46,6 +50,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
             $_SESSION['user'] = $u;
             $_SESSION['lang'] = $u['language'] ?? ($_SESSION['lang'] ?? 'en');
+
             if (($u['account_status'] ?? 'active') === 'pending') {
                 $_SESSION['pending_notice'] = true;
                 header('Location: ' . url_for('profile.php?pending=1'));
@@ -55,9 +60,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             exit;
         }
     } else {
-        $err = t($t,'invalid_login','Invalid username or password');
+        $err = t($t, 'invalid_login', 'Invalid username or password');
     }
 }
+
 $logoPath = get_branding_logo_path($cfg);
 if ($logoPath === null) {
     $logoRenderPath = asset_url('assets/img/epss-logo.svg');
@@ -66,50 +72,60 @@ if ($logoPath === null) {
 } else {
     $logoRenderPath = asset_url(ltrim($logoPath, '/'));
 }
+
 $logo = htmlspecialchars($logoRenderPath, ENT_QUOTES, 'UTF-8');
-$site_name = htmlspecialchars($cfg['site_name'] ?? 'My Performance');
-$landing_text = htmlspecialchars($cfg['landing_text'] ?? '');
-$address = htmlspecialchars($cfg['address'] ?? '');
-$contact = htmlspecialchars($cfg['contact'] ?? '');
+$siteName = htmlspecialchars($cfg['site_name'] ?? 'My Performance', ENT_QUOTES, 'UTF-8');
+$landingText = htmlspecialchars($cfg['landing_text'] ?? '', ENT_QUOTES, 'UTF-8');
+$address = htmlspecialchars($cfg['address'] ?? '', ENT_QUOTES, 'UTF-8');
+$contact = htmlspecialchars($cfg['contact'] ?? '', ENT_QUOTES, 'UTF-8');
+$bodyClass = htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8');
+$bodyStyle = htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8');
+$baseUrl = htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8');
+$langAttr = htmlspecialchars($locale, ENT_QUOTES, 'UTF-8');
 ?>
 <!doctype html>
-<html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+<html lang="<?= $langAttr ?>" data-base-url="<?= $baseUrl ?>">
 <head>
   <meta charset="utf-8">
-  <title><?=$site_name?></title>
+  <title><?= $siteName ?></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="app-base-url" content="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
-  <link rel="manifest" href="<?=asset_url('manifest.webmanifest')?>">
-  <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
-  <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
+  <meta name="app-base-url" content="<?= $baseUrl ?>">
+  <link rel="manifest" href="<?= asset_url('manifest.webmanifest') ?>">
+  <link rel="stylesheet" href="<?= asset_url('assets/css/material.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('assets/css/styles.css') ?>">
 </head>
-<body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>" style="<?=htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8')?>">
+<body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>">
   <div id="google_translate_element" class="visually-hidden" aria-hidden="true"></div>
   <div class="md-container">
     <div class="md-card md-elev-3 md-login">
       <div class="md-card-media">
-        <img src="<?=$logo?>" alt="Logo" class="md-logo">
-        <h1 class="md-title"><?=$site_name?></h1>
+        <img src="<?= $logo ?>" alt="Logo" class="md-logo">
+        <h1 class="md-title"><?= $siteName ?></h1>
       </div>
-      <?php if ($landing_text): ?>
-        <p class="md-subtitle"><?=$landing_text?></p>
+
+      <?php if ($landingText !== ''): ?>
+        <p class="md-subtitle"><?= $landingText ?></p>
       <?php else: ?>
-        <p class="md-subtitle"><?=t($t,'welcome_msg','Sign in to start your self-assessment and track your performance over time.')?></p>
+        <p class="md-subtitle"><?= t($t, 'welcome_msg', 'Sign in to start your self-assessment and track your performance over time.') ?></p>
       <?php endif; ?>
 
-      <form method="post" class="md-form" action="<?=htmlspecialchars(url_for('index.php'), ENT_QUOTES, 'UTF-8')?>">
-        <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <form method="post" class="md-form" action="<?= htmlspecialchars(url_for('index.php'), ENT_QUOTES, 'UTF-8') ?>">
+        <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
         <label class="md-field">
-          <span><?=t($t,'username','Username')?></span>
+          <span><?= t($t, 'username', 'Username') ?></span>
           <input name="username" required>
         </label>
         <label class="md-field">
-          <span><?=t($t,'password','Password')?></span>
+          <span><?= t($t, 'password', 'Password') ?></span>
           <input type="password" name="password" required>
         </label>
-        <?php if (!empty($err)): ?><div class="md-alert"><?=htmlspecialchars($err, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
+        <?php if ($err !== ''): ?>
+          <div class="md-alert"><?= htmlspecialchars($err, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
         <div class="md-form-actions md-form-actions--center md-login-actions">
-          <button class="md-button md-primary md-elev-2"><?=t($t,'sign_in','Sign In')?></button>
+          <button class="md-button md-primary md-elev-2" type="submit">
+            <?= t($t, 'sign_in', 'Sign In') ?>
+          </button>
         </div>
       </form>
 
@@ -117,28 +133,35 @@ $contact = htmlspecialchars($cfg['contact'] ?? '');
         <div class="md-divider"></div>
         <div class="md-sso-buttons">
           <?php foreach ($oauthProviders as $provider => $label): ?>
-            <a class="md-button md-elev-1 md-sso-btn <?=$provider?>" href="<?=htmlspecialchars(url_for('oauth.php?provider=' . $provider), ENT_QUOTES, 'UTF-8')?>"><?=$label?></a>
+            <a
+              class="md-button md-elev-1 md-sso-btn <?= htmlspecialchars($provider, ENT_QUOTES, 'UTF-8') ?>"
+              href="<?= htmlspecialchars(url_for('oauth.php?provider=' . $provider), ENT_QUOTES, 'UTF-8') ?>"
+            ><?= $label ?></a>
           <?php endforeach; ?>
         </div>
       <?php endif; ?>
 
       <div class="md-meta">
-        <?php if ($address): ?><div class='md-small'><strong><?=t($t,'address_label','Address')?>: </strong><?=$address?></div><?php endif; ?>
-        <?php if ($contact): ?><div class='md-small'><strong><?=t($t,'contact_label','Contact')?>: </strong><?=$contact?></div><?php endif; ?>
+        <?php if ($address !== ''): ?>
+          <div class="md-small"><strong><?= t($t, 'address_label', 'Address') ?>:</strong> <?= $address ?></div>
+        <?php endif; ?>
+        <?php if ($contact !== ''): ?>
+          <div class="md-small"><strong><?= t($t, 'contact_label', 'Contact') ?>:</strong> <?= $contact ?></div>
+        <?php endif; ?>
         <div class="md-small lang-switch">
-          <a href="<?=htmlspecialchars(url_for('set_lang.php?lang=en'), ENT_QUOTES, 'UTF-8')?>">EN</a> ·
-          <a href="<?=htmlspecialchars(url_for('set_lang.php?lang=am'), ENT_QUOTES, 'UTF-8')?>">AM</a> ·
-          <a href="<?=htmlspecialchars(url_for('set_lang.php?lang=fr'), ENT_QUOTES, 'UTF-8')?>">FR</a>
+          <a href="<?= htmlspecialchars(url_for('set_lang.php?lang=en'), ENT_QUOTES, 'UTF-8') ?>">EN</a> ·
+          <a href="<?= htmlspecialchars(url_for('set_lang.php?lang=am'), ENT_QUOTES, 'UTF-8') ?>">AM</a> ·
+          <a href="<?= htmlspecialchars(url_for('set_lang.php?lang=fr'), ENT_QUOTES, 'UTF-8') ?>">FR</a>
         </div>
       </div>
     </div>
   </div>
-  <script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
-    window.APP_BASE_URL = <?=json_encode(BASE_URL, JSON_THROW_ON_ERROR)?>;
-    window.APP_DEFAULT_LOCALE = <?=json_encode(AVAILABLE_LOCALES[0], JSON_THROW_ON_ERROR)?>;
-    window.APP_AVAILABLE_LOCALES = <?=json_encode(AVAILABLE_LOCALES, JSON_THROW_ON_ERROR)?>;
+
+  <script nonce="<?= htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8') ?>">
+    window.APP_BASE_URL = <?= json_encode(BASE_URL, JSON_THROW_ON_ERROR) ?>;
+    window.APP_DEFAULT_LOCALE = <?= json_encode(AVAILABLE_LOCALES[0], JSON_THROW_ON_ERROR) ?>;
+    window.APP_AVAILABLE_LOCALES = <?= json_encode(AVAILABLE_LOCALES, JSON_THROW_ON_ERROR) ?>;
   </script>
-  <script src="<?=asset_url('assets/js/app.js')?>"></script>
+  <script src="<?= asset_url('assets/js/app.js') ?>"></script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- streamline index.php to avoid malformed HTML attributes and ensure safe escaping
- keep OAuth provider buttons and site metadata rendering while simplifying the logic

## Testing
- php -l index.php
- find . -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68ec11906468832da07252ca410fc861