### PR TITLE
Add upgrade_repo column to schema scripts

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -50,7 +50,8 @@ CREATE TABLE site_config (
   smtp_encryption VARCHAR(10) NOT NULL DEFAULT 'none',
   smtp_from_email VARCHAR(255) NULL,
   smtp_from_name VARCHAR(255) NULL,
-  smtp_timeout INT NULL
+  smtp_timeout INT NULL,
+  upgrade_repo VARCHAR(255) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE users (
@@ -254,7 +255,8 @@ INSERT INTO site_config (
   smtp_encryption,
   smtp_from_email,
   smtp_from_name,
-  smtp_timeout
+  smtp_timeout,
+  upgrade_repo
 ) VALUES (
   1,
   'My Performance',
@@ -289,7 +291,8 @@ INSERT INTO site_config (
   'none',
   NULL,
   NULL,
-  20
+  20,
+  'khoppenworth/HRassessv300'
 );
 
 -- default users are disabled by default; update the passwords and enable accounts after installation

--- a/migration.sql
+++ b/migration.sql
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS site_config (
   microsoft_oauth_client_secret VARCHAR(255) NULL,
   microsoft_oauth_tenant VARCHAR(255) NULL,
   color_theme VARCHAR(50) NOT NULL DEFAULT 'light',
-  enabled_locales TEXT NULL
+  enabled_locales TEXT NULL,
+  upgrade_repo VARCHAR(255) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS footer_org_name VARCHAR(255) NULL AFTER logo_path,
@@ -66,7 +67,8 @@ ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS smtp_from_email VARCHAR(255) NULL AFTER smtp_encryption,
   ADD COLUMN IF NOT EXISTS smtp_from_name VARCHAR(255) NULL AFTER smtp_from_email,
   ADD COLUMN IF NOT EXISTS smtp_timeout INT NULL AFTER smtp_from_name,
-  ADD COLUMN IF NOT EXISTS enabled_locales TEXT NULL AFTER smtp_timeout;
+  ADD COLUMN IF NOT EXISTS enabled_locales TEXT NULL AFTER smtp_timeout,
+  ADD COLUMN IF NOT EXISTS upgrade_repo VARCHAR(255) NULL AFTER enabled_locales;
 INSERT IGNORE INTO site_config (
   id,
   site_name,
@@ -101,7 +103,8 @@ INSERT IGNORE INTO site_config (
   smtp_from_email,
   smtp_from_name,
   smtp_timeout,
-  enabled_locales
+  enabled_locales,
+  upgrade_repo
 ) VALUES (
   1,
   'My Performance',
@@ -136,7 +139,8 @@ INSERT IGNORE INTO site_config (
   NULL,
   NULL,
   20,
-  '["en","fr","am"]'
+  '["en","fr","am"]',
+  'khoppenworth/HRassessv300'
 );
 
 UPDATE site_config

--- a/scripts/check_database_integrity.php
+++ b/scripts/check_database_integrity.php
@@ -206,6 +206,7 @@ $expectedSchemas = [
         'smtp_from_name' => ['type' => 'varchar', 'null' => 'YES'],
         'smtp_timeout' => ['type' => 'int', 'null' => 'YES'],
         'enabled_locales' => ['type' => 'text', 'null' => 'YES'],
+        'upgrade_repo' => ['type' => 'varchar', 'null' => 'YES'],
     ],
     'users' => [
         'id' => ['type' => 'int', 'null' => 'NO', 'key' => 'PRI', 'extra' => 'auto_increment'],

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS site_config (
   smtp_encryption VARCHAR(10) NOT NULL DEFAULT 'none',
   smtp_from_email VARCHAR(255) NULL,
   smtp_from_name VARCHAR(255) NULL,
-  smtp_timeout INT NULL
+  smtp_timeout INT NULL,
+  upgrade_repo VARCHAR(255) NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE site_config
@@ -72,7 +73,8 @@ ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS smtp_encryption VARCHAR(10) NOT NULL DEFAULT 'none',
   ADD COLUMN IF NOT EXISTS smtp_from_email VARCHAR(255) NULL,
   ADD COLUMN IF NOT EXISTS smtp_from_name VARCHAR(255) NULL,
-  ADD COLUMN IF NOT EXISTS smtp_timeout INT NULL;
+  ADD COLUMN IF NOT EXISTS smtp_timeout INT NULL,
+  ADD COLUMN IF NOT EXISTS upgrade_repo VARCHAR(255) NULL;
 
 INSERT INTO site_config (
   id, site_name, landing_text, address, contact, logo_path,
@@ -81,7 +83,7 @@ INSERT INTO site_config (
   footer_rights, google_oauth_enabled, google_oauth_client_id, google_oauth_client_secret,
   microsoft_oauth_enabled, microsoft_oauth_client_id, microsoft_oauth_client_secret, microsoft_oauth_tenant,
   color_theme, brand_color, enabled_locales, smtp_enabled, smtp_host, smtp_port, smtp_username, smtp_password,
-  smtp_encryption, smtp_from_email, smtp_from_name, smtp_timeout
+  smtp_encryption, smtp_from_email, smtp_from_name, smtp_timeout, upgrade_repo
 ) VALUES (
   1, 'My Performance', NULL, NULL, NULL, NULL,
   'Ethiopian Pharmaceutical Supply Service', 'EPSS / EPS', 'epss.gov.et', 'https://epss.gov.et',
@@ -89,14 +91,15 @@ INSERT INTO site_config (
   'All rights reserved.', 0, NULL, NULL,
   0, NULL, NULL, 'common',
   'light', '#2073bf', '["en","fr","am"]', 0, NULL, 587, NULL, NULL,
-  'none', NULL, NULL, 20
+  'none', NULL, NULL, 20, 'khoppenworth/HRassessv300'
 ) ON DUPLICATE KEY UPDATE
   site_name = COALESCE(site_config.site_name, VALUES(site_name)),
   brand_color = IFNULL(site_config.brand_color, VALUES(brand_color)),
   color_theme = IFNULL(site_config.color_theme, VALUES(color_theme)),
   enabled_locales = IFNULL(site_config.enabled_locales, VALUES(enabled_locales)),
   smtp_port = IFNULL(site_config.smtp_port, VALUES(smtp_port)),
-  smtp_timeout = IFNULL(site_config.smtp_timeout, VALUES(smtp_timeout));
+  smtp_timeout = IFNULL(site_config.smtp_timeout, VALUES(smtp_timeout)),
+  upgrade_repo = IFNULL(site_config.upgrade_repo, VALUES(upgrade_repo));
 
 -- Ensure users table columns match the application expectations.
 ALTER TABLE users


### PR DESCRIPTION
## Summary
- add the upgrade_repo column to the site_config definitions in init.sql, migration.sql, and upgrade_to_v3.sql
- ensure default seed data writes the configured GitHub repository slug
- extend the database integrity check to expect the new upgrade_repo column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1ab010a14832d890dfa276d47ca2a