### PR TITLE
Refactor work function handling to avoid config constants

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -6,6 +6,7 @@ require_profile_completion($pdo);
 $locale = ensure_locale();
 $t = load_lang($locale);
 $cfg = get_site_config($pdo);
+$workFunctionOptions = work_function_choices($pdo);
 
 $avg = $pdo->query("SELECT u.username, u.full_name, AVG(score) avg_score, COUNT(*) cnt FROM questionnaire_response qr JOIN users u ON u.id=qr.user_id GROUP BY u.id ORDER BY avg_score DESC")->fetchAll();
 $time = $pdo->query("SELECT DATE(created_at) d, COUNT(*) c FROM questionnaire_response GROUP BY DATE(created_at) ORDER BY d ASC")->fetchAll();
@@ -42,7 +43,7 @@ foreach ($time as $row) {
 $workFunctionChart = [];
 foreach ($workFunctionStats as $row) {
   $wfKey = $row['work_function'] ?? '';
-  $wfLabel = WORK_FUNCTION_LABELS[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t, 'unknown', 'Unknown'));
+  $wfLabel = $workFunctionOptions[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t, 'unknown', 'Unknown'));
   $workFunctionChart[] = [
     'label' => $wfLabel,
     'total' => (int)($row['total_responses'] ?? 0),
@@ -187,7 +188,7 @@ SQL;
         <?php foreach ($workFunctionStats as $row): ?>
           <?php
             $wfKey = $row['work_function'] ?? '';
-            $wfLabel = WORK_FUNCTION_LABELS[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t,'unknown','Unknown'));
+            $wfLabel = $workFunctionOptions[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t,'unknown','Unknown'));
           ?>
           <tr>
             <td><?=htmlspecialchars($wfLabel, ENT_QUOTES, 'UTF-8')?></td>

--- a/my_performance.php
+++ b/my_performance.php
@@ -7,6 +7,7 @@ $locale = ensure_locale();
 $t = load_lang($locale);
 $cfg = get_site_config($pdo);
 $user = current_user();
+$userWorkFunctionLabel = work_function_label($pdo, (string)($user['work_function'] ?? ''));
 
 function compute_section_breakdowns(PDO $pdo, array $responses, array $translations): array
 {
@@ -328,7 +329,7 @@ if ($flash === 'submitted') {
   <?php if ($flashMessage): ?><div class="md-alert success"><?=htmlspecialchars($flashMessage, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t,'performance_overview','Performance Overview')?></h2>
-    <p><?=t($t,'current_work_function','Current work function:')?> <?=htmlspecialchars(WORK_FUNCTION_LABELS[$user['work_function']] ?? $user['work_function'])?></p>
+    <p><?=t($t,'current_work_function','Current work function:')?> <?=htmlspecialchars($userWorkFunctionLabel !== '' ? $userWorkFunctionLabel : (string)($user['work_function'] ?? ''), ENT_QUOTES, 'UTF-8')?></p>
     <?php if ($latestEntry): ?>
       <p><?=t($t,'latest_submission','Latest submission:')?> <?=htmlspecialchars($latestEntry['period_label'])?> · <?=htmlspecialchars($latestEntry['title'])?> (<?= is_null($latestEntry['score']) ? '-' : (int)$latestEntry['score'] ?>%)</p>
     <?php else: ?>

--- a/profile.php
+++ b/profile.php
@@ -8,6 +8,7 @@ $cfg = get_site_config($pdo);
 $user = current_user();
 $message = '';
 $error = '';
+$workFunctionOptions = work_function_choices($pdo);
 $pendingStatus = ($user['account_status'] ?? 'active') === 'pending';
 $pendingNotice = $pendingStatus;
 if (!empty($_SESSION['pending_notice'])) {
@@ -95,7 +96,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = t($t,'invalid_email','Provide a valid email address.');
     } elseif (!in_array($gender, ['female','male','other','prefer_not_say'], true)) {
         $error = t($t,'invalid_gender','Select a valid gender option.');
-    } elseif (!in_array($workFunction, WORK_FUNCTIONS, true)) {
+    } elseif (!isset($workFunctionOptions[$workFunction])) {
         $error = t($t,'invalid_work_function','Select a valid work function.');
     } elseif (strlen($phoneLocalDigits) < 6 || strlen($phoneLocalDigits) > 12) {
         $error = t($t,'invalid_phone','Enter a valid phone number including the country code.');
@@ -211,8 +212,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <select name="work_function" required>
           <?php $wval = $user['work_function'] ?? ''; ?>
           <option value="" disabled <?= $wval ? '' : 'selected' ?>><?=t($t,'select_option','Select')?></option>
-          <?php foreach (WORK_FUNCTIONS as $function): ?>
-            <option value="<?=$function?>" <?=$wval===$function?'selected':''?>><?=htmlspecialchars(WORK_FUNCTION_LABELS[$function] ?? $function)?></option>
+          <?php foreach ($workFunctionOptions as $function => $label): ?>
+            <option value="<?=$function?>" <?=$wval===$function?'selected':''?>><?=htmlspecialchars($label ?? $function, ENT_QUOTES, 'UTF-8')?></option>
           <?php endforeach; ?>
         </select>
       </label>


### PR DESCRIPTION
## Summary
- replace the WORK_FUNCTION constants with helper functions that derive available work functions dynamically
- update admin and staff pages to consume the new helpers for validation, option lists, and analytics labels
- ensure questionnaire management stores default work function assignments using the dynamic list

## Testing
- php -l config.php
- php -l profile.php
- php -l my_performance.php
- php -l admin/users.php
- php -l admin/analytics.php
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_68ec2b4352fc832daf21f177569c0c42