### PR TITLE
Revamp login layout and theme palette

### DIFF
--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -23,6 +23,7 @@ body.md-bg {
   background: var(--md-bg);
   color: var(--app-text-primary);
   font-family: "Segoe UI", "Poppins", system-ui, -apple-system, Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
 }
 
 .md-appbar {
@@ -238,9 +239,9 @@ body.md-bg {
 }
 
 .md-alert {
-  background: var(--app-warning-soft));
-  border-left: 4px solid var(--app-warning));
-  color: var(--md-muted);
+  background: var(--status-warning-surface);
+  border-left: 4px solid var(--status-warning);
+  color: var(--status-warning-text);
   padding: 12px 16px;
   border-radius: 12px;
   margin: 12px 0;
@@ -379,16 +380,160 @@ body.md-bg {
 }
 
 .md-container {
+  position: relative;
   min-height: 100vh;
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  padding: 32px 18px;
+}
+
+.md-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 12% 18%, rgba(14, 165, 233, 0.18), transparent 45%),
+    radial-gradient(circle at 88% 12%, rgba(124, 58, 237, 0.14), transparent 50%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.md-container > * {
+  position: relative;
+  z-index: 1;
 }
 
 .md-login {
   max-width: 460px;
   width: 100%;
+}
+
+.md-login.md-login--split {
+  max-width: 960px;
+  padding: 0;
+  border-radius: 28px;
+  overflow: hidden;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  box-shadow: 0 36px 86px rgba(15, 23, 42, 0.16);
+}
+
+.md-login.md-login--split::before {
+  content: none;
+}
+
+.md-login--split .md-login-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 960px) {
+  .md-login--split .md-login-grid {
+    grid-template-columns: 1.05fr 1fr;
+  }
+}
+
+.md-login--split .md-login-panel {
+  padding: 2.75rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (max-width: 599px) {
+  .md-login--split .md-login-panel {
+    padding: 2.2rem 1.75rem;
+  }
+}
+
+.md-login--split .md-login-panel--brand {
+  background: linear-gradient(162deg, var(--app-primary-dark) 0%, var(--app-primary) 52%, var(--app-secondary) 100%);
+  color: var(--app-text-inverse);
+  position: relative;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.md-login--split .md-login-panel--brand::after {
+  content: "";
+  position: absolute;
+  inset: -40% -35% auto -30%;
+  height: 420px;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.22), transparent 70%);
+  pointer-events: none;
+}
+
+.md-login--split .md-login-panel--brand > * {
+  position: relative;
+  z-index: 1;
+}
+
+.md-login--split .md-login-panel--brand .md-title {
+  margin-top: 0.5rem;
+  font-size: 2.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: inherit;
+}
+
+.md-login--split .md-login-panel--brand .md-logo {
+  width: min(220px, 60%);
+  max-width: 220px;
+  height: auto;
+  filter: drop-shadow(0 18px 36px rgba(6, 15, 40, 0.25));
+}
+
+.md-login--split .md-login-tagline {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.7;
+  color: rgba(255, 255, 255, 0.85);
+  max-width: 28rem;
+}
+
+.md-login--split .md-login-panel--form {
+  background: var(--app-surface);
+  color: var(--app-text-primary);
+  justify-content: center;
+  gap: 1.25rem;
+}
+
+.md-login--split .md-login-panel--form .md-subtitle {
+  margin: 0;
+  color: var(--app-text-secondary);
+  text-align: left;
+}
+
+.md-login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+}
+
+.md-login-form .md-field {
+  gap: 0.5rem;
+}
+
+.md-login-form .md-field span {
+  font-weight: 600;
+  color: var(--app-text-secondary);
+}
+
+.md-login-form .md-field input {
+  border: 1px solid var(--app-border);
+  background: var(--app-input-bg);
+  color: var(--app-on-surface-strong);
+}
+
+.md-login-form .md-field input:focus {
+  border-color: var(--app-secondary);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.18);
+  background: #ffffff;
+}
+
+.md-login--split .md-login-panel--form .md-alert {
+  margin-bottom: 0;
 }
 
 .md-card-media {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,5 +1,73 @@
 :root {
   --appbar-height: 64px;
+  --app-primary: #274690;
+  --app-primary-dark: #1b2f59;
+  --app-primary-darker: #111a30;
+  --app-primary-light: #5a7bd8;
+  --app-secondary: #0ea5e9;
+  --app-secondary-soft: rgba(14, 165, 233, 0.15);
+  --app-accent: #7c3aed;
+  --app-accent-soft: rgba(124, 58, 237, 0.18);
+  --app-muted: #5b6b8c;
+  --app-muted-light: #7a87a6;
+  --app-border: rgba(15, 23, 42, 0.12);
+  --app-border-strong: rgba(15, 23, 42, 0.18);
+  --app-divider: rgba(15, 23, 42, 0.12);
+  --app-surface: #ffffff;
+  --app-surface-alt: #f5f7fb;
+  --app-surface-muted: #eef2ff;
+  --app-surface-highlight: #0f172a;
+  --app-bg: radial-gradient(circle at top left, rgba(39, 70, 144, 0.12), transparent 55%),
+    linear-gradient(140deg, #f5f7fb, #e9efff);
+  --app-shadow-soft: 0 28px 64px rgba(15, 23, 42, 0.14);
+  --app-shadow-strong: 0 36px 86px rgba(15, 23, 42, 0.2);
+  --app-primary-soft: rgba(39, 70, 144, 0.16);
+  --app-primary-softer: rgba(39, 70, 144, 0.24);
+  --app-danger: #dc2626;
+  --app-danger-soft: rgba(220, 38, 38, 0.18);
+  --app-warning: #d97706;
+  --app-warning-soft: rgba(217, 119, 6, 0.18);
+  --app-info: #0ea5e9;
+  --app-info-soft: rgba(14, 165, 233, 0.18);
+  --app-input-bg: rgba(255, 255, 255, 0.92);
+  --app-on-primary: #ffffff;
+  --app-on-primary-soft: rgba(255, 255, 255, 0.22);
+  --app-on-primary-subtle: rgba(255, 255, 255, 0.32);
+  --app-on-surface: #1b233d;
+  --app-on-surface-muted: rgba(27, 35, 61, 0.72);
+  --app-on-surface-strong: #111936;
+  --app-text-primary: #1b233d;
+  --app-text-secondary: #36446b;
+  --app-text-muted: #5b6b8c;
+  --app-text-inverse: #ffffff;
+  --app-table-stripe: rgba(15, 23, 42, 0.06);
+  --app-table-border: rgba(15, 23, 42, 0.12);
+  --app-chart-grid: rgba(39, 70, 144, 0.18);
+  --app-chart-axis: rgba(27, 35, 61, 0.45);
+  --app-chart-label: #36446b;
+  --app-chart-surface: #ffffff;
+  --app-chip-bg: rgba(39, 70, 144, 0.1);
+  --app-chip-border: rgba(39, 70, 144, 0.18);
+  --app-hero-gradient: linear-gradient(135deg, #eff6ff, #e0e7ff);
+  --app-success-gradient: linear-gradient(120deg, #16a34a, #22c55e);
+  --floating-shadow: rgba(15, 23, 42, 0.18);
+  --floating-shadow-strong: rgba(15, 23, 42, 0.26);
+  --status-success: #16a34a;
+  --status-success-soft: rgba(22, 163, 74, 0.14);
+  --status-success-text: #0f5132;
+  --status-success-border: rgba(22, 163, 74, 0.32);
+  --status-success-surface: #f0fdf4;
+  --status-success-gradient: linear-gradient(120deg, #16a34a, #22c55e);
+  --status-warning: #d97706;
+  --status-warning-soft: rgba(217, 119, 6, 0.18);
+  --status-warning-text: #92400e;
+  --status-warning-border: rgba(217, 119, 6, 0.32);
+  --status-warning-surface: #fffbeb;
+  --status-danger: #dc2626;
+  --status-danger-soft: rgba(220, 38, 38, 0.18);
+  --status-danger-text: #991b1b;
+  --status-danger-border: rgba(220, 38, 38, 0.32);
+  --status-danger-surface: #fef2f2;
 }
 
 * {
@@ -23,7 +91,8 @@ body.md-bg {
   min-height: 100vh;
   margin: 0;
   font-family: "Segoe UI", "Poppins", system-ui, -apple-system, Roboto, Helvetica, Arial, sans-serif;
-  color: inherit;
+  color: var(--app-text-primary);
+  line-height: 1.6;
 }
 
 .md-appbar {
@@ -31,7 +100,7 @@ body.md-bg {
   align-items: center;
   justify-content: space-between;
   padding: 0.85rem 1.35rem;
-  background: linear-gradient(92deg, var(--app-primary-dark), var(--app-primary));
+  background: linear-gradient(92deg, var(--app-primary-dark), var(--app-primary);
   position: sticky;
   top: 0;
   z-index: 1000;
@@ -198,7 +267,7 @@ body.md-bg {
   margin-left: 0;
   padding: 1.2rem 0;
   transition: margin-left 0.3s ease;
-  min-height: calc(100vh - var(--appbar-height));
+  min-height: calc(100vh - var(--appbar-height);
 }
 
 .md-section {
@@ -221,7 +290,7 @@ body.md-bg {
   position: absolute;
   inset: 0 0 auto;
   height: 4px;
-  background: linear-gradient(90deg, var(--app-primary), var(--app-secondary));
+  background: linear-gradient(90deg, var(--app-primary), var(--app-secondary);
 }
 
 .md-card > * {
@@ -270,7 +339,7 @@ body.md-bg {
   margin: 0.5rem 0 0;
   padding: 1rem 1.25rem;
   border-radius: 14px;
-  background: var(--app-primary-soft));
+  background: var(--app-primary-soft);
   color: var(--app-muted);
   font-weight: 500;
   letter-spacing: 0.01em;
@@ -321,7 +390,7 @@ body.theme-dark .md-user-card {
   width: 3.1rem;
   height: 3.1rem;
   border-radius: 50%;
-  background: var(--app-primary-soft));
+  background: var(--app-primary-soft);
   color: var(--app-primary-dark);
   font-weight: 700;
   display: grid;
@@ -363,7 +432,7 @@ body.theme-dark .md-user-card__heading h3 {
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  background: var(--app-primary-soft));
+  background: var(--app-primary-soft);
   color: var(--app-primary-dark);
   box-shadow: inset 0 0 0 1px var(--app-primary-softer);
 }
@@ -537,7 +606,7 @@ body.theme-dark .md-field.md-field--compact select {
 .md-phone-flag {
   font-size: 1.6rem;
   line-height: 1;
-  filter: drop-shadow(0 3px 8px var(--app-primary-soft));
+  filter: drop-shadow(0 3px 8px var(--app-primary-soft);
 }
 
 .md-phone-country {
@@ -670,38 +739,51 @@ body.theme-dark .md-field.md-field--compact select {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  margin-top: 0.75rem;
+  margin-top: 1.25rem;
 }
 
 .md-sso-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.6rem;
   width: 100%;
   text-align: center;
+  background: var(--app-surface-alt);
+  border: 1px solid var(--app-border);
+  color: var(--app-on-surface-strong);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
 
 .md-sso-btn.google {
-  background: var(--app-surface);
-  border: 1px solid var(--app-border-strong);
-  color: var(--app-primary-dark);
+  background: #ffffff;
 }
 
 .md-sso-btn.microsoft {
-  background: var(--app-surface);
-  border: 1px solid var(--app-border-strong);
-  color: var(--app-primary-dark);
+  background: #ffffff;
 }
 
 .md-sso-btn.google:hover,
 .md-sso-btn.microsoft:hover {
   background: var(--app-input-bg);
+  border-color: var(--app-secondary);
+  color: var(--app-primary-dark);
+}
+
+@media (min-width: 600px) {
+  .md-sso-buttons {
+    flex-direction: row;
+  }
+
+  .md-sso-btn {
+    width: auto;
+    flex: 1;
+  }
 }
 
 .md-button.md-outline {
   background: transparent;
-  border: 1px solid var(--app-border));
+  border: 1px solid var(--app-border);
   color: var(--app-primary);
   box-shadow: none;
 }
@@ -726,8 +808,8 @@ body.theme-dark .md-field.md-field--compact select {
 
 
 .md-button.md-outline:hover {
-  background: var(--app-primary-soft));
-  box-shadow: var(--app-shadow-soft));
+  background: var(--app-primary-soft);
+  box-shadow: var(--app-shadow-soft);
 }
 
 .md-form-actions {
@@ -754,11 +836,113 @@ body.theme-dark .md-field.md-field--compact select {
 }
 
 .md-login-actions {
-  margin-top: 1.25rem;
+  margin-top: 1.5rem;
 }
 
 .md-login-actions .md-button {
-  min-width: 9rem;
+  width: 100%;
+  min-width: 0;
+}
+
+@media (min-width: 520px) {
+  .md-login-actions .md-button {
+    width: auto;
+    min-width: 9rem;
+  }
+}
+
+.md-login-divider {
+  position: relative;
+  margin: 1.75rem 0 1.25rem;
+  text-align: center;
+  color: var(--app-muted);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.md-login-divider::before,
+.md-login-divider::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 36%;
+  height: 1px;
+  background: var(--app-border);
+}
+
+.md-login-divider::before {
+  left: 0;
+}
+
+.md-login-divider::after {
+  right: 0;
+}
+
+.md-login-divider span {
+  display: inline-block;
+  padding: 0 0.75rem;
+  background: var(--app-surface);
+  position: relative;
+  z-index: 1;
+}
+
+.md-login-footer {
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--app-muted);
+}
+
+.md-login-footer-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  text-align: left;
+}
+
+@media (min-width: 600px) {
+  .md-login-footer-item {
+    text-align: center;
+  }
+}
+
+.md-login-footer-label {
+  font-weight: 600;
+  color: var(--app-text-secondary);
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+}
+
+.md-login-footer-value {
+  color: var(--app-on-surface-muted);
+}
+
+.md-login-footer-locale {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.md-login-footer-locale a {
+  color: var(--app-primary);
+  font-weight: 600;
+  text-decoration: none;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.md-login-footer-locale a:hover,
+.md-login-footer-locale a:focus {
+  background: var(--app-primary-soft);
+  border-color: var(--app-primary);
+  color: var(--app-primary-dark);
 }
 
 .md-radar-grid {
@@ -852,28 +1036,29 @@ body.theme-dark .md-floating-save-draft {
 .md-alert {
   padding: 0.85rem 1rem;
   border-radius: 12px;
-  background: var(--app-warning-soft));
+  background: var(--status-warning-surface);
   color: var(--status-warning-text);
-  border-left: 5px solid var(--app-warning));
+  border-left: 5px solid var(--status-warning);
   margin-bottom: 1.1rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
 .md-alert.success {
-  background: var(--app-secondary-soft));
-  color: var(--app-primary-dark);
-  border-left-color: var(--app-secondary);
+  background: var(--status-success-surface);
+  color: var(--status-success-text);
+  border-left-color: var(--status-success);
 }
 
 .md-alert.error {
-  background: var(--app-danger-soft));
+  background: var(--status-danger-surface);
   color: var(--status-danger-text);
-  border-left-color: var(--app-danger));
+  border-left-color: var(--status-danger);
 }
 
 .md-alert.warning {
-  background: var(--app-warning-soft));
+  background: var(--status-warning-surface);
   color: var(--status-warning-text);
-  border-left-color: var(--app-warning));
+  border-left-color: var(--status-warning);
 }
 
 .md-draft-alert {
@@ -944,8 +1129,8 @@ body.theme-dark .md-card {
 body.theme-dark .md-field select,
 body.theme-dark .md-field input,
 body.theme-dark .md-field textarea {
-  background: var(--app-input-bg));
-  border: 1px solid var(--app-border));
+  background: var(--app-input-bg);
+  border: 1px solid var(--app-border);
   color: inherit;
 }
 
@@ -954,23 +1139,23 @@ body.theme-dark .md-field select:focus,
 body.theme-dark .md-field textarea:focus {
   background: var(--app-input-bg);
   border-color: var(--app-secondary);
-  box-shadow: 0 0 0 3px var(--app-secondary-soft));
+  box-shadow: 0 0 0 3px var(--app-secondary-soft);
 }
 
 body.theme-dark .md-alert {
-  background: var(--app-secondary-soft));
+  background: var(--app-secondary-soft);
   color: var(--app-surface-highlight);
   border-left-color: var(--app-secondary);
 }
 
 body.theme-dark .md-alert.error {
-  background: var(--app-danger-soft));
+  background: var(--app-danger-soft);
   color: var(--status-danger-surface);
-  border-left-color: var(--app-danger));
+  border-left-color: var(--app-danger);
 }
 
 body.theme-dark .md-alert.success {
-  background: var(--app-secondary-soft));
+  background: var(--app-secondary-soft);
   color: var(--app-surface-highlight);
 }
 
@@ -992,12 +1177,12 @@ body.theme-dark .md-button {
 }
 
 body.theme-dark .md-button.md-outline {
-  border-color: var(--app-border));
-  color: var(--app-secondary));
+  border-color: var(--app-border);
+  color: var(--app-secondary);
 }
 
 body.theme-dark .md-button.md-outline:hover {
-  background: var(--app-secondary-soft));
+  background: var(--app-secondary-soft);
 }
 
 body.theme-dark .md-button.md-primary {

--- a/login.php
+++ b/login.php
@@ -85,6 +85,17 @@ $bodyStyle = htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8');
 $baseUrl = htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8');
 $langAttr = htmlspecialchars($locale, ENT_QUOTES, 'UTF-8');
 $brandStyle = site_brand_style($cfg);
+$introText = $landingText !== ''
+    ? $landingText
+    : htmlspecialchars(
+        t(
+            $t,
+            'welcome_msg',
+            'Sign in to start your self-assessment and track your performance over time.'
+        ),
+        ENT_QUOTES,
+        'UTF-8'
+    );
 ?>
 <!doctype html>
 <html lang="<?= $langAttr ?>" data-base-url="<?= $baseUrl ?>">
@@ -103,68 +114,72 @@ $brandStyle = site_brand_style($cfg);
 <body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>">
   <div id="google_translate_element" class="visually-hidden" aria-hidden="true"></div>
   <div class="md-container">
-    <div class="md-card md-elev-3 md-login">
-      <div class="md-card-media">
-        <img src="<?= $logo ?>" alt="Logo" class="md-logo">
-        <h1 class="md-title"><?= $siteName ?></h1>
-      </div>
+    <div class="md-card md-elev-3 md-login md-login--split">
+      <div class="md-login-grid">
+        <section class="md-login-panel md-login-panel--brand">
+          <img src="<?= $logo ?>" alt="Logo" class="md-logo">
+          <h1 class="md-title"><?= $siteName ?></h1>
+          <?php if ($introText !== ''): ?>
+            <p class="md-login-tagline"><?= $introText ?></p>
+          <?php endif; ?>
+        </section>
+        <section class="md-login-panel md-login-panel--form">
+          <?php if ($err !== ''): ?>
+            <div class="md-alert error"><?= htmlspecialchars($err, ENT_QUOTES, 'UTF-8') ?></div>
+          <?php endif; ?>
 
-      <?php if ($landingText !== ''): ?>
-        <p class="md-subtitle"><?= $landingText ?></p>
-      <?php else: ?>
-        <p class="md-subtitle"><?= t($t, 'welcome_msg', 'Sign in to start your self-assessment and track your performance over time.') ?></p>
-      <?php endif; ?>
+          <form method="post" class="md-form md-login-form" action="<?= htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8') ?>">
+            <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+            <label class="md-field">
+              <span><?= t($t, 'username', 'Username') ?></span>
+              <input name="username" autocomplete="username" required>
+            </label>
+            <label class="md-field">
+              <span><?= t($t, 'password', 'Password') ?></span>
+              <input type="password" name="password" autocomplete="current-password" required>
+            </label>
+            <div class="md-form-actions md-form-actions--center md-login-actions">
+              <button class="md-button md-primary md-elev-2" type="submit">
+                <?= t($t, 'sign_in', 'Sign In') ?>
+              </button>
+            </div>
+          </form>
 
-      <form method="post" class="md-form" action="<?= htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8') ?>">
-        <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
-        <label class="md-field">
-          <span><?= t($t, 'username', 'Username') ?></span>
-          <input name="username" required>
-        </label>
-        <label class="md-field">
-          <span><?= t($t, 'password', 'Password') ?></span>
-          <input type="password" name="password" required>
-        </label>
-        <?php if ($err !== ''): ?>
-          <div class="md-alert"><?= htmlspecialchars($err, ENT_QUOTES, 'UTF-8') ?></div>
-        <?php endif; ?>
-        <div class="md-form-actions md-form-actions--center md-login-actions">
-          <button class="md-button md-primary md-elev-2" type="submit">
-            <?= t($t, 'sign_in', 'Sign In') ?>
-          </button>
-        </div>
-      </form>
+          <?php if (!empty($oauthProviders)): ?>
+            <div class="md-login-divider"><span><?= htmlspecialchars(t($t, 'or_continue_with', 'or continue with'), ENT_QUOTES, 'UTF-8') ?></span></div>
+            <div class="md-sso-buttons">
+              <?php foreach ($oauthProviders as $provider => $label): ?>
+                <a
+                  class="md-button md-elev-1 md-sso-btn <?= htmlspecialchars($provider, ENT_QUOTES, 'UTF-8') ?>"
+                  href="<?= htmlspecialchars(url_for('oauth.php?provider=' . $provider), ENT_QUOTES, 'UTF-8') ?>"
+                ><?= $label ?></a>
+              <?php endforeach; ?>
+            </div>
+          <?php endif; ?>
 
-      <?php if (!empty($oauthProviders)): ?>
-        <div class="md-divider"></div>
-        <div class="md-sso-buttons">
-          <?php foreach ($oauthProviders as $provider => $label): ?>
-            <a
-              class="md-button md-elev-1 md-sso-btn <?= htmlspecialchars($provider, ENT_QUOTES, 'UTF-8') ?>"
-              href="<?= htmlspecialchars(url_for('oauth.php?provider=' . $provider), ENT_QUOTES, 'UTF-8') ?>"
-            ><?= $label ?></a>
-          <?php endforeach; ?>
-        </div>
-      <?php endif; ?>
-
-      <div class="md-meta">
-        <?php if ($address !== ''): ?>
-          <div class="md-small"><strong><?= t($t, 'address_label', 'Address') ?>:</strong> <?= $address ?></div>
-        <?php endif; ?>
-        <?php if ($contact !== ''): ?>
-          <div class="md-small"><strong><?= t($t, 'contact_label', 'Contact') ?>:</strong> <?= $contact ?></div>
-        <?php endif; ?>
-        <div class="md-small lang-switch">
-          <?php
-          $links = [];
-          foreach ($availableLocales as $loc) {
-              $url = htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8');
-              $label = htmlspecialchars(strtoupper($loc), ENT_QUOTES, 'UTF-8');
-              $links[] = "<a href='" . $url . "'>" . $label . "</a>";
-          }
-          echo implode(' · ', $links);
-          ?>
-        </div>
+          <div class="md-login-footer">
+            <?php if ($address !== ''): ?>
+              <div class="md-login-footer-item">
+                <span class="md-login-footer-label"><?= t($t, 'address_label', 'Address') ?></span>
+                <span class="md-login-footer-value"><?= $address ?></span>
+              </div>
+            <?php endif; ?>
+            <?php if ($contact !== ''): ?>
+              <div class="md-login-footer-item">
+                <span class="md-login-footer-label"><?= t($t, 'contact_label', 'Contact') ?></span>
+                <span class="md-login-footer-value"><?= $contact ?></span>
+              </div>
+            <?php endif; ?>
+            <div class="md-login-footer-item">
+              <span class="md-login-footer-label"><?= t($t, 'language_label', 'Language') ?></span>
+              <nav class="md-login-footer-value md-login-footer-locale lang-switch" aria-label="<?= htmlspecialchars(t($t, 'language_label', 'Language'), ENT_QUOTES, 'UTF-8') ?>">
+                <?php foreach ($availableLocales as $loc): ?>
+                  <a href="<?= htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars(strtoupper($loc), ENT_QUOTES, 'UTF-8') ?></a>
+                <?php endforeach; ?>
+              </nav>
+            </div>
+          </div>
+        </section>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add explicit fallback theme variables to keep colours and contrasts consistent across pages
- rebuild the login card into a split brand/form layout with improved accessibility and clearer metadata
- refresh supporting components such as SSO buttons, dividers and alerts for better visual polish

## Testing
- php -l login.php

------
https://chatgpt.com/codex/tasks/task_e_68efad6cd004832d81a639116fd07361