### PR TITLE
Improve robustness of settings assets

### DIFF
--- a/config.php
+++ b/config.php
@@ -368,9 +368,9 @@ function site_enabled_locales(array $cfg): array
     return enforce_locale_requirements(decode_enabled_locales($raw));
 }
 
-/** get_site_config(): fetch branding and contact settings (singleton row id=1) */
-function get_site_config(PDO $pdo): array {
-    $defaults = [
+function site_config_defaults(): array
+{
+    return [
         'id' => 1,
         'site_name' => 'My Performance',
         'landing_text' => null,
@@ -406,12 +406,18 @@ function get_site_config(PDO $pdo): array {
         'smtp_timeout' => 20,
         'enabled_locales' => ['en', 'fr', 'am'],
     ];
+}
+
+/** get_site_config(): fetch branding and contact settings (singleton row id=1) */
+function get_site_config(PDO $pdo): array
+{
+    $defaults = site_config_defaults();
 
     try {
         ensure_site_config_schema($pdo);
         $pdo->exec("INSERT IGNORE INTO site_config (id, site_name, landing_text, address, contact, logo_path, footer_org_name, footer_org_short, footer_website_label, footer_website_url, footer_email, footer_phone, footer_hotline_label, footer_hotline_number, footer_rights, google_oauth_enabled, google_oauth_client_id, google_oauth_client_secret, microsoft_oauth_enabled, microsoft_oauth_client_id, microsoft_oauth_client_secret, microsoft_oauth_tenant, color_theme, brand_color, smtp_enabled, smtp_host, smtp_port, smtp_username, smtp_password, smtp_encryption, smtp_from_email, smtp_from_name, smtp_timeout, enabled_locales) VALUES (1, 'My Performance', NULL, NULL, NULL, NULL, 'Ethiopian Pharmaceutical Supply Service', 'EPSS / EPS', 'epss.gov.et', 'https://epss.gov.et', 'info@epss.gov.et', '+251 11 155 9900', 'Hotline 939', '939', 'All rights reserved.', 0, NULL, NULL, 0, NULL, NULL, 'common', 'light', '#2073bf', 0, NULL, 587, NULL, NULL, 'none', NULL, NULL, 20, '[\"en\",\"fr\",\"am\"]')");
         $cfg = $pdo->query('SELECT * FROM site_config WHERE id=1')->fetch(PDO::FETCH_ASSOC);
-    } catch (PDOException $e) {
+    } catch (Throwable $e) {
         error_log('get_site_config failed: ' . $e->getMessage());
         remember_available_locales($defaults['enabled_locales']);
         return $defaults;

--- a/manifest.php
+++ b/manifest.php
@@ -1,72 +1,94 @@
 <?php
 require_once __DIR__ . '/config.php';
 
-$cfg = get_site_config($pdo);
-$tokens = site_theme_tokens($cfg);
-$theme = site_color_theme($cfg);
-$themeVars = $tokens[$theme === 'dark' ? 'dark' : 'light'] ?? [];
-$rootVars = $tokens['root'] ?? [];
-$brand = site_brand_palette($cfg);
+$buildManifest = static function (array $cfg): array {
+    $tokens = site_theme_tokens($cfg);
+    $theme = site_color_theme($cfg);
+    $themeVars = $tokens[$theme === 'dark' ? 'dark' : 'light'] ?? [];
+    $rootVars = $tokens['root'] ?? [];
+    $brand = site_brand_palette($cfg);
 
-$themeColorCandidate = $rootVars['--brand-primary'] ?? $brand['primary'];
-$themeColor = normalize_hex_color($themeColorCandidate) ?? $brand['primary'];
+    $themeColorCandidate = $rootVars['--brand-primary'] ?? $brand['primary'];
+    $themeColor = normalize_hex_color($themeColorCandidate) ?? $brand['primary'];
 
-$backgroundCandidates = [
-    $themeVars['--app-surface'] ?? null,
-    $themeVars['--app-background'] ?? null,
-    $rootVars['--brand-bg'] ?? null,
-];
+    $backgroundCandidates = [
+        $themeVars['--app-surface'] ?? null,
+        $themeVars['--app-background'] ?? null,
+        $rootVars['--brand-bg'] ?? null,
+    ];
 
-$backgroundColor = null;
-foreach ($backgroundCandidates as $candidate) {
-    if ($candidate !== null && trim((string)$candidate) !== '') {
-        $backgroundColor = $candidate;
-        break;
+    $backgroundColor = null;
+    foreach ($backgroundCandidates as $candidate) {
+        if ($candidate !== null && trim((string)$candidate) !== '') {
+            $backgroundColor = $candidate;
+            break;
+        }
     }
-}
 
-$isGradient = static function (?string $value): bool {
-    if ($value === null) {
-        return false;
+    $isGradient = static function (?string $value): bool {
+        if ($value === null) {
+            return false;
+        }
+        $trimmed = strtolower(trim($value));
+        return str_starts_with($trimmed, 'linear-gradient') || str_starts_with($trimmed, 'radial-gradient');
+    };
+
+    if ($isGradient($backgroundColor)) {
+        $backgroundColor = null;
     }
-    $trimmed = strtolower(trim($value));
-    return str_starts_with($trimmed, 'linear-gradient') || str_starts_with($trimmed, 'radial-gradient');
+
+    $backgroundColor = normalize_hex_color((string)$backgroundColor);
+    if ($backgroundColor === null) {
+        $backgroundColor = $theme === 'dark'
+            ? shade_color($brand['primary'], 0.82)
+            : tint_color($brand['primary'], 0.92);
+    }
+
+    return [
+        'name' => (string)($cfg['site_name'] ?? 'My Performance'),
+        'short_name' => (string)($cfg['site_name'] ?? 'Performance'),
+        'start_url' => 'my_performance.php',
+        'display' => 'standalone',
+        'background_color' => $backgroundColor,
+        'theme_color' => $themeColor,
+        'icons' => [
+            [
+                'src' => asset_url('logo.php'),
+                'sizes' => '192x192',
+                'type' => 'image/svg+xml',
+            ],
+        ],
+    ];
 };
 
-if ($isGradient($backgroundColor)) {
-    $backgroundColor = null;
+try {
+    $cfg = get_site_config($pdo);
+    $manifest = $buildManifest($cfg);
+} catch (Throwable $e) {
+    error_log('manifest generation failed: ' . $e->getMessage());
+    $manifest = $buildManifest(site_config_defaults());
 }
-
-$backgroundColor = normalize_hex_color((string)$backgroundColor);
-if ($backgroundColor === null) {
-    $backgroundColor = $theme === 'dark'
-        ? shade_color($brand['primary'], 0.82)
-        : tint_color($brand['primary'], 0.92);
-}
-
-$manifest = [
-    'name' => (string)($cfg['site_name'] ?? 'My Performance'),
-    'short_name' => (string)($cfg['site_name'] ?? 'Performance'),
-    'start_url' => 'my_performance.php',
-    'display' => 'standalone',
-    'background_color' => $backgroundColor,
-    'theme_color' => $themeColor,
-    'icons' => [
-        [
-            'src' => asset_url('logo.php'),
-            'sizes' => '192x192',
-            'type' => 'image/svg+xml',
-        ],
-    ],
-];
 
 $json = json_encode($manifest, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
 if ($json === false) {
-    http_response_code(500);
-    header('Content-Type: application/manifest+json; charset=utf-8');
-    echo json_encode(['error' => 'Unable to generate manifest'], JSON_UNESCAPED_SLASHES);
-    return;
+    error_log('manifest json_encode failure: ' . json_last_error_msg());
+    $fallback = [
+        'name' => 'My Performance',
+        'short_name' => 'Performance',
+        'start_url' => 'my_performance.php',
+        'display' => 'standalone',
+        'background_color' => '#2073bf',
+        'theme_color' => '#2073bf',
+        'icons' => [
+            [
+                'src' => asset_url('logo.php'),
+                'sizes' => '192x192',
+                'type' => 'image/svg+xml',
+            ],
+        ],
+    ];
+    $json = json_encode($fallback, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
 }
 
 header('Content-Type: application/manifest+json; charset=utf-8');
-echo $json;
+echo $json ?: '{}';


### PR DESCRIPTION
## Summary
- add a reusable default site configuration helper and reuse it when the database lookup fails
- harden manifest and logo generators with try/catch fallbacks so they always return usable responses
- wrap the settings controller in defensive error handling and surface debug details when APP_DEBUG is enabled

## Testing
- php -l config.php
- php -l manifest.php
- php -l logo.php
- php -l admin/settings.php

------
https://chatgpt.com/codex/tasks/task_e_68ec5501c938832db5c96e8db962c9b0