### PR TITLE
Handle invalid site configuration when loading admin settings

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -6,6 +6,9 @@ require_profile_completion($pdo);
 $locale = ensure_locale();
 $t = load_lang($locale);
 $cfg = get_site_config($pdo);
+if (!is_array($cfg)) {
+    $cfg = [];
+}
 
 $themes = [
     'light' => t($t, 'theme_light', 'Light'),


### PR DESCRIPTION
## Summary
- ensure the admin settings page falls back to an empty configuration array when site configuration retrieval does not return an array
- prevent locale handling from crashing when the stored configuration is invalid or missing

## Testing
- php -l admin/settings.php

------
https://chatgpt.com/codex/tasks/task_e_68ec4b6aded8832db73a2261df165b22