### PR TITLE
Fix hue normalization to prevent settings page error

### DIFF
--- a/config.php
+++ b/config.php
@@ -1151,7 +1151,11 @@ function hex_to_hsl(string $hex): array
 
 function hsl_to_hex(float $h, float $s, float $l): string
 {
-    $h = fmod(($h % 360) + 360, 360) / 360;
+    $normalizedHue = fmod($h, 360.0);
+    if ($normalizedHue < 0.0) {
+        $normalizedHue += 360.0;
+    }
+    $h = $normalizedHue / 360.0;
     $s = clamp_float($s, 0.0, 1.0);
     $l = clamp_float($l, 0.0, 1.0);
 


### PR DESCRIPTION
## Summary
- normalize hue calculations in `hsl_to_hex` to avoid float modulo deprecation warnings on PHP 8.2
- ensure the branding color palette renders without triggering a 500 error on the settings page

## Testing
- php -l config.php
- php -r "define('APP_BOOTSTRAPPED', true); require 'config.php'; site_brand_style(['brand_color'=>'#2073bf']);"


------
https://chatgpt.com/codex/tasks/task_e_68ec4713c87c832db2070e4ea175c4b2