### PR TITLE
Avoid precaching authenticated pages

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -9,11 +9,8 @@ function withBase(path) {
   return `${BASE_SCOPE}${path}`;
 }
 
+// Only precache static shell assets that do not contain user-specific data.
 const APP_SHELL_URLS = [
-  withBase('my_performance.php'),
-  withBase('submit_assessment.php'),
-  withBase('profile.php'),
-  withBase('dashboard.php'),
   withBase('offline.html'),
 ];
 


### PR DESCRIPTION
## Summary
- stop precaching authenticated PHP pages in the service worker install step to avoid caching user-specific data offline

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f1a5c23950832d97131ec716606cfe