### PR TITLE
Refactor questionnaire manager layout

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -688,33 +688,44 @@ if (isset($_POST['import'])) {
   <?php if ($msg): ?>
     <div class="md-alert"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div>
   <?php endif; ?>
-  <div class="md-card md-elev-2">
-    <h2 class="md-card-title"><?=t($t,'fhir_import','FHIR Import')?></h2>
-    <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
-      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-      <label class="md-field"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
-      <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
-    </form>
-    <div class="qb-import-actions">
-      <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
-        <?=t($t,'download_xml_template','Download XML template')?>
-      </a>
-      <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
-        <?=t($t,'download_import_guide','Download Import Guide')?>
-      </a>
+  <div class="qb-manager-layout">
+    <div class="qb-manager-main">
+      <div class="md-card md-elev-2 qb-builder-card">
+        <div class="qb-toolbar">
+          <button class="md-button md-primary md-elev-2" id="qb-add-questionnaire"><?=t($t,'add_questionnaire','Add Questionnaire')?></button>
+          <div class="qb-toolbar-spacer"></div>
+          <button class="md-button md-elev-2" id="qb-save" disabled><?=t($t,'save','Save Changes')?></button>
+          <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
+        </div>
+        <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
+        <div id="qb-list" class="qb-list" aria-live="polite"></div>
+      </div>
     </div>
-  </div>
-
-  <div class="md-card md-elev-2">
-    <div class="qb-toolbar">
-      <button class="md-button md-primary md-elev-2" id="qb-add-questionnaire"><?=t($t,'add_questionnaire','Add Questionnaire')?></button>
-      <div class="qb-toolbar-spacer"></div>
-      <button class="md-button md-elev-2" id="qb-save" disabled><?=t($t,'save','Save Changes')?></button>
-      <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
-    </div>
-    <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
-    <div id="qb-tabs" class="qb-tabs" role="tablist" aria-label="<?=htmlspecialchars(t($t,'questionnaire_tabs','Questionnaire navigation'), ENT_QUOTES, 'UTF-8')?>"></div>
-    <div id="qb-list" class="qb-list" aria-live="polite"></div>
+    <aside class="qb-manager-sidebar" aria-label="<?=htmlspecialchars(t($t,'questionnaire_side_menu','Questionnaire side menu'), ENT_QUOTES, 'UTF-8')?>">
+      <div class="md-card md-elev-2 qb-sidebar-card">
+        <h3 class="md-card-title"><?=t($t,'questionnaire_navigation','Questionnaire Navigation')?></h3>
+        <div id="qb-tabs" class="qb-tabs qb-tabs-vertical" role="tablist" aria-label="<?=htmlspecialchars(t($t,'questionnaire_tabs','Questionnaire navigation'), ENT_QUOTES, 'UTF-8')?>"></div>
+        <nav id="qb-section-nav" class="qb-section-nav" aria-label="<?=htmlspecialchars(t($t,'section_navigation','Section navigation'), ENT_QUOTES, 'UTF-8')?>" data-empty-label="<?=htmlspecialchars(t($t,'select_questionnaire_to_view_sections','Select a questionnaire to view its sections'), ENT_QUOTES, 'UTF-8')?>" data-root-label="<?=htmlspecialchars(t($t,'items_without_section','Items without a section'), ENT_QUOTES, 'UTF-8')?>" data-untitled-label="<?=htmlspecialchars(t($t,'untitled_questionnaire','Untitled questionnaire'), ENT_QUOTES, 'UTF-8')?>">
+          <p class="qb-section-nav-empty"><?=t($t,'select_questionnaire_to_view_sections','Select a questionnaire to view its sections')?></p>
+        </nav>
+      </div>
+      <div class="md-card md-elev-2 qb-sidebar-card">
+        <h3 class="md-card-title"><?=t($t,'fhir_import','FHIR Import')?></h3>
+        <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
+          <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+          <label class="md-field"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
+          <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
+        </form>
+        <div class="qb-import-actions">
+          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
+            <?=t($t,'download_xml_template','Download XML template')?>
+          </a>
+          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
+            <?=t($t,'download_import_guide','Download Import Guide')?>
+          </a>
+        </div>
+      </div>
+    </aside>
   </div>
 </section>
 <?php if ($recentImportId): ?>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -5,6 +5,127 @@
   align-items: center;
 }
 
+.qb-builder-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.qb-manager-layout {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.qb-manager-main {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.qb-manager-sidebar {
+  width: min(320px, 100%);
+  flex: 0 0 320px;
+  max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.qb-sidebar-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.qb-tabs-vertical {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.qb-tabs-vertical .qb-tab {
+  width: 100%;
+  text-align: left;
+  justify-content: flex-start;
+  display: flex;
+  align-items: center;
+}
+
+.qb-section-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.qb-section-nav-empty {
+  font-size: 0.9rem;
+  color: var(--app-muted, rgba(0, 0, 0, 0.6));
+}
+
+.qb-section-nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.qb-section-nav-summary {
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.qb-section-nav-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.qb-section-nav-button {
+  width: 100%;
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: var(--app-primary-soft);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border 0.2s ease;
+  font: inherit;
+}
+
+.qb-section-nav-button:hover,
+.qb-section-nav-button:focus-visible {
+  background: var(--app-primary);
+  color: var(--md-on-primary);
+  border-color: var(--app-primary);
+  outline: none;
+}
+
+.qb-section-nav-count {
+  font-size: 0.8rem;
+  color: var(--app-muted, rgba(0, 0, 0, 0.6));
+}
+
+.qb-section-highlight {
+  outline: 2px solid var(--app-secondary, var(--app-primary));
+  outline-offset: 2px;
+}
+
+@media (max-width: 960px) {
+  .qb-manager-layout {
+    flex-direction: column;
+  }
+
+  .qb-manager-sidebar {
+    width: 100%;
+    flex: 1 1 auto;
+  }
+}
+
 .qb-toolbar-spacer {
   flex: 1 1 auto;
 }


### PR DESCRIPTION
## Summary
- move the questionnaire builder into a two-column layout with a dedicated sidebar for navigation and imports
- surface a section navigation list in the sidebar alongside the questionnaire tabs for quicker access
- add supporting styles and client-side logic to drive the sidebar navigation and smooth scrolling highlights

## Testing
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_68efed8c8910832db7ec8bf201d11e6e