### PR TITLE
Address Codex follow-up for "Redesign navigation layout and pin questionnaire sidebar"

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -43,7 +43,7 @@
     });
 
     document.addEventListener('click', (event) => {
-      if (topnav.contains(event.target)) {
+      if (topnav.contains(event.target) || (toggle && toggle.contains(event.target))) {
         return;
       }
       closeSubmenus();


### PR DESCRIPTION
## Summary
- prevent the document-level outside-click handler from closing the navigation when the mobile toggle is pressed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f1595798f0832d923c865242697b4c