### PR TITLE
Improve navigation highlighting and strengthen backups

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -109,6 +109,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $timestamp = date('Ymd_His');
             $filename = 'system-backup-' . $timestamp . '.zip';
             $fullPath = $backupDir . '/' . $filename;
+            $tempFiles = [];
+            $backupGenerated = false;
 
             try {
                 $zip = new ZipArchive();
@@ -156,6 +158,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $responseItemsStmt = $pdo->query('SELECT response_id, linkId, answer FROM questionnaire_response_item ORDER BY response_id, id');
                 $addJson($zip, 'data/questionnaire_response_items.json', $responseItemsStmt ? $responseItemsStmt->fetchAll(PDO::FETCH_ASSOC) : []);
 
+                $databaseDump = '-- Database backup generated ' . date('c') . "\n";
                 try {
                     $tablesStmt = $pdo->query('SHOW TABLES');
                     $tables = $tablesStmt ? $tablesStmt->fetchAll(PDO::FETCH_COLUMN) : [];
@@ -199,11 +202,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 }
                             }
                         }
-                        $zip->addFromString('database/backup.sql', implode("\n", $dumpLines) . "\n");
+                        $databaseDump = implode("\n", $dumpLines) . "\n";
+                    } else {
+                        $databaseDump .= "-- No tables were found in the database at the time of backup.\n";
                     }
                 } catch (Throwable $dumpError) {
                     error_log('Database backup export failed: ' . $dumpError->getMessage());
+                    $databaseDump .= "-- Failed to export database. Check server logs for details.\n";
                 }
+                $zip->addFromString('database/backup.sql', $databaseDump);
 
                 $uploadsDir = base_path('assets/uploads');
                 if (is_dir($uploadsDir)) {
@@ -221,9 +228,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
                 try {
                     $appRoot = base_path('');
-                    $zip->addEmptyDir('application');
+                    $tempArchive = tempnam(sys_get_temp_dir(), 'appzip_');
+                    if ($tempArchive === false) {
+                        throw new RuntimeException('Unable to create temporary archive for application backup.');
+                    }
+                    $appArchivePath = $tempArchive . '.zip';
+                    if (!@rename($tempArchive, $appArchivePath)) {
+                        @unlink($tempArchive);
+                        throw new RuntimeException('Unable to prepare archive path for application backup.');
+                    }
+                    $tempFiles[] = $appArchivePath;
+                    $appZip = new ZipArchive();
+                    if ($appZip->open($appArchivePath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+                        throw new RuntimeException('Unable to create application archive.');
+                    }
                     $iterator = new RecursiveIteratorIterator(
-                        new RecursiveDirectoryIterator($appRoot, FilesystemIterator::SKIP_DOTS)
+                        new RecursiveDirectoryIterator($appRoot, FilesystemIterator::SKIP_DOTS),
+                        RecursiveIteratorIterator::SELF_FIRST
                     );
                     foreach ($iterator as $fileInfo) {
                         if (!$fileInfo->isFile()) {
@@ -238,16 +259,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             continue;
                         }
                         $relative = str_replace('\\', '/', $relative);
-                        if (strpos($relative, '.git/') === 0) {
+                        if ($relative === '' || strpos($relative, '.git/') === 0) {
                             continue;
                         }
-                        $zip->addFile($pathName, 'application/' . $relative);
+                        if (strpos($relative, 'assets/backups/') === 0 || strpos($relative, 'backups/') === 0) {
+                            continue;
+                        }
+                        $appZip->addFile($pathName, $relative);
                     }
+                    $appZip->close();
+                    $zip->addFile($appArchivePath, 'application.zip');
                 } catch (Throwable $archiveError) {
+                    if (isset($appZip) && $appZip instanceof ZipArchive) {
+                        $appZip->close();
+                    }
                     error_log('Application archive export failed: ' . $archiveError->getMessage());
                 }
 
                 $zip->close();
+                $backupGenerated = true;
             } catch (Throwable $backupError) {
                 if (isset($zip) && $zip instanceof ZipArchive) {
                     $zip->close();
@@ -258,6 +288,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 error_log('Admin backup failed: ' . $backupError->getMessage());
                 $flashMessage = t($t, 'backup_failed', 'Unable to generate the backup archive.');
                 $flashType = 'error';
+            }
+
+            foreach ($tempFiles as $tempFile) {
+                if (is_string($tempFile) && is_file($tempFile)) {
+                    @unlink($tempFile);
+                }
+            }
+
+            if (!$backupGenerated) {
                 break;
             }
 

--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -468,10 +468,18 @@ if ($action === 'save' || $action === 'publish') {
     ]);
 }
 
-$msg = '';
+$msg = $_SESSION['questionnaire_import_flash'] ?? '';
 $recentImportId = null;
+if (isset($_SESSION['questionnaire_import_focus'])) {
+    $candidate = (int)$_SESSION['questionnaire_import_focus'];
+    if ($candidate > 0) {
+        $recentImportId = $candidate;
+    }
+}
+unset($_SESSION['questionnaire_import_flash'], $_SESSION['questionnaire_import_focus']);
 if (isset($_POST['import'])) {
     csrf_check();
+    $recentImportId = null;
     if (!empty($_FILES['file']['tmp_name'])) {
         $raw = file_get_contents($_FILES['file']['tmp_name']);
         $data = null;
@@ -650,6 +658,13 @@ if (isset($_POST['import'])) {
     } else {
         $msg = t($t, 'no_file_uploaded', 'No file uploaded');
     }
+    $_SESSION['questionnaire_import_flash'] = $msg;
+    if ($recentImportId) {
+        $_SESSION['questionnaire_import_focus'] = $recentImportId;
+    }
+    session_write_close();
+    header('Location: ' . url_for('admin/questionnaire_manage.php'));
+    exit;
 }
 ?>
 <!doctype html>

--- a/templates/header.php
+++ b/templates/header.php
@@ -19,6 +19,43 @@ $siteTitle = htmlspecialchars($cfg['site_name'] ?? 'My Performance');
 $availableLocales = available_locales();
 $defaultLocale = $availableLocales[0] ?? 'en';
 $brandStyle = site_brand_style($cfg);
+$drawerKey = $drawerKey ?? null;
+$scriptName = ltrim((string)($_SERVER['SCRIPT_NAME'] ?? ''), '/');
+$navKeyMap = [
+    'my_performance.php' => 'workspace.my_performance',
+    'submit_assessment.php' => 'workspace.submit_assessment',
+    'profile.php' => 'workspace.profile',
+    'admin/supervisor_review.php' => 'team.review_queue',
+    'admin/pending_accounts.php' => 'team.pending_accounts',
+    'admin/questionnaire_assignments.php' => 'team.assignments',
+    'admin/dashboard.php' => 'admin.dashboard',
+    'admin/users.php' => 'admin.users',
+    'admin/questionnaire_manage.php' => 'admin.manage_questionnaires',
+    'admin/analytics.php' => 'admin.analytics',
+    'admin/export.php' => 'admin.export',
+    'admin/branding.php' => 'admin.branding',
+    'admin/settings.php' => 'admin.settings',
+    'swagger.php' => 'admin.api_docs',
+];
+if ($drawerKey === null && $scriptName !== '') {
+    $drawerKey = $navKeyMap[$scriptName] ?? null;
+}
+$isActiveNav = static function (string ...$keys) use ($drawerKey): bool {
+    if ($drawerKey === null) {
+        return false;
+    }
+    foreach ($keys as $key) {
+        if ($drawerKey === $key) {
+            return true;
+        }
+    }
+    return false;
+};
+$drawerLinkAttributes = static function (string ...$keys) use ($isActiveNav): string {
+    $class = 'md-drawer-link' . ($isActiveNav(...$keys) ? ' active' : '');
+    $aria = $isActiveNav(...$keys) ? ' aria-current="page"' : '';
+    return sprintf('class="%s"%s', $class, $aria);
+};
 ?>
 <?php if ($brandStyle !== ''): ?>
 <style id="md-brand-style">:root { <?=htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8')?>; }</style>
@@ -54,29 +91,29 @@ $brandStyle = site_brand_style($cfg);
   <nav class="md-drawer-nav">
     <div class="md-drawer-section">
       <span class="md-drawer-label"><?=t($t, 'my_workspace', 'My Workspace')?></span>
-      <a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'my_performance', 'My Performance')?></a>
-      <a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'submit_assessment', 'Submit Assessment')?></a>
-      <a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'profile', 'Profile')?></a>
+      <a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('workspace.my_performance')?>><?=t($t, 'my_performance', 'My Performance')?></a>
+      <a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('workspace.submit_assessment')?>><?=t($t, 'submit_assessment', 'Submit Assessment')?></a>
+      <a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('workspace.profile')?>><?=t($t, 'profile', 'Profile')?></a>
     </div>
     <?php if (in_array($role, ['admin', 'supervisor'], true)): ?>
       <div class="md-drawer-section">
         <span class="md-drawer-label"><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
