### PR TITLE
Ensure init teardown drops new questionnaire tables

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,6 +1,9 @@
 
 -- Enhanced init.sql (adds site_config and weight_percent)
 DROP TABLE IF EXISTS training_recommendation;
+DROP TABLE IF EXISTS analytics_report_schedule;
+DROP TABLE IF EXISTS questionnaire_assignment;
+DROP TABLE IF EXISTS questionnaire_work_function;
 DROP TABLE IF EXISTS course_catalogue;
 DROP TABLE IF EXISTS questionnaire_response_item;
 DROP TABLE IF EXISTS questionnaire_response;


### PR DESCRIPTION
## Summary
- include questionnaire_work_function, questionnaire_assignment, and analytics_report_schedule in the init teardown
- maintain dependency-safe drop order for the initialization script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f18189664c832d9cdd090da92751e4