### PR TITLE
Add email notifications and scheduled analytics reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ Performance assessment portal built with PHP and MySQL.
    ```
 8. Visit [http://localhost:8080](http://localhost:8080) and sign in with the seeded administrator credentials.
 
+## Scheduled analytics reports
+
+Administrators can configure recurring analytics emails from the **Analytics → Scheduled analytics reports** card. Once a schedule is active, add the CLI helper to cron so PDFs are generated and emailed on time:
+
+```sh
+php scripts/send_scheduled_reports.php
+```
+
+The command checks for all due schedules, renders the latest analytics snapshot, and emails recipients using the SMTP configuration stored in **Settings → Notifications**. Review the script output (or cron logs) periodically to confirm reports are delivered successfully.
+
 ## LAMP deployment guide
 
 The application runs on a traditional Linux + Apache + MySQL/MariaDB + PHP stack. The steps below assume Ubuntu 22.04 with

--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1,11 +1,146 @@
 <?php
 require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/analytics_report.php';
 auth_required(['admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);
 $locale = ensure_locale();
 $t = load_lang($locale);
 $cfg = get_site_config($pdo);
+
+$reportMessage = '';
+$reportError = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check();
+    $action = $_POST['action'] ?? '';
+    if ($action === 'send-report') {
+        $recipientInput = trim((string)($_POST['report_recipients'] ?? ''));
+        $selectedQuestionnaire = (int)($_POST['report_questionnaire_id'] ?? 0);
+        $includeDetails = !empty($_POST['report_include_details']);
+        $recipients = analytics_report_parse_recipients($recipientInput);
+        if (!$recipients) {
+            $reportError = t($t, 'analytics_report_recipients_required', 'Please provide at least one valid email address.');
+        } else {
+            $targetQuestionnaire = $selectedQuestionnaire > 0 ? $selectedQuestionnaire : null;
+            try {
+                $snapshot = analytics_report_snapshot($pdo, $targetQuestionnaire, $includeDetails);
+                $pdfData = analytics_report_render_pdf($snapshot, $cfg);
+                /** @var DateTimeImmutable $generatedAt */
+                $generatedAt = $snapshot['generated_at'];
+                $filename = analytics_report_filename($snapshot['selected_questionnaire_id'], $generatedAt);
+                $siteName = trim((string)($cfg['site_name'] ?? 'HR Assessment'));
+                $subject = ($siteName !== '' ? $siteName : 'HR Assessment') . ' analytics report - ' . $generatedAt->format('Y-m-d');
+                $bodyLines = [
+                    'Hello,',
+                    '',
+                    'Please find the attached analytics report generated on ' . $generatedAt->format('Y-m-d H:i') . '.',
+                ];
+                if ($includeDetails && !empty($snapshot['selected_questionnaire_title'])) {
+                    $bodyLines[] = 'Questionnaire focus: ' . $snapshot['selected_questionnaire_title'];
+                }
+                $bodyLines[] = '';
+                $bodyLines[] = 'Regards,';
+                $bodyLines[] = $siteName !== '' ? $siteName : 'HR Assessment';
+                $attachments = [[
+                    'filename' => $filename,
+                    'content' => $pdfData,
+                    'content_type' => 'application/pdf',
+                ]];
+                if (send_notification_email($cfg, $recipients, $subject, implode("\n", $bodyLines), $attachments)) {
+                    $reportMessage = t($t, 'analytics_report_sent', 'Analytics report emailed successfully.');
+                } else {
+                    $reportError = t($t, 'analytics_report_send_failed', 'Unable to send the analytics report email.');
+                }
+            } catch (Throwable $e) {
+                error_log('analytics report send failed: ' . $e->getMessage());
+                $reportError = t($t, 'analytics_report_send_failed', 'Unable to send the analytics report email.');
+            }
+        }
+    } elseif ($action === 'create-schedule') {
+        $recipientInput = trim((string)($_POST['schedule_recipients'] ?? ''));
+        $frequency = strtolower(trim((string)($_POST['schedule_frequency'] ?? 'weekly')));
+        if (!in_array($frequency, analytics_report_allowed_frequencies(), true)) {
+            $frequency = 'weekly';
+        }
+        $includeDetails = !empty($_POST['schedule_include_details']);
+        $questionnaireSelection = (int)($_POST['schedule_questionnaire_id'] ?? 0);
+        $recipients = analytics_report_parse_recipients($recipientInput);
+        if (!$recipients) {
+            $reportError = t($t, 'analytics_report_recipients_required', 'Please provide at least one valid email address.');
+        } else {
+            $startInput = trim((string)($_POST['schedule_start_at'] ?? ''));
+            if ($startInput === '') {
+                $startAt = new DateTimeImmutable('now');
+            } else {
+                $startAt = DateTimeImmutable::createFromFormat('Y-m-d\TH:i', $startInput) ?: null;
+            }
+            if (!$startAt) {
+                $reportError = t($t, 'analytics_schedule_start_invalid', 'Please provide a valid start date and time.');
+            } else {
+                $targetQuestionnaire = $questionnaireSelection > 0 ? $questionnaireSelection : null;
+                $recipientsStored = implode(', ', $recipients);
+                $createdBy = $_SESSION['user']['id'] ?? null;
+                try {
+                    $stmt = $pdo->prepare(
+                        'INSERT INTO analytics_report_schedule (recipients, frequency, next_run_at, last_run_at, created_by, questionnaire_id, include_details, active, created_at, updated_at) '
+                        . 'VALUES (?, ?, ?, NULL, ?, ?, ?, 1, NOW(), NOW())'
+                    );
+                    $stmt->execute([
+                        $recipientsStored,
+                        $frequency,
+                        $startAt->format('Y-m-d H:i:s'),
+                        $createdBy,
+                        $targetQuestionnaire,
+                        $includeDetails ? 1 : 0,
+                    ]);
+                    $reportMessage = t($t, 'analytics_schedule_created', 'Report schedule created successfully.');
+                } catch (PDOException $e) {
+                    error_log('analytics schedule create failed: ' . $e->getMessage());
+                    $reportError = t($t, 'analytics_schedule_create_failed', 'Unable to save the schedule. Please try again.');
+                }
+            }
+        }
+    } elseif ($action === 'toggle-schedule') {
+        $scheduleId = (int)($_POST['schedule_id'] ?? 0);
+        if ($scheduleId > 0) {
+            try {
+                $rowStmt = $pdo->prepare('SELECT active FROM analytics_report_schedule WHERE id = ?');
+                $rowStmt->execute([$scheduleId]);
+                $row = $rowStmt->fetch(PDO::FETCH_ASSOC);
+                if ($row) {
+                    $newStatus = ((int)($row['active'] ?? 0) === 1) ? 0 : 1;
+                    $update = $pdo->prepare('UPDATE analytics_report_schedule SET active = ?, updated_at = NOW() WHERE id = ?');
+                    $update->execute([$newStatus, $scheduleId]);
+                    $reportMessage = $newStatus
+                        ? t($t, 'analytics_schedule_enabled', 'Schedule enabled.')
+                        : t($t, 'analytics_schedule_paused', 'Schedule paused.');
+                } else {
+                    $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
+                }
+            } catch (PDOException $e) {
+                error_log('analytics schedule toggle failed: ' . $e->getMessage());
+                $reportError = t($t, 'analytics_schedule_update_failed', 'Unable to update the schedule.');
+            }
+        } else {
+            $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
+        }
+    } elseif ($action === 'delete-schedule') {
+        $scheduleId = (int)($_POST['schedule_id'] ?? 0);
+        if ($scheduleId > 0) {
+            try {
+                $stmt = $pdo->prepare('DELETE FROM analytics_report_schedule WHERE id = ?');
+                $stmt->execute([$scheduleId]);
+                $reportMessage = t($t, 'analytics_schedule_deleted', 'Schedule removed.');
+            } catch (PDOException $e) {
+                error_log('analytics schedule delete failed: ' . $e->getMessage());
+                $reportError = t($t, 'analytics_schedule_update_failed', 'Unable to update the schedule.');
+            }
+        } else {
+            $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
+        }
+    }
+}
 
 $summaryStmt = $pdo->query(
     "SELECT COUNT(*) AS total_responses, "
@@ -332,6 +467,20 @@ if (count($workFunctionChartData) > 12) {
     $workFunctionChartData = array_slice($workFunctionChartData, 0, 12);
 }
 
+try {
+    $scheduleStmt = $pdo->query(
+        'SELECT s.*, q.title AS questionnaire_title, u.full_name AS creator_name '
+        . 'FROM analytics_report_schedule s '
+        . 'LEFT JOIN questionnaire q ON q.id = s.questionnaire_id '
+        . 'LEFT JOIN users u ON u.id = s.created_by '
+        . 'ORDER BY s.next_run_at ASC'
+    );
+    $reportSchedules = $scheduleStmt ? $scheduleStmt->fetchAll(PDO::FETCH_ASSOC) : [];
+} catch (PDOException $e) {
+    error_log('analytics schedule fetch failed: ' . $e->getMessage());
+    $reportSchedules = [];
+}
+
 $chartJsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 if (defined('JSON_THROW_ON_ERROR')) {
     $chartJsonFlags |= JSON_THROW_ON_ERROR;
@@ -402,6 +551,21 @@ $selectedAverage = $selectedAggregate['scored_count'] > 0
       font-size: 1.25rem;
       margin-bottom: 0.35rem;
     }
+    .md-report-grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      margin-bottom: 1rem;
+    }
+    .md-report-grid textarea {
+      min-height: 80px;
+    }
+    .md-schedule-actions {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
     .md-table--interactive tr.is-selected {
       background: rgba(0, 132, 255, 0.08);
     }
@@ -437,6 +601,12 @@ $selectedAverage = $selectedAggregate['scored_count'] > 0
 <body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
 <?php include __DIR__ . '/../templates/header.php'; ?>
 <section class="md-section">
+  <?php if ($reportMessage): ?>
+    <div class="md-alert success"><?=htmlspecialchars($reportMessage, ENT_QUOTES, 'UTF-8')?></div>
+  <?php endif; ?>
+  <?php if ($reportError): ?>
+    <div class="md-alert error"><?=htmlspecialchars($reportError, ENT_QUOTES, 'UTF-8')?></div>
+  <?php endif; ?>
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'analytics_overview', 'Analytics overview')?></h2>
     <div class="md-summary-grid">
@@ -459,6 +629,130 @@ $selectedAverage = $selectedAggregate['scored_count'] > 0
     </div>
     <?php if (!empty($summary['latest_at'])): ?>
       <p class="md-analytics-meta"><?=t($t, 'latest_submission', 'Latest submission:')?> <?=htmlspecialchars($summary['latest_at'], ENT_QUOTES, 'UTF-8')?></p>
+    <?php endif; ?>
+  </div>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'analytics_email_report', 'Email analytics report')?></h2>
+    <form method="post" class="md-form-grid md-report-grid" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>">
+      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <input type="hidden" name="action" value="send-report">
+      <label class="md-field">
+        <span><?=t($t, 'recipients', 'Recipients')?></span>
+        <textarea name="report_recipients" placeholder="name@example.com, other@example.com" required></textarea>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
+        <select name="report_questionnaire_id">
+          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
+          <?php foreach ($questionnaires as $row): ?>
+            <option value="<?=$row['id']?>"><?=htmlspecialchars($row['title'] ?? t($t, 'questionnaire', 'Questionnaire'), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-checkbox">
+        <input type="checkbox" name="report_include_details" value="1">
+        <span><?=t($t, 'include_detailed_breakdown', 'Include detailed questionnaire breakdown')?></span>
+      </label>
+      <div class="md-inline-actions">
+        <button class="md-button md-primary" type="submit"><?=t($t, 'send_report_now', 'Send report')?></button>
+      </div>
+    </form>
+  </div>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'analytics_schedules', 'Scheduled analytics reports')?></h2>
+    <form method="post" class="md-form-grid md-report-grid" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>">
+      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <input type="hidden" name="action" value="create-schedule">
+      <label class="md-field">
+        <span><?=t($t, 'recipients', 'Recipients')?></span>
+        <textarea name="schedule_recipients" placeholder="name@example.com, other@example.com" required></textarea>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'frequency', 'Frequency')?></span>
+        <select name="schedule_frequency">
+          <?php foreach (analytics_report_allowed_frequencies() as $freq): ?>
+            <option value="<?=$freq?>"><?=htmlspecialchars(t($t, 'frequency_' . $freq, analytics_report_frequency_label($freq)), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'start_time', 'First delivery (local time)')?></span>
+        <input type="datetime-local" name="schedule_start_at">
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
+        <select name="schedule_questionnaire_id">
+          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
+          <?php foreach ($questionnaires as $row): ?>
+            <option value="<?=$row['id']?>"><?=htmlspecialchars($row['title'] ?? t($t, 'questionnaire', 'Questionnaire'), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-checkbox">
+        <input type="checkbox" name="schedule_include_details" value="1">
+        <span><?=t($t, 'include_detailed_breakdown', 'Include detailed questionnaire breakdown')?></span>
+      </label>
+      <div class="md-inline-actions">
+        <button class="md-button md-primary" type="submit"><?=t($t, 'create_schedule', 'Create schedule')?></button>
+      </div>
+    </form>
+
+    <?php if ($reportSchedules): ?>
+      <div class="md-table-responsive">
+        <table class="md-table">
+          <thead>
+            <tr>
+              <th><?=t($t, 'recipients', 'Recipients')?></th>
+              <th><?=t($t, 'frequency', 'Frequency')?></th>
+              <th><?=t($t, 'questionnaire', 'Questionnaire')?></th>
+              <th><?=t($t, 'include_detailed_breakdown', 'Detailed breakdown?')?></th>
+              <th><?=t($t, 'next_run', 'Next send')?></th>
+              <th><?=t($t, 'last_run', 'Last sent')?></th>
+              <th><?=t($t, 'status', 'Status')?></th>
+              <th><?=t($t, 'action', 'Action')?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($reportSchedules as $schedule): ?>
+              <?php
+                $isActive = (int)($schedule['active'] ?? 0) === 1;
+                $frequencyKey = (string)($schedule['frequency'] ?? '');
+                $frequencyLabel = t($t, 'frequency_' . $frequencyKey, analytics_report_frequency_label($frequencyKey));
+                $questionnaireLabel = $schedule['questionnaire_id'] ? ($schedule['questionnaire_title'] ?? t($t, 'questionnaire', 'Questionnaire')) : t($t, 'all_questionnaires', 'All questionnaires');
+              ?>
+              <tr>
+                <td><?=htmlspecialchars($schedule['recipients'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($frequencyLabel, ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($questionnaireLabel, ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=!empty($schedule['include_details']) ? t($t, 'yes', 'Yes') : t($t, 'no', 'No')?></td>
+                <td><?=htmlspecialchars($schedule['next_run_at'] ?? '-', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($schedule['last_run_at'] ?? '-', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?= $isActive ? t($t, 'status_active', 'Active') : t($t, 'status_disabled', 'Disabled') ?></td>
+                <td>
+                  <div class="md-schedule-actions">
+                    <form method="post" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-inline-form">
+                      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+                      <input type="hidden" name="action" value="toggle-schedule">
+                      <input type="hidden" name="schedule_id" value="<?= (int)$schedule['id'] ?>">
+                      <button class="md-button" type="submit"><?= $isActive ? t($t, 'pause', 'Pause') : t($t, 'resume', 'Resume') ?></button>
+                    </form>
+                    <form method="post" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-inline-form" onsubmit="return confirm('<?=htmlspecialchars(t($t, 'confirm_delete_schedule', 'Remove this schedule?'), ENT_QUOTES, 'UTF-8')?>');">
+                      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+                      <input type="hidden" name="action" value="delete-schedule">
+                      <input type="hidden" name="schedule_id" value="<?= (int)$schedule['id'] ?>">
+                      <button class="md-button md-danger" type="submit"><?=t($t, 'delete', 'Delete')?></button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php else: ?>
+      <p class="md-upgrade-meta"><?=t($t, 'no_schedules_configured', 'No report schedules have been configured yet.')?></p>
     <?php endif; ?>
   </div>
 

--- a/init.sql
+++ b/init.sql
@@ -197,6 +197,24 @@ CREATE TABLE questionnaire_assignment (
   CONSTRAINT fk_assignment_supervisor FOREIGN KEY (assigned_by) REFERENCES users(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE analytics_report_schedule (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  recipients TEXT NOT NULL,
+  frequency ENUM('daily','weekly','monthly') NOT NULL DEFAULT 'weekly',
+  next_run_at DATETIME NOT NULL,
+  last_run_at DATETIME NULL,
+  created_by INT NULL,
+  questionnaire_id INT NULL,
+  include_details TINYINT(1) NOT NULL DEFAULT 0,
+  active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_report_schedule_next_run (next_run_at),
+  KEY idx_report_schedule_active (active),
+  CONSTRAINT fk_report_schedule_creator FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,
+  CONSTRAINT fk_report_schedule_questionnaire FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 INSERT INTO site_config (
   id,
   site_name,

--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/simple_pdf.php';
+
+function analytics_report_allowed_frequencies(): array
+{
+    return ['daily', 'weekly', 'monthly'];
+}
+
+function analytics_report_frequency_label(string $frequency): string
+{
+    return match ($frequency) {
+        'daily' => 'Daily',
+        'weekly' => 'Weekly',
+        'monthly' => 'Monthly',
+        default => ucfirst($frequency),
+    };
+}
+
+function analytics_report_parse_recipients(string $input): array
+{
+    $pieces = preg_split('/[\s,;]+/', trim($input));
+    $emails = [];
+    foreach ($pieces as $piece) {
+        if ($piece === '') {
+            continue;
+        }
+        $candidate = filter_var($piece, FILTER_VALIDATE_EMAIL);
+        if ($candidate) {
+            $emails[strtolower($candidate)] = $candidate;
+        }
+    }
+    return array_values($emails);
+}
+
+function analytics_report_snapshot(PDO $pdo, ?int $questionnaireId = null, bool $includeDetails = false): array
+{
+    $summaryRow = $pdo->query(
+        "SELECT COUNT(*) AS total_responses, "
+        . "SUM(status='approved') AS approved_count, "
+        . "SUM(status='submitted') AS submitted_count, "
+        . "SUM(status='draft') AS draft_count, "
+        . "SUM(status='rejected') AS rejected_count, "
+        . "AVG(score) AS avg_score, "
+        . "MAX(created_at) AS latest_at "
+        . "FROM questionnaire_response"
+    );
+    $summary = [
+        'total_responses' => 0,
+        'approved_count' => 0,
+        'submitted_count' => 0,
+        'draft_count' => 0,
+        'rejected_count' => 0,
+        'avg_score' => null,
+        'latest_at' => null,
+    ];
+    if ($summaryRow) {
+        $row = $summaryRow->fetch(PDO::FETCH_ASSOC) ?: [];
+        $summary['total_responses'] = (int)($row['total_responses'] ?? 0);
+        $summary['approved_count'] = (int)($row['approved_count'] ?? 0);
+        $summary['submitted_count'] = (int)($row['submitted_count'] ?? 0);
+        $summary['draft_count'] = (int)($row['draft_count'] ?? 0);
+        $summary['rejected_count'] = (int)($row['rejected_count'] ?? 0);
+        $summary['avg_score'] = isset($row['avg_score']) ? (float)$row['avg_score'] : null;
+        $summary['latest_at'] = $row['latest_at'] ?? null;
+    }
+
+    $totalParticipants = (int)($pdo->query('SELECT COUNT(DISTINCT user_id) FROM questionnaire_response')->fetchColumn() ?: 0);
+
+    $questionnaireStmt = $pdo->query(
+        "SELECT q.id, q.title, COUNT(*) AS total_responses, "
+        . "SUM(qr.status='approved') AS approved_count, "
+        . "SUM(qr.status='submitted') AS submitted_count, "
+        . "SUM(qr.status='draft') AS draft_count, "
+        . "SUM(qr.status='rejected') AS rejected_count, "
+        . "AVG(qr.score) AS avg_score "
+        . "FROM questionnaire_response qr "
+        . "JOIN questionnaire q ON q.id = qr.questionnaire_id "
+        . "GROUP BY q.id, q.title "
+        . "ORDER BY q.title"
+    );
+    $questionnaires = [];
+    $availableIds = [];
+    if ($questionnaireStmt) {
+        foreach ($questionnaireStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $id = (int)($row['id'] ?? 0);
+            $availableIds[] = $id;
+            $questionnaires[] = [
+                'id' => $id,
+                'title' => (string)($row['title'] ?? ''),
+                'total_responses' => (int)($row['total_responses'] ?? 0),
+                'approved_count' => (int)($row['approved_count'] ?? 0),
+                'submitted_count' => (int)($row['submitted_count'] ?? 0),
+                'draft_count' => (int)($row['draft_count'] ?? 0),
+                'rejected_count' => (int)($row['rejected_count'] ?? 0),
+                'avg_score' => isset($row['avg_score']) ? (float)$row['avg_score'] : null,
+            ];
+        }
+    }
+
+    $selectedId = null;
+    if ($questionnaireId && in_array($questionnaireId, $availableIds, true)) {
+        $selectedId = $questionnaireId;
+    } elseif ($availableIds) {
+        $selectedId = $availableIds[0];
+    }
+
+    $selectedTitle = '';
+    foreach ($questionnaires as $qRow) {
+        if ($qRow['id'] === $selectedId) {
+            $selectedTitle = (string)$qRow['title'];
+            break;
+        }
+    }
+
+    $userBreakdown = [];
+    if ($includeDetails && $selectedId) {
+        $userStmt = $pdo->prepare(
+            'SELECT u.username, u.full_name, u.work_function, '
+            . 'COUNT(*) AS total_responses, '
+            . 'SUM(qr.status="approved") AS approved_count, '
+            . 'AVG(qr.score) AS avg_score '
+            . 'FROM questionnaire_response qr '
+            . 'JOIN users u ON u.id = qr.user_id '
+            . 'WHERE qr.questionnaire_id = ? '
+            . 'GROUP BY u.id, u.username, u.full_name, u.work_function '
+            . 'ORDER BY (avg_score IS NULL), avg_score DESC, total_responses DESC '
+            . 'LIMIT 15'
+        );
+        if ($userStmt) {
+            $userStmt->execute([$selectedId]);
+            $userBreakdown = $userStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+        }
+    }
+
+    return [
+        'summary' => $summary,
+        'total_participants' => $totalParticipants,
+        'questionnaires' => $questionnaires,
+        'selected_questionnaire_id' => $selectedId,
+        'selected_questionnaire_title' => $selectedTitle,
+        'user_breakdown' => $userBreakdown,
+        'include_details' => $includeDetails,
+        'generated_at' => new DateTimeImmutable('now'),
+    ];
+}
+
+function analytics_report_render_pdf(array $snapshot, array $cfg): string
+{
+    $pdf = new SimplePdfDocument();
+    $siteName = trim((string)($cfg['site_name'] ?? ''));
+    $title = ($siteName !== '' ? $siteName : 'HR Assessment') . ' Analytics Report';
+    $pdf->addHeading($title);
+
+    /** @var DateTimeImmutable $generatedAt */
+    $generatedAt = $snapshot['generated_at'];
+    $pdf->addParagraph('Generated on ' . $generatedAt->format('Y-m-d H:i'));
+
+    $summary = $snapshot['summary'];
+    $summaryRows = [
+        ['Total responses', analytics_report_format_number($summary['total_responses'] ?? 0)],
+        ['Approved', analytics_report_format_number($summary['approved_count'] ?? 0)],
+        ['Submitted', analytics_report_format_number($summary['submitted_count'] ?? 0)],
+        ['Draft', analytics_report_format_number($summary['draft_count'] ?? 0)],
+        ['Rejected', analytics_report_format_number($summary['rejected_count'] ?? 0)],
+        ['Average score', analytics_report_format_score($summary['avg_score'])],
+        ['Latest submission', analytics_report_format_date($summary['latest_at'])],
+        ['Unique participants', analytics_report_format_number($snapshot['total_participants'] ?? 0)],
+    ];
+
+    $pdf->addSubheading('Overall summary');
+    $pdf->addTable(['Metric', 'Value'], $summaryRows, [32, 18]);
+
+    $pdf->addSubheading('Questionnaire performance');
+    $questionnaireRows = [];
+    foreach ($snapshot['questionnaires'] as $row) {
+        $questionnaireRows[] = [
+            (string)($row['title'] ?? 'Questionnaire'),
+            analytics_report_format_number($row['total_responses'] ?? 0),
+            analytics_report_format_number($row['approved_count'] ?? 0),
+            analytics_report_format_number($row['submitted_count'] ?? 0),
+            analytics_report_format_number($row['draft_count'] ?? 0),
+            analytics_report_format_number($row['rejected_count'] ?? 0),
+            analytics_report_format_score($row['avg_score'] ?? null),
+        ];
+    }
+
+    if ($questionnaireRows) {
+        $pdf->addTable(
+            ['Questionnaire', 'Total', 'Approved', 'Submitted', 'Draft', 'Rejected', 'Avg'],
+            $questionnaireRows,
+            [40, 7, 9, 10, 8, 9, 7]
+        );
+    } else {
+        $pdf->addParagraph('No questionnaire responses have been recorded yet.');
+    }
+
+    if (!empty($snapshot['include_details']) && !empty($snapshot['user_breakdown'])) {
+        $selectedTitle = trim((string)($snapshot['selected_questionnaire_title'] ?? ''));
+        $pdf->addSubheading('Top contributors' . ($selectedTitle !== '' ? ': ' . $selectedTitle : ''));
+        $detailRows = [];
+        foreach ($snapshot['user_breakdown'] as $row) {
+            $display = trim((string)($row['full_name'] ?? ''));
+            if ($display === '') {
+                $display = (string)($row['username'] ?? 'User');
+            }
+            $detailRows[] = [
+                $display,
+                (string)($row['work_function'] ?? ''),
+                analytics_report_format_number($row['total_responses'] ?? 0),
+                analytics_report_format_number($row['approved_count'] ?? 0),
+                analytics_report_format_score($row['avg_score'] ?? null),
+            ];
+        }
+        $pdf->addTable(
+            ['User', 'Work function', 'Responses', 'Approved', 'Avg score'],
+            $detailRows,
+            [28, 18, 12, 10, 10]
+        );
+    }
+
+    return $pdf->output();
+}
+
+function analytics_report_format_number($value): string
+{
+    $number = (int)$value;
+    return number_format($number);
+}
+
+function analytics_report_format_score($value): string
+{
+    if ($value === null) {
+        return '-';
+    }
+    $float = (float)$value;
+    return number_format($float, 2);
+}
+
+function analytics_report_format_date($value): string
+{
+    if (!$value) {
+        return '-';
+    }
+    try {
+        $dt = new DateTimeImmutable((string)$value);
+        return $dt->format('Y-m-d H:i');
+    } catch (Throwable $e) {
+        return (string)$value;
+    }
+}
+
+function analytics_report_filename(?int $questionnaireId, DateTimeInterface $generatedAt): string
+{
+    $suffix = $questionnaireId ? '-q' . $questionnaireId : '';
+    return 'analytics-report' . $suffix . '-' . $generatedAt->format('Ymd_His') . '.pdf';
+}
+
+function analytics_report_next_run(string $frequency, DateTimeImmutable $from): DateTimeImmutable
+{
+    return match ($frequency) {
+        'daily' => $from->add(new DateInterval('P1D')),
+        'monthly' => $from->add(new DateInterval('P1M')),
+        default => $from->add(new DateInterval('P7D')),
+    };
+}

--- a/lib/simple_pdf.php
+++ b/lib/simple_pdf.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+class SimplePdfDocument
+{
+    private float $width = 595.28; // A4 width in points
+    private float $height = 841.89; // A4 height in points
+    private float $marginLeft = 50.0;
+    private float $marginRight = 50.0;
+    private float $marginTop = 50.0;
+    private float $marginBottom = 60.0;
+    private float $cursorY;
+    private array $pages = [];
+    private array $currentOps = [];
+    private bool $pageOpen = false;
+
+    public function __construct()
+    {
+        $this->startNewPage();
+    }
+
+    public function addHeading(string $text): void
+    {
+        $this->addTextBlock($text, 18.0, 'F2', 1.5);
+        $this->addSpacer(6.0);
+    }
+
+    public function addSubheading(string $text): void
+    {
+        $this->addTextBlock($text, 14.0, 'F2', 1.4);
+        $this->addSpacer(4.0);
+    }
+
+    public function addParagraph(string $text, float $fontSize = 11.0): void
+    {
+        $this->addTextBlock($text, $fontSize, 'F1', 1.35);
+        $this->addSpacer(4.0);
+    }
+
+    public function addBulletList(array $lines, float $fontSize = 11.0): void
+    {
+        foreach ($lines as $line) {
+            $this->addTextBlock('• ' . $line, $fontSize, 'F1', 1.35, false);
+        }
+        $this->addSpacer(4.0);
+    }
+
+    public function addSpacer(float $points): void
+    {
+        $this->cursorY -= $points;
+        if ($this->cursorY <= $this->marginBottom) {
+            $this->startNewPage();
+        }
+    }
+
+    public function addTable(array $headers, array $rows, array $columnWidths, float $fontSize = 10.0): void
+    {
+        $this->ensurePage();
+        $lineHeight = $this->lineHeight($fontSize, 1.35);
+        $formattedHeader = $this->formatTableRow($headers, $columnWidths);
+        $this->writeMonospaceLine($formattedHeader, $fontSize);
+        $this->cursorY -= $lineHeight;
+        $this->ensureSpace($lineHeight);
+        $separator = $this->formatTableSeparator($columnWidths);
+        $this->writeMonospaceLine($separator, $fontSize);
+        $this->cursorY -= $lineHeight;
+        foreach ($rows as $row) {
+            $this->ensureSpace($lineHeight);
+            $this->writeMonospaceLine($this->formatTableRow($row, $columnWidths), $fontSize);
+            $this->cursorY -= $lineHeight;
+        }
+        $this->addSpacer(6.0);
+    }
+
+    public function output(): string
+    {
+        if ($this->pageOpen) {
+            $this->pages[] = $this->currentOps;
+            $this->currentOps = [];
+            $this->pageOpen = false;
+        }
+
+        if (!$this->pages) {
+            $this->startNewPage();
+            $this->pages[] = $this->currentOps;
+            $this->currentOps = [];
+            $this->pageOpen = false;
+        }
+
+        $objects = [];
+        $pageReferences = [];
+        $objectIndex = 6; // reserve 1-5 for catalog, pages, fonts
+
+        foreach ($this->pages as $ops) {
+            $content = implode("\n", $ops) . "\n";
+            $contentObjNum = $objectIndex++;
+            $objects[$contentObjNum] = '<< /Length ' . strlen($content) . " >>\nstream\n" . $content . "endstream";
+            $pageObjNum = $objectIndex++;
+            $pageReferences[] = $pageObjNum;
+            $pageObject = '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ' . $this->formatFloat($this->width) . ' ' . $this->formatFloat($this->height) . '] '
+                . '/Resources << /Font << /F1 3 0 R /F2 4 0 R /F3 5 0 R >> >> '
+                . '/Contents ' . $contentObjNum . ' 0 R >>';
+            $objects[$pageObjNum] = $pageObject;
+        }
+
+        $pagesObject = '<< /Type /Pages /Kids [';
+        foreach ($pageReferences as $ref) {
+            $pagesObject .= ' ' . $ref . ' 0 R';
+        }
+        $pagesObject .= ' ] /Count ' . count($pageReferences) . ' >>';
+
+        $objects[1] = '<< /Type /Catalog /Pages 2 0 R >>';
+        $objects[2] = $pagesObject;
+        $objects[3] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+        $objects[4] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >>';
+        $objects[5] = '<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>';
+
+        ksort($objects);
+
+        $output = "%PDF-1.4\n";
+        $offsets = [0 => 0];
+        foreach ($objects as $num => $content) {
+            $offsets[$num] = strlen($output);
+            $output .= $num . " 0 obj\n" . $content . "\nendobj\n";
+        }
+
+        $xrefPosition = strlen($output);
+        $maxObject = max(array_keys($objects));
+        $output .= 'xref\n0 ' . ($maxObject + 1) . "\n";
+        $output .= "0000000000 65535 f \n";
+        for ($i = 1; $i <= $maxObject; $i++) {
+            $offset = $offsets[$i] ?? 0;
+            $output .= sprintf("%010d 00000 n \n", $offset);
+        }
+
+        $output .= 'trailer << /Size ' . ($maxObject + 1) . ' /Root 1 0 R >>' . "\n";
+        $output .= 'startxref' . "\n" . $xrefPosition . "\n%%EOF";
+
+        return $output;
+    }
+
+    private function addTextBlock(string $text, float $fontSize, string $fontKey, float $lineSpacing, bool $addSpacer = true): void
+    {
+        $this->ensurePage();
+        $lines = $this->wrapText($text, $fontSize);
+        $lineHeight = $this->lineHeight($fontSize, $lineSpacing);
+        foreach ($lines as $line) {
+            $this->ensureSpace($lineHeight);
+            $this->writeTextLine($line, $fontKey, $fontSize);
+            $this->cursorY -= $lineHeight;
+        }
+        if ($addSpacer) {
+            $this->cursorY -= 2.0;
+        }
+    }
+
+    private function ensurePage(): void
+    {
+        if (!$this->pageOpen) {
+            $this->startNewPage();
+        }
+    }
+
+    private function startNewPage(): void
+    {
+        if ($this->pageOpen) {
+            $this->pages[] = $this->currentOps;
+        }
+        $this->currentOps = [];
+        $this->cursorY = $this->height - $this->marginTop;
+        $this->pageOpen = true;
+    }
+
+    private function ensureSpace(float $lineHeight): void
+    {
+        if ($this->cursorY - $lineHeight <= $this->marginBottom) {
+            $this->startNewPage();
+        }
+    }
+
+    private function writeTextLine(string $text, string $fontKey, float $fontSize): void
+    {
+        $escaped = $this->escapeText($text);
+        $x = $this->marginLeft;
+        $y = $this->cursorY;
+        $this->currentOps[] = sprintf('BT /%s %.2f Tf 1 0 0 1 %.2f %.2f Tm (%s) Tj ET', $fontKey, $fontSize, $x, $y, $escaped);
+    }
+
+    private function writeMonospaceLine(string $text, float $fontSize): void
+    {
+        $escaped = $this->escapeText($text);
+        $x = $this->marginLeft;
+        $y = $this->cursorY;
+        $this->currentOps[] = sprintf('BT /F3 %.2f Tf 1 0 0 1 %.2f %.2f Tm (%s) Tj ET', $fontSize, $x, $y, $escaped);
+    }
+
+    private function wrapText(string $text, float $fontSize): array
+    {
+        $normalized = preg_replace("/\s+/u", ' ', trim($text));
+        if ($normalized === '') {
+            return [''];
+        }
+        $availableWidth = $this->width - $this->marginLeft - $this->marginRight;
+        $avgCharWidth = max(0.1, $fontSize * 0.55);
+        $maxChars = max(10, (int)floor($availableWidth / $avgCharWidth));
+        $wrapped = wordwrap($normalized, $maxChars, "\n", true);
+        return explode("\n", $wrapped);
+    }
+
+    private function lineHeight(float $fontSize, float $multiplier): float
+    {
+        return $fontSize * $multiplier;
+    }
+
+    private function escapeText(string $text): string
+    {
+        $text = str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text);
+        return preg_replace("/[\r\n]+/", ' ', $text);
+    }
+
+    private function formatTableRow(array $row, array $columnWidths): string
+    {
+        $cells = [];
+        $count = min(count($row), count($columnWidths));
+        for ($i = 0; $i < $count; $i++) {
+            $cell = (string)$row[$i];
+            $width = max(1, (int)$columnWidths[$i]);
+            $cell = mb_strimwidth($cell, 0, $width, '', 'UTF-8');
+            $cells[] = str_pad($cell, $width);
+        }
+        return implode('  ', $cells);
+    }
+
+    private function formatTableSeparator(array $columnWidths): string
+    {
+        $parts = [];
+        foreach ($columnWidths as $width) {
+            $parts[] = str_repeat('-', max(1, (int)$width));
+        }
+        return implode('  ', $parts);
+    }
+
+    private function formatFloat(float $value): string
+    {
+        return number_format($value, 2, '.', '');
+    }
+}

--- a/scripts/check_database_integrity.php
+++ b/scripts/check_database_integrity.php
@@ -233,6 +233,19 @@ $expectedSchemas = [
         'assigned_by' => ['type' => 'int', 'null' => 'YES'],
         'assigned_at' => ['type' => 'datetime', 'null' => 'NO'],
     ],
+    'analytics_report_schedule' => [
+        'id' => ['type' => 'int', 'null' => 'NO', 'key' => 'PRI', 'extra' => 'auto_increment'],
+        'recipients' => ['type' => 'text', 'null' => 'NO'],
+        'frequency' => ['type' => "enum('daily','weekly','monthly')", 'null' => 'NO'],
+        'next_run_at' => ['type' => 'datetime', 'null' => 'NO'],
+        'last_run_at' => ['type' => 'datetime', 'null' => 'YES'],
+        'created_by' => ['type' => 'int', 'null' => 'YES'],
+        'questionnaire_id' => ['type' => 'int', 'null' => 'YES'],
+        'include_details' => ['type' => 'tinyint', 'null' => 'NO'],
+        'active' => ['type' => 'tinyint', 'null' => 'NO'],
+        'created_at' => ['type' => 'datetime', 'null' => 'NO'],
+        'updated_at' => ['type' => 'datetime', 'null' => 'NO'],
+    ],
 ];
 
 $issues = [];

--- a/scripts/send_scheduled_reports.php
+++ b/scripts/send_scheduled_reports.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    echo "This utility must be run from the command line.\n";
+    exit(1);
+}
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/analytics_report.php';
+
+$cfg = get_site_config($pdo);
+$now = new DateTimeImmutable('now');
+
+try {
+    $stmt = $pdo->prepare('SELECT * FROM analytics_report_schedule WHERE active = 1 AND next_run_at <= ? ORDER BY next_run_at ASC');
+    $stmt->execute([$now->format('Y-m-d H:i:s')]);
+    $schedules = $stmt->fetchAll(PDO::FETCH_ASSOC);
+} catch (PDOException $e) {
+    fwrite(STDERR, 'Unable to fetch scheduled reports: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+if (!$schedules) {
+    fwrite(STDOUT, "No scheduled reports due at this time.\n");
+    exit(0);
+}
+
+foreach ($schedules as $schedule) {
+    $scheduleId = (int)($schedule['id'] ?? 0);
+    $recipients = analytics_report_parse_recipients((string)($schedule['recipients'] ?? ''));
+    $frequency = (string)($schedule['frequency'] ?? 'weekly');
+    $includeDetails = !empty($schedule['include_details']);
+    $questionnaireId = isset($schedule['questionnaire_id']) ? (int)$schedule['questionnaire_id'] : null;
+    $nextRunSource = isset($schedule['next_run_at']) ? DateTimeImmutable::createFromFormat('Y-m-d H:i:s', (string)$schedule['next_run_at']) : false;
+    $nextRunBase = $nextRunSource instanceof DateTimeImmutable ? $nextRunSource : $now;
+    $nextRun = analytics_report_next_run($frequency, $nextRunBase);
+    while ($nextRun <= $now) {
+        $nextRun = analytics_report_next_run($frequency, $nextRun);
+    }
+
+    if (!$recipients) {
+        fwrite(STDERR, sprintf("Schedule %d skipped (no valid recipients).\n", $scheduleId));
+        $update = $pdo->prepare('UPDATE analytics_report_schedule SET next_run_at = ?, updated_at = NOW() WHERE id = ?');
+        $update->execute([$nextRun->format('Y-m-d H:i:s'), $scheduleId]);
+        continue;
+    }
+
+    try {
+        $snapshot = analytics_report_snapshot($pdo, $questionnaireId ?: null, $includeDetails);
+        $pdfData = analytics_report_render_pdf($snapshot, $cfg);
+        /** @var DateTimeImmutable $generatedAt */
+        $generatedAt = $snapshot['generated_at'];
+        $filename = analytics_report_filename($snapshot['selected_questionnaire_id'], $generatedAt);
+        $siteName = trim((string)($cfg['site_name'] ?? 'HR Assessment'));
+        $subject = ($siteName !== '' ? $siteName : 'HR Assessment') . ' analytics report - ' . $generatedAt->format('Y-m-d');
+        $bodyLines = [
+            'Hello,',
+            '',
+            'Attached is the scheduled analytics report generated on ' . $generatedAt->format('Y-m-d H:i') . '.',
+        ];
+        if ($includeDetails && !empty($snapshot['selected_questionnaire_title'])) {
+            $bodyLines[] = 'Questionnaire focus: ' . $snapshot['selected_questionnaire_title'];
+        }
+        $bodyLines[] = '';
+        $bodyLines[] = 'Regards,';
+        $bodyLines[] = $siteName !== '' ? $siteName : 'HR Assessment';
+        $attachments = [[
+            'filename' => $filename,
+            'content' => $pdfData,
+            'content_type' => 'application/pdf',
+        ]];
+
+        $sent = send_notification_email($cfg, $recipients, $subject, implode("\n", $bodyLines), $attachments);
+        if ($sent) {
+            $update = $pdo->prepare('UPDATE analytics_report_schedule SET last_run_at = ?, next_run_at = ?, updated_at = NOW() WHERE id = ?');
+            $update->execute([$now->format('Y-m-d H:i:s'), $nextRun->format('Y-m-d H:i:s'), $scheduleId]);
+            fwrite(STDOUT, sprintf("Schedule %d sent to %s.\n", $scheduleId, implode(', ', $recipients)));
+        } else {
+            fwrite(STDERR, sprintf("Failed to send schedule %d.\n", $scheduleId));
+            $update = $pdo->prepare('UPDATE analytics_report_schedule SET next_run_at = ?, updated_at = NOW() WHERE id = ?');
+            $update->execute([$nextRun->format('Y-m-d H:i:s'), $scheduleId]);
+        }
+    } catch (Throwable $e) {
+        fwrite(STDERR, sprintf("Error processing schedule %d: %s\n", $scheduleId, $e->getMessage()));
+        $update = $pdo->prepare('UPDATE analytics_report_schedule SET next_run_at = ?, updated_at = NOW() WHERE id = ?');
+        $update->execute([$nextRun->format('Y-m-d H:i:s'), $scheduleId]);
+    }
+}
+
+exit(0);


### PR DESCRIPTION
## Summary
- send questionnaire assignment emails to staff and supervisors when assignments change
- notify staff when next assessment dates are set through the admin interface
- add analytics report emailing and scheduling with PDF generation, CLI sender, and supporting schema updates

## Testing
- php -l admin/analytics.php
- php -l admin/questionnaire_assignments.php
- php -l admin/users.php
- php -l config.php
- php -l lib/mailer.php
- php -l lib/notifications.php
- php -l lib/analytics_report.php
- php -l lib/simple_pdf.php
- php -l scripts/send_scheduled_reports.php

------
https://chatgpt.com/codex/tasks/task_e_68efd09fab88832da90a7a5d0da9b1f9