-        <a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'review_queue', 'Review Queue')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'pending_accounts', 'Pending Approvals')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('team.review_queue')?>><?=t($t, 'review_queue', 'Review Queue')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('team.pending_accounts')?>><?=t($t, 'pending_accounts', 'Pending Approvals')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('team.assignments')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a>
       </div>
     <?php endif; ?>
     <?php if ($role === 'admin'): ?>
       <div class="md-drawer-section">
         <span class="md-drawer-label"><?=t($t, 'admin_navigation', 'Administration')?></span>
-        <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'admin_dashboard', 'Admin Dashboard')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'manage_users', 'Manage Users')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'analytics', 'Analytics')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'export_data', 'Export Data')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'branding', 'Branding & Landing')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t, 'settings', 'Settings')?></a>
-        <a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link"><?=t($t,'api_documentation','API Documentation')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.dashboard')?>><?=t($t, 'admin_dashboard', 'Admin Dashboard')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.users')?>><?=t($t, 'manage_users', 'Manage Users')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.manage_questionnaires')?>><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.analytics')?>><?=t($t, 'analytics', 'Analytics')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.export')?>><?=t($t, 'export_data', 'Export Data')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.branding')?>><?=t($t, 'branding', 'Branding & Landing')?></a>
+        <a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.settings')?>><?=t($t, 'settings', 'Settings')?></a>
+        <a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.api_docs')?>><?=t($t,'api_documentation','API Documentation')?></a>
       </div>
     <?php endif; ?>
   </nav>


### PR DESCRIPTION
## Summary
- highlight the active navigation menu entry automatically based on the current page
- redirect after questionnaire imports so the newly imported form opens by default
- bundle a database dump and full application archive in admin-generated backups

## Testing
- php -l templates/header.php
- php -l admin/questionnaire_manage.php
- php -l admin/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68eeac3a6374832da4317363d80243da