### PR TITLE
Ensure seeded admin accounts are reactivated during seeding scripts

### DIFF
--- a/scripts/rebuild_app.php
+++ b/scripts/rebuild_app.php
@@ -168,11 +168,11 @@ function seedAdmin(PDO $pdo): string
         $stmt->execute([$username]);
         $existing = $stmt->fetchColumn();
         if ($existing) {
-            $update = $pdo->prepare('UPDATE users SET password = ?, role = "admin", full_name = ?, email = ?, profile_completed = 1, must_reset_password = 1 WHERE id = ?');
+            $update = $pdo->prepare("UPDATE users SET password = ?, role = 'admin', full_name = ?, email = ?, profile_completed = 1, account_status = 'active', must_reset_password = 1 WHERE id = ?");
             $update->execute([$hash, $fullName, $email, $existing]);
             $userId = (int) $existing;
         } else {
-            $insert = $pdo->prepare('INSERT INTO users (username, password, role, full_name, email, profile_completed, must_reset_password) VALUES (?,?,?,?,?,1,1)');
+            $insert = $pdo->prepare("INSERT INTO users (username, password, role, full_name, email, profile_completed, account_status, must_reset_password) VALUES (?,?,?,?,?,1, 'active',1)");
             $insert->execute([$username, $hash, 'admin', $fullName, $email]);
             $userId = (int) $pdo->lastInsertId();
         }

--- a/scripts/seed_admin.php
+++ b/scripts/seed_admin.php
@@ -13,11 +13,11 @@ try {
     $stmt->execute([$username]);
     $existing = $stmt->fetchColumn();
     if ($existing) {
-        $update = $pdo->prepare('UPDATE users SET password = ?, role = "admin", full_name = ?, email = ?, profile_completed = 1, must_reset_password = 1 WHERE id = ?');
+        $update = $pdo->prepare("UPDATE users SET password = ?, role = 'admin', full_name = ?, email = ?, profile_completed = 1, account_status = 'active', must_reset_password = 1 WHERE id = ?");
         $update->execute([$hash, $fullName, $email, $existing]);
         $userId = (int)$existing;
     } else {
-        $insert = $pdo->prepare('INSERT INTO users (username, password, role, full_name, email, profile_completed, must_reset_password) VALUES (?,?,?,?,?,1,1)');
+        $insert = $pdo->prepare("INSERT INTO users (username, password, role, full_name, email, profile_completed, account_status, must_reset_password) VALUES (?,?,?,?,?,1, 'active',1)");
         $insert->execute([$username, $hash, 'admin', $fullName, $email]);
         $userId = (int)$pdo->lastInsertId();
     }


### PR DESCRIPTION
## Summary
- activate the admin account when reseeding credentials via scripts/seed_admin.php
- mirror the activation when seeding through scripts/rebuild_app.php

## Testing
- php -l scripts/seed_admin.php
- php -l scripts/rebuild_app.php

------
https://chatgpt.com/codex/tasks/task_e_68f185091574832dae4271675371eb46