### PR TITLE
Keep top nav dropdown open when moving to submenu

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -187,6 +187,18 @@ body.md-bg {
   z-index: 980;
 }
 
+@media (hover: hover) {
+  .md-topnav-submenu::before {
+    content: "";
+    position: absolute;
+    top: -0.6rem;
+    left: 0;
+    right: 0;
+    height: 0.6rem;
+    display: block;
+  }
+}
+
 .md-topnav-item.is-open > .md-topnav-submenu,
 .md-topnav-item:focus-within > .md-topnav-submenu {
   display: flex;


### PR DESCRIPTION
## Summary
- add a hover buffer around the top navigation submenu so it remains open while moving into submenu items

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f141e6eb2c832d8af2685a78fa25ee