### PR TITLE
Remove unused user role bootstrap logic

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -79,7 +79,7 @@ mysql -u epss_user -p epss_v300 < init.sql
 mysql -u epss_user -p epss_v300 < dummy_data.sql
 ```
 
-Upgrading from releases prior to v3.0.0? Run the consolidated upgrade helper to add the `user_role` table, questionnaire work-function mapping, and SMTP settings columns:
+Upgrading from releases prior to v3.0.0? Run the consolidated upgrade helper to add the questionnaire work-function mapping and SMTP settings columns:
 
 ```bash
 mysql -u epss_user -p epss_v300 < upgrade_to_v3.sql

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ mysql -u hrassess -p hrassess < /var/www/hrassess/migration.sql
 mysql -u hrassess -p hrassess < /var/www/hrassess/dummy_data.sql
 ```
 
-If you are upgrading from an installation that predates v3.0.0, apply the consolidated upgrade script to provision the new `user_role` table, questionnaire work-function mapping, and SMTP configuration columns:
+If you are upgrading from an installation that predates v3.0.0, apply the consolidated upgrade script to provision the questionnaire work-function mapping and SMTP configuration columns:
 
 ```sh
 mysql -u hrassess -p hrassess < /var/www/hrassess/upgrade_to_v3.sql

--- a/config.php
+++ b/config.php
@@ -66,7 +66,6 @@ if (!defined('APP_BOOTSTRAPPED')) {
         $pdo = new PDO($dsn, $dbUser, $dbPass, $options);
         ensure_site_config_schema($pdo);
         ensure_users_schema($pdo);
-        ensure_user_roles_schema($pdo);
         ensure_questionnaire_item_schema($pdo);
         ensure_questionnaire_work_function_schema($pdo);
     } catch (PDOException $e) {
@@ -122,30 +121,6 @@ const WORK_FUNCTION_LABELS = [
     'dfm' => 'DFM',
     'driver' => 'Driver',
     'ethics' => 'Ethics',
-];
-
-const DEFAULT_USER_ROLES = [
-    [
-        'role_key' => 'admin',
-        'label' => 'Administrator',
-        'description' => 'Full administrative access to manage the platform.',
-        'sort_order' => 0,
-        'is_protected' => 1,
-    ],
-    [
-        'role_key' => 'supervisor',
-        'label' => 'Supervisor',
-        'description' => 'Can review assessments and manage assigned staff.',
-        'sort_order' => 10,
-        'is_protected' => 1,
-    ],
-    [
-        'role_key' => 'staff',
-        'label' => 'Staff',
-        'description' => 'Standard access for employees completing assessments.',
-        'sort_order' => 20,
-        'is_protected' => 1,
-    ],
 ];
 
 const DEFAULT_BRAND_COLOR = '#2073bf';
@@ -418,57 +393,6 @@ function ensure_users_schema(PDO $pdo): void
     }
 }
 
