### PR TITLE
Improve app bar contrast

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -36,7 +36,7 @@ body.md-bg {
   top: 0;
   z-index: 1000;
   min-height: var(--appbar-height);
-  color: var(--app-text-inverse);
+  color: var(--app-on-primary, #ffffff);
   box-shadow: 0 14px 34px var(--floating-shadow-strong);
 }
 
@@ -188,7 +188,7 @@ body.md-bg {
 .md-lang-switch a.active,
 .md-lang-switch a:hover {
   background: var(--app-on-primary-soft);
-  color: var(--status-success-surface);
+  color: var(--app-on-primary, #ffffff);
 }
 
 .md-shell {


### PR DESCRIPTION
## Summary
- update the top bar text color to use the high-contrast on-primary token for better readability
- ensure active and hovered language switch links keep the same high-contrast color

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68efceef61b0832dbeec57e545894c82