### PR TITLE
Redesign navigation layout and pin questionnaire sidebar

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -29,6 +29,9 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  position: sticky;
+  top: calc(var(--appbar-height) + var(--topnav-height) + 1.5rem);
+  align-self: flex-start;
 }
 
 .qb-sidebar-card {
@@ -123,6 +126,8 @@
   .qb-manager-sidebar {
     width: 100%;
     flex: 1 1 auto;
+    position: static;
+    top: auto;
   }
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,5 +1,6 @@
 :root {
   --appbar-height: 64px;
+  --topnav-height: 64px;
 }
 
 * {
@@ -80,6 +81,147 @@ body.md-bg {
   display: flex;
   align-items: center;
   gap: 0.85rem;
+}
+
+.md-topnav {
+  position: sticky;
+  top: var(--appbar-height);
+  z-index: 950;
+  background: var(--app-surface);
+  border-radius: 20px;
+  border: 1px solid var(--app-border);
+  margin: 1.35rem auto 1.75rem;
+  padding: 0.5rem 0.85rem;
+  box-shadow: var(--app-shadow-soft);
+  display: flex;
+  align-items: stretch;
+  min-height: var(--topnav-height);
+}
+
+.md-topnav::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.md-topnav > * {
+  position: relative;
+  z-index: 1;
+}
+
+.md-topnav-list {
+  list-style: none;
+  display: flex;
+  align-items: stretch;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.md-topnav-item {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+}
+
+.md-topnav-item.is-active > .md-topnav-trigger {
+  background: var(--app-primary-soft);
+  color: var(--app-primary-dark);
+}
+
+.md-topnav-trigger {
+  border: none;
+  background: transparent;
+  color: var(--app-on-surface-strong);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.md-topnav-trigger:hover,
+.md-topnav-trigger:focus-visible {
+  background: var(--app-primary);
+  color: var(--md-on-primary);
+  box-shadow: var(--app-shadow-soft);
+  outline: none;
+}
+
+.md-topnav-chevron {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+  margin-left: 0.25rem;
+}
+
+.md-topnav-item.is-open > .md-topnav-trigger .md-topnav-chevron,
+.md-topnav-item:focus-within > .md-topnav-trigger .md-topnav-chevron {
+  transform: rotate(-135deg);
+}
+
+.md-topnav-submenu {
+  position: absolute;
+  top: calc(100% + 0.6rem);
+  left: 0;
+  display: none;
+  flex-direction: column;
+  min-width: 220px;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: 14px;
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+  padding: 0.5rem 0.35rem;
+  z-index: 980;
+}
+
+.md-topnav-item.is-open > .md-topnav-submenu,
+.md-topnav-item:focus-within > .md-topnav-submenu {
+  display: flex;
+}
+
+@media (hover: hover) {
+  .md-topnav-item:hover > .md-topnav-submenu {
+    display: flex;
+  }
+
+  .md-topnav-item:hover > .md-topnav-trigger .md-topnav-chevron {
+    transform: rotate(-135deg);
+  }
+}
+
+.md-topnav-submenu li {
+  list-style: none;
+}
+
+.md-topnav-link {
+  display: block;
+  padding: 0.55rem 0.85rem;
+  border-radius: 10px;
+  color: var(--app-on-surface-strong);
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.md-topnav-link:hover,
+.md-topnav-link:focus-visible,
+.md-topnav-link.active {
+  background: var(--app-primary-soft);
+  color: var(--app-primary-dark);
+  outline: none;
 }
 
 .md-status-indicator {
@@ -276,7 +418,7 @@ body.md-bg {
   margin-left: 0;
   padding: 1.2rem 0;
   transition: margin-left 0.3s ease;
-  min-height: calc(100vh - var(--appbar-height));
+  min-height: calc(100vh - var(--appbar-height) - var(--topnav-height));
 }
 
 .md-section {
@@ -1388,27 +1530,16 @@ body.theme-dark .md-button.md-primary {
 
 @media (min-width: 960px) {
   .md-shell {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    column-gap: 2rem;
     padding: 1.75rem 2.25rem 2.75rem;
   }
 
-  .md-drawer {
-    position: sticky;
-    top: calc(var(--appbar-height) + 1.5rem);
-    transform: none;
-    height: calc(100vh - var(--appbar-height) - 3rem);
-    box-shadow: 0 22px 46px var(--app-primary-soft);
-    border-radius: 18px;
-    left: auto;
-    bottom: auto;
+  .md-topnav {
+    margin-top: 1.75rem;
   }
 
   .md-main {
-    margin-left: 0;
     padding: 0;
-    min-height: calc(100vh - var(--appbar-height) - 3rem);
+    min-height: calc(100vh - var(--appbar-height) - var(--topnav-height) - 3rem);
   }
 
   .md-appbar-toggle {
@@ -1428,6 +1559,62 @@ body.theme-dark .md-button.md-primary {
 
   .md-footer-links {
     justify-content: flex-end;
+  }
+}
+
+@media (max-width: 900px) {
+  .md-topnav {
+    flex-direction: column;
+    align-items: stretch;
+    margin: 1rem 0 1.25rem;
+    padding: 0.35rem 0.75rem;
+  }
+
+  .md-topnav::before {
+    opacity: 0.95;
+  }
+
+  .md-topnav-list {
+    flex-direction: column;
+    gap: 0.25rem;
+    display: none;
+  }
+
+  .md-topnav.is-open .md-topnav-list {
+    display: flex;
+  }
+
+  .md-topnav-item {
+    width: 100%;
+  }
+
+  .md-topnav-trigger {
+    width: 100%;
+    justify-content: space-between;
+    padding: 0.75rem 0.85rem;
+  }
+
+  .md-topnav-submenu {
+    position: static;
+    display: none;
+    box-shadow: none;
+    border: none;
+    border-radius: 10px;
+    padding: 0.35rem 0 0.75rem;
+    margin: 0 0 0.35rem;
+  }
+
+  .md-topnav-item.is-open > .md-topnav-submenu,
+  .md-topnav-item:focus-within > .md-topnav-submenu {
+    display: flex;
+  }
+
+  .md-topnav-submenu li {
+    width: 100%;
+  }
+
+  .md-topnav-link {
+    width: 100%;
   }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,17 +6,89 @@
   }
   const normalizedBase = appBase.replace(/\/+$/, '') || '';
 
-  const drawer = document.querySelector('[data-drawer]');
+  const topnav = document.querySelector('[data-topnav]');
   const toggle = document.querySelector('[data-drawer-toggle]');
-  if (drawer && toggle) {
-    toggle.addEventListener('click', () => {
-      drawer.classList.toggle('open');
+  let closeTopnavSubmenus = null;
+  if (topnav) {
+    const triggers = topnav.querySelectorAll('[data-topnav-trigger]');
+    const links = topnav.querySelectorAll('.md-topnav-link');
+
+    const closeSubmenus = () => {
+      triggers.forEach((trigger) => {
+        trigger.setAttribute('aria-expanded', 'false');
+        const item = trigger.closest('[data-topnav-item]');
+        if (item) {
+          item.classList.remove('is-open');
+        }
+      });
+    };
+
+    closeTopnavSubmenus = closeSubmenus;
+
+    triggers.forEach((trigger) => {
+      trigger.setAttribute('aria-expanded', 'false');
+      trigger.addEventListener('click', (event) => {
+        event.preventDefault();
+        const item = trigger.closest('[data-topnav-item]');
+        if (!item) {
+          return;
+        }
+        const willOpen = !item.classList.contains('is-open');
+        closeSubmenus();
+        if (willOpen) {
+          trigger.setAttribute('aria-expanded', 'true');
+          item.classList.add('is-open');
+        }
+      });
     });
-    drawer.addEventListener('click', (evt) => {
-      if (evt.target.classList.contains('md-drawer-link')) {
-        drawer.classList.remove('open');
+
+    document.addEventListener('click', (event) => {
+      if (topnav.contains(event.target)) {
+        return;
+      }
+      closeSubmenus();
+      if (topnav.classList.contains('is-open')) {
+        topnav.classList.remove('is-open');
+        if (toggle) {
+          toggle.setAttribute('aria-expanded', 'false');
+        }
       }
     });
+
+    topnav.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeSubmenus();
+        if (toggle) {
+          toggle.setAttribute('aria-expanded', 'false');
+        }
+        topnav.classList.remove('is-open');
+      }
+    });
+
+    links.forEach((link) => {
+      link.addEventListener('click', () => {
+        closeSubmenus();
+        if (toggle) {
+          toggle.setAttribute('aria-expanded', 'false');
+        }
+        topnav.classList.remove('is-open');
+      });
+    });
+  }
+
+  if (topnav && toggle) {
+    toggle.addEventListener('click', () => {
+      const isOpen = topnav.classList.toggle('is-open');
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      if (!isOpen && typeof closeTopnavSubmenus === 'function') {
+        closeTopnavSubmenus();
+      } else if (isOpen && typeof closeTopnavSubmenus === 'function') {
+        closeTopnavSubmenus();
+      }
+    });
+  } else if (toggle) {
+    toggle.hidden = true;
+    toggle.setAttribute('aria-hidden', 'true');
   }
 
   if (!document.querySelector('link[rel="manifest"]')) {

--- a/templates/header.php
+++ b/templates/header.php
@@ -51,8 +51,8 @@ $isActiveNav = static function (string ...$keys) use ($drawerKey): bool {
     }
     return false;
 };
-$drawerLinkAttributes = static function (string ...$keys) use ($isActiveNav): string {
-    $class = 'md-drawer-link' . ($isActiveNav(...$keys) ? ' active' : '');
+$topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): string {
+    $class = 'md-topnav-link' . ($isActiveNav(...$keys) ? ' active' : '');
     $aria = $isActiveNav(...$keys) ? ' aria-current="page"' : '';
     return sprintf('class="%s"%s', $class, $aria);
 };
@@ -65,7 +65,7 @@ $drawerLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
   window.APP_AVAILABLE_LOCALES = <?=json_encode($availableLocales, JSON_THROW_ON_ERROR)?>;
 </script>
 <header class="md-appbar md-elev-2">
-  <button class="md-appbar-toggle" aria-label="Toggle navigation" data-drawer-toggle>
+  <button class="md-appbar-toggle" aria-label="Toggle navigation" data-drawer-toggle aria-controls="app-topnav" aria-expanded="false">
     <span></span>
     <span></span>
     <span></span>
@@ -170,40 +170,56 @@ $drawerLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
 </script>
 <div id="google_translate_element" class="visually-hidden" aria-hidden="true"></div>
 <div class="md-shell">
-<aside class="md-drawer" data-drawer>
-  <div class="md-drawer-header">
-    <img src="<?=$logoPathSmall?>" alt="Logo" class="md-logo-sm">
-    <div class="md-drawer-title"><?=$siteTitle?></div>
-  </div>
-  <nav class="md-drawer-nav">
-    <div class="md-drawer-section">
-      <span class="md-drawer-label"><?=t($t, 'my_workspace', 'My Workspace')?></span>
-      <a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('workspace.my_performance')?>><?=t($t, 'my_performance', 'My Performance')?></a>
-      <a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('workspace.submit_assessment')?>><?=t($t, 'submit_assessment', 'Submit Assessment')?></a>
-      <a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('workspace.profile')?>><?=t($t, 'profile', 'Profile')?></a>
-    </div>
+<nav id="app-topnav" class="md-topnav md-elev-2" data-topnav aria-label="<?=htmlspecialchars(t($t, 'primary_navigation', 'Primary navigation'), ENT_QUOTES, 'UTF-8')?>">
+  <ul class="md-topnav-list">
+    <?php
+    $workspaceActive = $isActiveNav('workspace.my_performance', 'workspace.submit_assessment', 'workspace.profile');
+    ?>
+    <li class="md-topnav-item<?=$workspaceActive ? ' is-active' : ''?>" data-topnav-item>
+      <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+        <span><?=t($t, 'my_workspace', 'My Workspace')?></span>
+        <span class="md-topnav-chevron" aria-hidden="true"></span>
+      </button>
+      <ul class="md-topnav-submenu">
+        <li><a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.my_performance')?>><?=t($t, 'my_performance', 'My Performance')?></a></li>
+        <li><a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.submit_assessment')?>><?=t($t, 'submit_assessment', 'Submit Assessment')?></a></li>
+        <li><a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.profile')?>><?=t($t, 'profile', 'Profile')?></a></li>
+      </ul>
+    </li>
     <?php if (in_array($role, ['admin', 'supervisor'], true)): ?>
-      <div class="md-drawer-section">
-        <span class="md-drawer-label"><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
-        <a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('team.review_queue')?>><?=t($t, 'review_queue', 'Review Queue')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('team.pending_accounts')?>><?=t($t, 'pending_accounts', 'Pending Approvals')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('team.assignments')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a>
-      </div>
+      <?php $teamActive = $isActiveNav('team.review_queue', 'team.pending_accounts', 'team.assignments'); ?>
+      <li class="md-topnav-item<?=$teamActive ? ' is-active' : ''?>" data-topnav-item>
+        <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+          <span><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
+          <span class="md-topnav-chevron" aria-hidden="true"></span>
+        </button>
+        <ul class="md-topnav-submenu">
+          <li><a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.review_queue')?>><?=t($t, 'review_queue', 'Review Queue')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.pending_accounts')?>><?=t($t, 'pending_accounts', 'Pending Approvals')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a></li>
+        </ul>
+      </li>
     <?php endif; ?>
     <?php if ($role === 'admin'): ?>
-      <div class="md-drawer-section">
-        <span class="md-drawer-label"><?=t($t, 'admin_navigation', 'Administration')?></span>
-        <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.dashboard')?>><?=t($t, 'admin_dashboard', 'Admin Dashboard')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.users')?>><?=t($t, 'manage_users', 'Manage Users')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.manage_questionnaires')?>><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.analytics')?>><?=t($t, 'analytics', 'Analytics')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.export')?>><?=t($t, 'export_data', 'Export Data')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.branding')?>><?=t($t, 'branding', 'Branding & Landing')?></a>
-        <a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" <?=$drawerLinkAttributes('admin.settings')?>><?=t($t, 'settings', 'Settings')?></a>
-        <a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" class="md-drawer-link" target="_blank" rel="noopener"><?=t($t,'api_documentation','API Documentation')?></a>
-      </div>
+      <?php $adminActive = $isActiveNav('admin.dashboard', 'admin.users', 'admin.manage_questionnaires', 'admin.analytics', 'admin.export', 'admin.branding', 'admin.settings'); ?>
+      <li class="md-topnav-item<?=$adminActive ? ' is-active' : ''?>" data-topnav-item>
+        <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+          <span><?=t($t, 'admin_navigation', 'Administration')?></span>
+          <span class="md-topnav-chevron" aria-hidden="true"></span>
+        </button>
+        <ul class="md-topnav-submenu">
+          <li><a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.dashboard')?>><?=t($t, 'admin_dashboard', 'Admin Dashboard')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.users')?>><?=t($t, 'manage_users', 'Manage Users')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.manage_questionnaires')?>><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.analytics')?>><?=t($t, 'analytics', 'Analytics')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.export')?>><?=t($t, 'export_data', 'Export Data')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.branding')?>><?=t($t, 'branding', 'Branding & Landing')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.settings')?>><?=t($t, 'settings', 'Settings')?></a></li>
+          <li><a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link" target="_blank" rel="noopener"><?=t($t,'api_documentation','API Documentation')?></a></li>
+        </ul>
+      </li>
     <?php endif; ?>
-  </nav>
-</aside>
+  </ul>
+</nav>
 <main class="md-main">
 


### PR DESCRIPTION
## Summary
- replace the legacy drawer with a sticky top navigation that groups workspace, team, and admin links into dropdown menus
- add responsive scripting and styling to support mobile toggling and keyboard interactions for the new navigation bar
- make the questionnaire management sidebar sticky beneath the locked navigation to keep section controls visible while scrolling

## Testing
- php -l templates/header.php

------
https://chatgpt.com/codex/tasks/task_e_68f137538bf0832d812d81e249bf1fbb