-function ensure_user_roles_schema(PDO $pdo): void
-{
-    try {
-        $pdo->exec("CREATE TABLE IF NOT EXISTS user_role (
-            id INT AUTO_INCREMENT PRIMARY KEY,
-            role_key VARCHAR(50) NOT NULL UNIQUE,
-            label VARCHAR(100) NOT NULL,
-            description TEXT NULL,
-            sort_order INT NOT NULL DEFAULT 0,
-            is_protected TINYINT(1) NOT NULL DEFAULT 0,
-            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
-        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
-
-        $columns = $pdo->query('SHOW COLUMNS FROM user_role');
-        $existing = [];
-        if ($columns) {
-            while ($col = $columns->fetch(PDO::FETCH_ASSOC)) {
-                $existing[$col['Field']] = true;
-            }
-        }
-
-        $required = [
-            'description' => 'ALTER TABLE user_role ADD COLUMN description TEXT NULL AFTER label',
-            'sort_order' => 'ALTER TABLE user_role ADD COLUMN sort_order INT NOT NULL DEFAULT 0 AFTER description',
-            'is_protected' => 'ALTER TABLE user_role ADD COLUMN is_protected TINYINT(1) NOT NULL DEFAULT 0 AFTER sort_order',
-            'created_at' => 'ALTER TABLE user_role ADD COLUMN created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER is_protected',
-            'updated_at' => 'ALTER TABLE user_role ADD COLUMN updated_at DATETIME NULL DEFAULT NULL AFTER created_at',
-        ];
-
-        foreach ($required as $field => $sql) {
-            if (!isset($existing[$field])) {
-                $pdo->exec($sql);
-            }
-        }
-
-        foreach (DEFAULT_USER_ROLES as $index => $role) {
-            $stmt = $pdo->prepare('INSERT INTO user_role (role_key, label, description, sort_order, is_protected) VALUES (?,?,?,?,?) ON DUPLICATE KEY UPDATE label=VALUES(label), description=VALUES(description), sort_order=VALUES(sort_order), is_protected=VALUES(is_protected)');
-            $stmt->execute([
-                $role['role_key'],
-                $role['label'],
-                $role['description'],
-                $role['sort_order'] ?? ($index * 10),
-                $role['is_protected'] ?? 0,
-            ]);
-        }
-    } catch (PDOException $e) {
-        error_log('ensure_user_roles_schema: ' . $e->getMessage());
-    }
-}
-
 function ensure_questionnaire_item_schema(PDO $pdo): void
 {
     try {
@@ -537,46 +461,6 @@ function ensure_questionnaire_work_function_schema(PDO $pdo): void
     } catch (PDOException $e) {
         error_log('ensure_questionnaire_work_function_schema: ' . $e->getMessage());
     }
-}
-
-function load_user_roles(PDO $pdo, bool $forceRefresh = false): array
-{
-    static $cache = null;
-    if ($forceRefresh || $cache === null) {
-        try {
-            $stmt = $pdo->query('SELECT id, role_key, label, description, sort_order, is_protected FROM user_role ORDER BY sort_order ASC, label ASC');
-            $cache = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
-        } catch (PDOException $e) {
-            error_log('load_user_roles: ' . $e->getMessage());
-            $cache = [];
-        }
-    }
-    return $cache ?? [];
-}
-
-function get_user_roles(PDO $pdo, bool $includeProtected = true): array
-{
-    $roles = load_user_roles($pdo);
-    if ($includeProtected) {
-        return $roles;
-    }
-    return array_values(array_filter($roles, static function ($role) {
-        return (int)($role['is_protected'] ?? 0) === 0;
-    }));
-}
-
-function get_user_role_map(PDO $pdo): array
-{
-    $map = [];
-    foreach (load_user_roles($pdo) as $role) {
-        $map[(string)$role['role_key']] = $role;
-    }
-    return $map;
-}
-
-function refresh_user_role_cache(PDO $pdo): void
-{
-    load_user_roles($pdo, true);
 }
 
 function site_color_theme(array $cfg): string

--- a/scripts/check_database_integrity.php
+++ b/scripts/check_database_integrity.php
@@ -147,34 +147,6 @@ function validate_table_schema(PDO $pdo, string $table, array $expectedColumns):
 }
 
 /**
- * Validate that the default user roles declared in config.php exist in the database.
- *
- * @return list<string>
- */
-function validate_default_user_roles(PDO $pdo): array
-{
-    if (!defined('DEFAULT_USER_ROLES')) {
-        return ['DEFAULT_USER_ROLES constant is not defined.'];
-    }
-
-    $issues = [];
-    $stmt = $pdo->query('SELECT role_key FROM user_role');
-    $existing = [];
-    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-        $existing[$row['role_key']] = true;
-    }
-
-    foreach (DEFAULT_USER_ROLES as $role) {
-        $key = $role['role_key'];
-        if (!isset($existing[$key])) {
-            $issues[] = sprintf('Missing default user role "%s"', $key);
-        }
-    }
-
-    return $issues;
-}
-
-/**
  * Validate that the singleton site configuration record exists.
  *
  * @return list<string>
@@ -247,16 +219,6 @@ $expectedSchemas = [
         'sso_provider' => ['type' => 'varchar', 'null' => 'YES'],
         'first_login_at' => ['type' => 'datetime', 'null' => 'YES'],
     ],
-    'user_role' => [
-        'id' => ['type' => 'int', 'null' => 'NO', 'key' => 'PRI', 'extra' => 'auto_increment'],
-        'role_key' => ['type' => 'varchar(50)', 'null' => 'NO', 'key' => 'UNI'],
-        'label' => ['type' => 'varchar(100)', 'null' => 'NO'],
-        'description' => ['type' => 'text', 'null' => 'YES'],
-        'sort_order' => ['type' => 'int', 'null' => 'NO', 'default' => '0'],
-        'is_protected' => ['type' => 'tinyint', 'null' => 'NO', 'default' => '0'],
-        'created_at' => ['type' => 'datetime', 'null' => 'NO'],
-        'updated_at' => ['type' => 'datetime', 'null' => 'YES'],
-    ],
     'questionnaire_item' => [
         'is_required' => ['type' => 'tinyint', 'null' => 'NO', 'default' => '0'],
     ],
@@ -271,7 +233,6 @@ foreach ($expectedSchemas as $table => $columns) {
     $issues = array_merge($issues, validate_table_schema($pdo, $table, $columns));
 }
 
-$issues = array_merge($issues, validate_default_user_roles($pdo));
 $issues = array_merge($issues, validate_site_config_row($pdo));
 
 if (empty($issues)) {

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -125,36 +125,6 @@ DEALLOCATE PREPARE stmt;
 ALTER TABLE questionnaire_item
   ADD COLUMN IF NOT EXISTS is_required TINYINT(1) NOT NULL DEFAULT 0 AFTER allow_multiple;
 
--- Ensure user_role table exists with required metadata.
-CREATE TABLE IF NOT EXISTS user_role (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  role_key VARCHAR(50) NOT NULL UNIQUE,
-  label VARCHAR(100) NOT NULL,
-  description TEXT NULL,
-  sort_order INT NOT NULL DEFAULT 0,
-  is_protected TINYINT(1) NOT NULL DEFAULT 0,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-ALTER TABLE user_role
-  ADD COLUMN IF NOT EXISTS description TEXT NULL AFTER label,
-  ADD COLUMN IF NOT EXISTS sort_order INT NOT NULL DEFAULT 0 AFTER description,
-  ADD COLUMN IF NOT EXISTS is_protected TINYINT(1) NOT NULL DEFAULT 0 AFTER sort_order,
-  ADD COLUMN IF NOT EXISTS created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER is_protected,
-  ADD COLUMN IF NOT EXISTS updated_at DATETIME NULL DEFAULT NULL AFTER created_at;
-
-INSERT INTO user_role (role_key, label, description, sort_order, is_protected)
-VALUES
-  ('admin', 'Administrator', 'Full administrative access to manage the platform.', 0, 1),
-  ('supervisor', 'Supervisor', 'Can review assessments and manage assigned staff.', 10, 1),
-  ('staff', 'Staff', 'Standard access for employees completing assessments.', 20, 1)
-ON DUPLICATE KEY UPDATE
-  label = VALUES(label),
-  description = VALUES(description),
-  sort_order = VALUES(sort_order),
-  is_protected = VALUES(is_protected);
-
 -- Ensure questionnaire_work_function exists and is keyed properly.
 CREATE TABLE IF NOT EXISTS questionnaire_work_function (
   questionnaire_id INT NOT NULL,


### PR DESCRIPTION
## Summary
- remove the user role bootstrap helpers from the application config to avoid unnecessary schema churn
- drop the database integrity and upgrade script references to the unused user_role table
- update deployment documentation to reflect the simplified upgrade requirements

## Testing
- php -l config.php
- php -l scripts/check_database_integrity.php

------
https://chatgpt.com/codex/tasks/task_e_68ec263f7a54832da363ecefc9e9e4f5