### PR TITLE
Create realistic multi-year demo dataset

### DIFF
--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -1,9 +1,14 @@
--- dummy_data.sql: comprehensive demo dataset covering questionnaires, assignments, responses, and analytics
--- Demo accounts share a temporary password that must be reset on first login.
+-- dummy_data.sql: realistic HR assessment demo dataset representing five performance cycles
+-- All demo accounts share a pre-hashed temporary password and require reset on first login.
 SET @password := '$2y$12$IQkYkVMIQE9G/dFkTcvObO1ekoYyOz2gk.d79KxQMOnPOrldv7drq';
 
 -- Clean up previous demo dataset ------------------------------------------------
-SET @demo_questionnaire := (SELECT id FROM questionnaire WHERE title = 'Demo Comprehensive Performance Review' LIMIT 1);
+SET @epsa_questionnaire := (
+    SELECT id
+    FROM questionnaire
+    WHERE title = 'EPSA Annual Performance Review 360'
+    LIMIT 1
+);
 
 DELETE tr
 FROM training_recommendation tr
@@ -17,120 +22,154 @@ JOIN questionnaire_response qr ON qr.id = qri.response_id
 JOIN users u ON u.id = qr.user_id
 WHERE u.username LIKE 'demo_%';
 
-DELETE FROM questionnaire_response WHERE questionnaire_id = @demo_questionnaire OR user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
-DELETE FROM questionnaire_assignment WHERE questionnaire_id = @demo_questionnaire OR staff_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
-DELETE FROM questionnaire_work_function WHERE questionnaire_id = @demo_questionnaire;
+DELETE FROM questionnaire_response
+WHERE questionnaire_id = @epsa_questionnaire
+   OR user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
+DELETE FROM questionnaire_assignment
+WHERE questionnaire_id = @epsa_questionnaire
+   OR staff_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
+DELETE FROM questionnaire_work_function WHERE questionnaire_id = @epsa_questionnaire;
+
 DELETE qio
 FROM questionnaire_item_option qio
 JOIN questionnaire_item qi ON qi.id = qio.questionnaire_item_id
-WHERE qi.questionnaire_id = @demo_questionnaire;
-DELETE FROM questionnaire_item WHERE questionnaire_id = @demo_questionnaire;
-DELETE FROM questionnaire_section WHERE questionnaire_id = @demo_questionnaire;
-DELETE FROM questionnaire WHERE id = @demo_questionnaire;
+WHERE qi.questionnaire_id = @epsa_questionnaire;
 
-DELETE FROM analytics_report_schedule WHERE created_by IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+DELETE FROM questionnaire_item WHERE questionnaire_id = @epsa_questionnaire;
+DELETE FROM questionnaire_section WHERE questionnaire_id = @epsa_questionnaire;
+DELETE FROM questionnaire WHERE id = @epsa_questionnaire;
+
+DELETE FROM analytics_report_schedule
+WHERE created_by IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
 DELETE FROM logs WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
-DELETE FROM course_catalogue WHERE code LIKE 'DEMO-%';
+
+DELETE FROM course_catalogue WHERE code LIKE 'EPSA-%';
 
 DELETE FROM users WHERE username LIKE 'demo_%';
 
--- Insert demo users --------------------------------------------------------------
-INSERT INTO users (username,password,role,full_name,email,gender,date_of_birth,phone,department,cadre,work_function,profile_completed,must_reset_password,account_status,language)
+-- Ensure performance periods exist for the last five cycles ---------------------
+INSERT INTO performance_period (label, period_start, period_end)
 VALUES
-('demo_admin', @password, 'admin', 'Demo System Administrator', 'demo.admin@example.com', 'female', '1980-01-01', '+251900000000', 'Executive Office', 'Administrator', 'leadership_tn', 1, 1, 'active', 'en'),
-('demo_supervisor', @password, 'supervisor', 'Demo Performance Supervisor', 'demo.supervisor@example.com', 'male', '1982-02-02', '+251900000010', 'People & Culture', 'Manager', 'hrm', 1, 1, 'active', 'en'),
-('demo_supervisor2', @password, 'supervisor', 'Demo Operations Supervisor', 'demo.supervisor2@example.com', 'female', '1984-03-03', '+251900000011', 'Operations', 'Manager', 'general_service', 1, 1, 'active', 'en'),
-('demo_finance', @password, 'staff', 'Finance Demo', 'demo.finance@example.com', 'female', '1986-01-01', '+251910000001', 'Finance', 'Officer', 'finance', 1, 1, 'active', 'en'),
-('demo_general_service', @password, 'staff', 'General Service Demo', 'demo.general@example.com', 'male', '1987-02-01', '+251910000002', 'General Services', 'Officer', 'general_service', 1, 1, 'active', 'en'),
-('demo_hrm', @password, 'staff', 'HRM Demo', 'demo.hrm@example.com', 'female', '1988-03-01', '+251910000003', 'Human Resources', 'Specialist', 'hrm', 1, 1, 'active', 'en'),
-('demo_ict', @password, 'staff', 'ICT Demo', 'demo.ict@example.com', 'male', '1989-04-01', '+251910000004', 'ICT', 'Specialist', 'ict', 1, 1, 'active', 'en'),
-('demo_leadership', @password, 'staff', 'Leadership Demo', 'demo.leadership@example.com', 'female', '1985-05-01', '+251910000005', 'Leadership', 'Coordinator', 'leadership_tn', 1, 1, 'active', 'en'),
-('demo_legal', @password, 'staff', 'Legal Service Demo', 'demo.legal@example.com', 'female', '1984-06-01', '+251910000006', 'Legal Service', 'Advisor', 'legal_service', 1, 1, 'active', 'en'),
-('demo_pme', @password, 'staff', 'PME Demo', 'demo.pme@example.com', 'male', '1983-07-01', '+251910000007', 'Planning & Evaluation', 'Analyst', 'pme', 1, 1, 'active', 'en'),
-('demo_quant', @password, 'staff', 'Quantification Demo', 'demo.quant@example.com', 'female', '1982-08-01', '+251910000008', 'Quantification', 'Analyst', 'quantification', 1, 1, 'active', 'en'),
-('demo_records', @password, 'staff', 'Records Demo', 'demo.records@example.com', 'female', '1981-09-01', '+251910000009', 'Records Management', 'Officer', 'records_documentation', 1, 1, 'active', 'en'),
-('demo_security_driver', @password, 'staff', 'Security Driver Demo', 'demo.secdriver@example.com', 'male', '1980-10-01', '+251910000010', 'Security & Driver', 'Supervisor', 'security_driver', 1, 1, 'active', 'en'),
-('demo_security', @password, 'staff', 'Security Demo', 'demo.security@example.com', 'male', '1979-11-01', '+251910000011', 'Security', 'Officer', 'security', 1, 1, 'active', 'en'),
-('demo_tmd', @password, 'staff', 'TMD Demo', 'demo.tmd@example.com', 'female', '1978-12-01', '+251910000012', 'TMD', 'Officer', 'tmd', 1, 1, 'active', 'en'),
-('demo_wim', @password, 'staff', 'WIM Demo', 'demo.wim@example.com', 'female', '1977-01-15', '+251910000013', 'WIM', 'Officer', 'wim', 1, 1, 'active', 'en'),
-('demo_cmd', @password, 'staff', 'CMD Demo', 'demo.cmd@example.com', 'male', '1976-02-15', '+251910000014', 'CMD', 'Officer', 'cmd', 1, 1, 'active', 'en'),
-('demo_comm', @password, 'staff', 'Communication Demo', 'demo.communication@example.com', 'female', '1975-03-15', '+251910000015', 'Communication', 'Officer', 'communication', 1, 1, 'active', 'en'),
-('demo_dfm', @password, 'staff', 'DFM Demo', 'demo.dfm@example.com', 'male', '1974-04-15', '+251910000016', 'DFM', 'Officer', 'dfm', 1, 1, 'active', 'en'),
-('demo_driver', @password, 'staff', 'Driver Demo', 'demo.driver@example.com', 'male', '1973-05-15', '+251910000017', 'Transport', 'Driver', 'driver', 1, 1, 'active', 'en'),
-('demo_ethics', @password, 'staff', 'Ethics Demo', 'demo.ethics@example.com', 'female', '1972-06-15', '+251910000018', 'Ethics', 'Advisor', 'ethics', 1, 1, 'active', 'en');
+('2021', '2021-01-01', '2021-12-31'),
+('2022', '2022-01-01', '2022-12-31'),
+('2023', '2023-01-01', '2023-12-31'),
+('2024', '2024-01-01', '2024-12-31'),
+('2025', '2025-01-01', '2025-12-31')
+ON DUPLICATE KEY UPDATE
+    period_start = VALUES(period_start),
+    period_end = VALUES(period_end);
 
-SET @demo_admin_id := (SELECT id FROM users WHERE username = 'demo_admin');
-SET @demo_supervisor_id := (SELECT id FROM users WHERE username = 'demo_supervisor');
-SET @demo_supervisor2_id := (SELECT id FROM users WHERE username = 'demo_supervisor2');
+-- Insert demo users representing realistic personas ----------------------------
+INSERT INTO users (username, password, role, full_name, email, gender, date_of_birth, phone,
+                   department, cadre, work_function, profile_completed, must_reset_password,
+                   account_status, language)
+VALUES
+('demo_strategy_admin', @password, 'admin', 'Selam Ayalew', 'demo.strategy.admin@example.com', 'female', '1979-06-12', '+251900200000', 'Strategy & Transformation', 'Director', 'leadership_tn', 1, 1, 'active', 'en'),
+('demo_people_lead', @password, 'supervisor', 'Kifle Bekele', 'demo.people.lead@example.com', 'male', '1981-04-18', '+251900200010', 'People & Culture', 'Manager', 'hrm', 1, 1, 'active', 'en'),
+('demo_supply_lead', @password, 'supervisor', 'Rahel Demissie', 'demo.supply.lead@example.com', 'female', '1983-02-22', '+251900200020', 'Supply Chain Integration', 'Manager', 'quantification', 1, 1, 'active', 'en'),
+('demo_region_lead', @password, 'supervisor', 'Samuel Fekadu', 'demo.region.lead@example.com', 'male', '1980-11-09', '+251900200030', 'Regional Operations', 'Manager', 'general_service', 1, 1, 'active', 'en'),
+('demo_finance_controller', @password, 'staff', 'Meron Gudeta', 'demo.finance.controller@example.com', 'female', '1987-01-08', '+251910300001', 'Finance & Grants', 'Controller', 'finance', 1, 1, 'active', 'en'),
+('demo_procurement_specialist', @password, 'staff', 'Hanna Mengistu', 'demo.procurement.specialist@example.com', 'female', '1989-03-14', '+251910300002', 'Supply Chain Management', 'Specialist', 'quantification', 1, 1, 'active', 'en'),
+('demo_hr_partner', @password, 'staff', 'Natnael Alemu', 'demo.hr.partner@example.com', 'male', '1990-05-20', '+251910300003', 'People & Culture', 'Senior Officer', 'hrm', 1, 1, 'active', 'en'),
+('demo_it_analyst', @password, 'staff', 'Saron Birhanu', 'demo.it.analyst@example.com', 'female', '1991-07-02', '+251910300004', 'Digital Health Systems', 'Analyst', 'ict', 1, 1, 'active', 'en'),
+('demo_field_adama', @password, 'staff', 'Yonas Getachew', 'demo.field.adama@example.com', 'male', '1988-09-11', '+251910300005', 'Regional Ops - Adama', 'Coordinator', 'general_service', 1, 1, 'active', 'en'),
+('demo_field_gondar', @password, 'staff', 'Lulit Endale', 'demo.field.gondar@example.com', 'female', '1992-10-27', '+251910300006', 'Regional Ops - Gondar', 'Coordinator', 'general_service', 1, 1, 'active', 'en'),
+('demo_security_coord', @password, 'staff', 'Tadesse Lemma', 'demo.security.coord@example.com', 'male', '1985-08-16', '+251910300007', 'Protection & Fleet', 'Coordinator', 'security', 1, 1, 'active', 'en'),
+('demo_driver_fleet', @password, 'staff', 'Hirut Abate', 'demo.driver.fleet@example.com', 'female', '1993-12-05', '+251910300008', 'Protection & Fleet', 'Lead Driver', 'driver', 1, 1, 'active', 'en'),
+('demo_quality_manager', @password, 'staff', 'Fitsum Kebede', 'demo.quality.manager@example.com', 'male', '1986-04-03', '+251910300009', 'Monitoring & Evaluation', 'Manager', 'pme', 1, 1, 'active', 'en'),
+('demo_lab_advisor', @password, 'staff', 'Rediet Eshetu', 'demo.lab.advisor@example.com', 'female', '1984-06-25', '+251910300010', 'National Laboratory Support', 'Advisor', 'wim', 1, 1, 'active', 'en'),
+('demo_records_officer', @password, 'staff', 'Abel Tsegaye', 'demo.records.officer@example.com', 'male', '1987-02-18', '+251910300011', 'Knowledge Management', 'Officer', 'records_documentation', 1, 1, 'active', 'en'),
+('demo_comm_lead', @password, 'staff', 'Ruth Desta', 'demo.comm.lead@example.com', 'female', '1985-01-30', '+251910300012', 'Communications & Partnerships', 'Lead', 'communication', 1, 1, 'active', 'en');
 
-UPDATE users SET approved_by = @demo_admin_id, approved_at = NOW() WHERE username LIKE 'demo_%' AND role = 'staff';
-UPDATE users SET first_login_at = DATE_SUB(NOW(), INTERVAL 10 DAY) WHERE username IN ('demo_admin','demo_supervisor','demo_supervisor2');
+SET @demo_admin_id := (SELECT id FROM users WHERE username = 'demo_strategy_admin');
+SET @demo_people_lead_id := (SELECT id FROM users WHERE username = 'demo_people_lead');
+SET @demo_supply_lead_id := (SELECT id FROM users WHERE username = 'demo_supply_lead');
+SET @demo_region_lead_id := (SELECT id FROM users WHERE username = 'demo_region_lead');
+
+UPDATE users
+SET approved_by = @demo_admin_id,
+    approved_at = DATE_SUB(NOW(), INTERVAL 40 DAY)
+WHERE username LIKE 'demo_%' AND role = 'staff';
+
+UPDATE users
+SET first_login_at = DATE_SUB(NOW(), INTERVAL 12 DAY)
+WHERE username IN ('demo_strategy_admin', 'demo_people_lead', 'demo_supply_lead', 'demo_region_lead');
 
 -- Activity log entries -----------------------------------------------------------
 INSERT INTO logs (user_id, action, meta)
 VALUES
-(@demo_admin_id, 'login', '{"ip":"10.0.0.5","agent":"demo-seed"}'),
-(@demo_supervisor_id, 'login', '{"ip":"10.0.0.6","agent":"demo-seed"}'),
-(@demo_supervisor2_id, 'login', '{"ip":"10.0.0.7","agent":"demo-seed"}');
+(@demo_admin_id, 'login', '{"ip":"10.55.0.10","agent":"seed-script"}'),
+(@demo_people_lead_id, 'login', '{"ip":"10.55.0.11","agent":"seed-script"}'),
+(@demo_supply_lead_id, 'login', '{"ip":"10.55.0.12","agent":"seed-script"}'),
+(@demo_region_lead_id, 'login', '{"ip":"10.55.0.13","agent":"seed-script"}'),
+(@demo_admin_id, 'analytics_export', '{"report":"balanced_scorecard","scope":"nationwide"}');
 
 INSERT INTO logs (user_id, action, meta)
-SELECT u.id, 'profile_update', CONCAT('{"status":"completed","department":"', u.department, '"}')
+SELECT u.id,
+       'profile_update',
+       CONCAT('{"status":"completed","department":"', u.department, '"}')
 FROM users u
 WHERE u.username LIKE 'demo_%' AND u.role = 'staff';
 
 -- Extended learning catalogue ----------------------------------------------------
 INSERT INTO course_catalogue (code, title, moodle_url, recommended_for, min_score, max_score)
 VALUES
-('DEMO-FIN-301', 'Advanced Budget Controls', 'https://moodle.example.com/course/fin301', 'finance', 0, 79),
-('DEMO-ICT-205', 'Automation & Scripting', 'https://moodle.example.com/course/ict205', 'ict', 0, 84),
-('DEMO-HRM-260', 'Coaching Conversations', 'https://moodle.example.com/course/hrm260', 'hrm', 0, 89),
-('DEMO-GEN-120', 'Customer Care Excellence', 'https://moodle.example.com/course/gen120', 'general_service', 0, 89),
-('DEMO-SEC-180', 'Security Incident Response', 'https://moodle.example.com/course/sec180', 'security', 0, 94),
-('DEMO-LEAD-400', 'Leading Change Initiatives', 'https://moodle.example.com/course/lead400', 'leadership_tn', 0, 96);
+('EPSA-FIN-410', 'Financial Stewardship for Donor Funds', 'https://moodle.example.com/course/fin410', 'finance', 0, 88),
+('EPSA-OPS-375', 'Regional Operations Coaching', 'https://moodle.example.com/course/ops375', 'general_service', 0, 85),
+('EPSA-ICT-320', 'Digital Supply Chain Integrations', 'https://moodle.example.com/course/ict320', 'ict', 0, 90),
+('EPSA-HRM-215', 'People Analytics for Wellbeing', 'https://moodle.example.com/course/hrm215', 'hrm', 0, 87),
+('EPSA-SEC-190', 'Protective Operations Playbooks', 'https://moodle.example.com/course/sec190', 'security', 0, 86),
+('EPSA-MEL-360', 'Evidence-based Performance Storytelling', 'https://moodle.example.com/course/mel360', 'pme', 0, 90),
+('EPSA-COM-240', 'Stakeholder Confidence Communications', 'https://moodle.example.com/course/com240', 'communication', 0, 90),
+('EPSA-DRV-220', 'Fleet Safety Leadership', 'https://moodle.example.com/course/drv220', 'driver', 0, 85);
 
 -- Demo questionnaire -------------------------------------------------------------
 INSERT INTO questionnaire (title, description)
-VALUES ('Demo Comprehensive Performance Review', 'Rich dataset covering all work functions.');
+VALUES ('EPSA Annual Performance Review 360', 'Five-year storyline covering supply chain modernization and people enablement.');
 SET @demo_qid := LAST_INSERT_ID();
 
 INSERT INTO questionnaire_section (questionnaire_id, title, description, order_index)
 VALUES
-(@demo_qid, 'Core Competencies', 'Baseline capability and compliance checks.', 1),
-(@demo_qid, 'Goals & Achievements', 'Narrative and objective goal tracking.', 2),
-(@demo_qid, 'Development Planning', 'Future development focus areas.', 3);
+(@demo_qid, 'Strategic Delivery', 'Measures how teams deliver essential health commodities.', 1),
+(@demo_qid, 'Operational Excellence', 'Assesses compliance and continuous improvement practices.', 2),
+(@demo_qid, 'Growth & Support', 'Captures development focus and mobility planning.', 3);
 
-SET @section_core := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 1);
-SET @section_goals := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 2);
-SET @section_dev := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 3);
+SET @section_strategic := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 1);
+SET @section_operational := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 2);
+SET @section_growth := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 3);
 
 INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent, allow_multiple, is_required)
 VALUES
-(@demo_qid, @section_core, 'core_1', 'Overall performance against annual objectives', 'likert', 1, 25, 0, 1),
-(@demo_qid, @section_core, 'core_2', 'Completed mandatory compliance trainings', 'boolean', 2, 20, 0, 1),
-(@demo_qid, @section_goals, 'goal_1', 'Summarize the most significant accomplishment this period', 'text', 1, 15, 0, 1),
-(@demo_qid, @section_goals, 'goal_2', 'Select achieved stretch goals', 'choice', 2, 10, 1, 0),
-(@demo_qid, @section_dev, 'dev_1', 'Describe a development need for the next review', 'textarea', 1, 15, 0, 0),
-(@demo_qid, @section_dev, 'dev_2', 'Readiness for additional responsibilities', 'likert', 2, 15, 0, 0);
+(@demo_qid, @section_strategic, 'strategic_results', 'Delivery reliability to health facilities', 'likert', 1, 30, 0, 1),
+(@demo_qid, @section_operational, 'quality_controls', 'All mandatory compliance and safety trainings completed', 'boolean', 2, 15, 0, 1),
+(@demo_qid, @section_operational, 'achievement_story', 'Summarize the most significant contribution this cycle', 'textarea', 3, 20, 0, 1),
+(@demo_qid, @section_operational, 'stretch_contributions', 'Select notable stretch contributions achieved', 'choice', 4, 10, 1, 0),
+(@demo_qid, @section_growth, 'development_focus', 'Describe a development focus for the next cycle', 'textarea', 5, 15, 0, 1),
+(@demo_qid, @section_growth, 'mobility_readiness', 'Readiness for broader national responsibilities', 'likert', 6, 10, 0, 0);
 
 INSERT INTO questionnaire_item_option (questionnaire_item_id, value, order_index)
 SELECT qi.id, opt.value, opt.order_index
 FROM questionnaire_item qi
 JOIN (
-    SELECT 'core_1' AS linkId, '5 - Outstanding' AS value, 1 AS order_index UNION ALL
-    SELECT 'core_1', '4 - Exceeds Expectations', 2 UNION ALL
-    SELECT 'core_1', '3 - Meets Expectations', 3 UNION ALL
-    SELECT 'core_1', '2 - Needs Improvement', 4 UNION ALL
-    SELECT 'core_1', '1 - Unsatisfactory', 5 UNION ALL
-    SELECT 'dev_2', '5 - Ready to Lead Projects', 1 UNION ALL
-    SELECT 'dev_2', '4 - Ready for Advanced Tasks', 2 UNION ALL
-    SELECT 'dev_2', '3 - Solid in Current Role', 3 UNION ALL
-    SELECT 'dev_2', '2 - Requires Coaching', 4 UNION ALL
-    SELECT 'dev_2', '1 - Significant Development Needed', 5 UNION ALL
-    SELECT 'goal_2', 'Cross-functional project delivery', 1 UNION ALL
-    SELECT 'goal_2', 'Mentored junior colleagues', 2 UNION ALL
-    SELECT 'goal_2', 'Implemented process automation', 3 UNION ALL
-    SELECT 'goal_2', 'Improved customer satisfaction scores', 4 UNION ALL
-    SELECT 'goal_2', 'Reduced compliance incidents', 5
+    SELECT 'strategic_results' AS linkId, '5 - Consistently surpassing delivery targets' AS value, 1 AS order_index UNION ALL
+    SELECT 'strategic_results', '4 - Meeting and occasionally exceeding', 2 UNION ALL
+    SELECT 'strategic_results', '3 - Meeting baseline service levels', 3 UNION ALL
+    SELECT 'strategic_results', '2 - Frequent service gaps', 4 UNION ALL
+    SELECT 'strategic_results', '1 - Severe service gaps', 5 UNION ALL
+    SELECT 'mobility_readiness', '5 - Ready to lead national initiatives', 1 UNION ALL
+    SELECT 'mobility_readiness', '4 - Ready for large multi-region assignments', 2 UNION ALL
+    SELECT 'mobility_readiness', '3 - Ready for expanded responsibilities', 3 UNION ALL
+    SELECT 'mobility_readiness', '2 - Needs targeted coaching before expansion', 4 UNION ALL
+    SELECT 'mobility_readiness', '1 - Focus on current role stabilization', 5 UNION ALL
+    SELECT 'stretch_contributions', 'Piloted national stock visibility dashboard', 1 UNION ALL
+    SELECT 'stretch_contributions', 'Stood up emergency distribution cell', 2 UNION ALL
+    SELECT 'stretch_contributions', 'Mentored regional supply coordinators', 3 UNION ALL
+    SELECT 'stretch_contributions', 'Reduced financial variances across grants', 4 UNION ALL
+    SELECT 'stretch_contributions', 'Improved facility-level reporting compliance', 5 UNION ALL
+    SELECT 'stretch_contributions', 'Advanced leadership coaching for site managers', 6
 ) AS opt ON opt.linkId = qi.linkId
 WHERE qi.questionnaire_id = @demo_qid;
 
@@ -138,61 +177,138 @@ INSERT INTO questionnaire_work_function (questionnaire_id, work_function)
 SELECT @demo_qid, wf
 FROM (
     SELECT 'finance' AS wf UNION ALL
-    SELECT 'general_service' UNION ALL
+    SELECT 'quantification' UNION ALL
     SELECT 'hrm' UNION ALL
     SELECT 'ict' UNION ALL
-    SELECT 'leadership_tn' UNION ALL
-    SELECT 'legal_service' UNION ALL
-    SELECT 'pme' UNION ALL
-    SELECT 'quantification' UNION ALL
-    SELECT 'records_documentation' UNION ALL
-    SELECT 'security_driver' UNION ALL
+    SELECT 'general_service' UNION ALL
     SELECT 'security' UNION ALL
-    SELECT 'tmd' UNION ALL
-    SELECT 'wim' UNION ALL
-    SELECT 'cmd' UNION ALL
-    SELECT 'communication' UNION ALL
-    SELECT 'dfm' UNION ALL
     SELECT 'driver' UNION ALL
-    SELECT 'ethics'
+    SELECT 'pme' UNION ALL
+    SELECT 'wim' UNION ALL
+    SELECT 'records_documentation' UNION ALL
+    SELECT 'communication'
 ) AS functions;
 
 -- Assign questionnaire to demo staff --------------------------------------------
+SET @assignment_offset := 0;
 INSERT INTO questionnaire_assignment (staff_id, questionnaire_id, assigned_by, assigned_at)
 SELECT u.id,
        @demo_qid,
-       CASE WHEN u.work_function IN ('finance','hrm','legal_service','pme','quantification') THEN @demo_supervisor_id ELSE @demo_supervisor2_id END,
-       DATE_SUB(NOW(), INTERVAL (u.id % 12) DAY)
+       CASE
+           WHEN u.work_function IN ('finance', 'quantification', 'pme', 'records_documentation') THEN @demo_supply_lead_id
+           WHEN u.work_function IN ('hrm', 'communication') THEN @demo_people_lead_id
+           ELSE @demo_region_lead_id
+       END,
+       DATE_SUB(NOW(), INTERVAL (@assignment_offset := @assignment_offset + 1) DAY)
 FROM users u
-WHERE u.username LIKE 'demo_%' AND u.role = 'staff';
+WHERE u.username LIKE 'demo_%' AND u.role = 'staff'
+ORDER BY u.username;
 
--- Responses for 2024 (approved) and 2025 (submitted) ------------------------------
+-- Metadata describing each performance cycle ------------------------------------
+DROP TEMPORARY TABLE IF EXISTS tmp_demo_period_meta;
+CREATE TEMPORARY TABLE tmp_demo_period_meta (
+    label VARCHAR(4) PRIMARY KEY,
+    status ENUM('draft','submitted','approved','rejected') NOT NULL,
+    review_days INT NULL,
+    review_comment VARCHAR(255) NULL,
+    score_adjustment INT NOT NULL,
+    narrative_focus VARCHAR(255) NOT NULL,
+    dev_theme VARCHAR(255) NOT NULL
+);
+
+INSERT INTO tmp_demo_period_meta (label, status, review_days, review_comment, score_adjustment, narrative_focus, dev_theme)
+VALUES
+('2021', 'approved', 32, 'First Balanced Scorecard cycle closed with targeted coaching', 0, 'Stabilized last mile availability', 'Advance analytics and reporting capability'),
+('2022', 'approved', 27, 'Digital tracking adoption reached three new regions', 2, 'Expanded visibility for strategic stock items', 'Strengthen coaching skills for line managers'),
+('2023', 'approved', 21, 'Quality loops embedded with partners', 4, 'Reduced emergency orders and strengthened cold chain discipline', 'Deepen mentoring for regional leads'),
+('2024', 'approved', 15, 'Automation dashboards validated at headquarters', 6, 'Closed donor scorecard reporting gaps', 'Lead enterprise change management sprints'),
+('2025', 'submitted', NULL, NULL, 8, 'Piloting predictive demand planning prototypes', 'Document and scale knowledge transfer playbooks');
+
+-- Responses for 2021-2025 cycles -------------------------------------------------
 INSERT INTO questionnaire_response (user_id, questionnaire_id, performance_period_id, status, score, reviewed_by, reviewed_at, review_comment, created_at)
 SELECT u.id,
        @demo_qid,
        pp.id,
-       CASE WHEN pp.label = '2024' THEN 'approved' ELSE 'submitted' END,
+       pm.status,
        CASE
-           WHEN pp.label = '2024' THEN 70 + (u.id % 6) * 5
-           ELSE 60 + (u.id % 5) * 4
-       END,
-       CASE WHEN pp.label = '2024' THEN CASE WHEN u.work_function IN ('finance','hrm','legal_service','pme','quantification') THEN @demo_supervisor_id ELSE @demo_supervisor2_id END ELSE NULL END,
-       CASE WHEN pp.label = '2024' THEN DATE_SUB(NOW(), INTERVAL (u.id % 9 + 1) DAY) ELSE NULL END,
-       CASE WHEN pp.label = '2024' THEN CONCAT('Reviewed by supervisor for ', u.department) ELSE NULL END,
-       DATE_ADD(pp.period_start, INTERVAL (u.id % 20) DAY)
+           WHEN pm.status = 'approved' THEN LEAST(100,
+               80 + pm.score_adjustment +
+               CASE u.work_function
+                   WHEN 'finance' THEN 6
+                   WHEN 'quantification' THEN 5
+                   WHEN 'hrm' THEN 4
+                   WHEN 'ict' THEN 5
+                   WHEN 'general_service' THEN 3
+                   WHEN 'security' THEN 2
+                   WHEN 'driver' THEN 1
+                   WHEN 'pme' THEN 6
+                   WHEN 'wim' THEN 5
+                   WHEN 'records_documentation' THEN 4
+                   WHEN 'communication' THEN 4
+                   ELSE 3
+               END
+               - (u.id % 5)
+           )
+           ELSE NULL
+       END AS score,
+       CASE
+           WHEN pm.status = 'approved' THEN CASE
+               WHEN u.work_function IN ('finance', 'quantification', 'pme', 'records_documentation') THEN @demo_supply_lead_id
+               WHEN u.work_function IN ('hrm', 'communication') THEN @demo_people_lead_id
+               ELSE @demo_region_lead_id
+           END
+           ELSE NULL
+       END AS reviewed_by,
+       CASE
+           WHEN pm.status = 'approved' THEN DATE_SUB(NOW(), INTERVAL (pm.review_days + (u.id % 6)) DAY)
+           ELSE NULL
+       END AS reviewed_at,
+       CASE
+           WHEN pm.status = 'approved' THEN CONCAT(pm.review_comment, ' | Focus area: ',
+               CASE u.work_function
+                   WHEN 'finance' THEN 'Supply planning accuracy'
+                   WHEN 'quantification' THEN 'Forecast collaboration with donors'
+                   WHEN 'hrm' THEN 'Workforce wellbeing metrics'
+                   WHEN 'ict' THEN 'Systems interoperability and uptime'
+                   WHEN 'general_service' THEN 'Regional coordination discipline'
+                   WHEN 'security' THEN 'Risk mitigation readiness'
+                   WHEN 'driver' THEN 'Fleet adherence and coaching'
+                   WHEN 'pme' THEN 'Evidence packaging for partners'
+                   WHEN 'wim' THEN 'Laboratory mentorship coverage'
+                   WHEN 'records_documentation' THEN 'Knowledge capture routines'
+                   WHEN 'communication' THEN 'Stakeholder confidence storytelling'
+                   ELSE 'Cross functional contribution'
+               END)
+           ELSE NULL
+       END AS review_comment,
+       DATE_ADD(pp.period_start, INTERVAL (12 + (u.id % 16)) DAY) AS created_at
 FROM users u
-JOIN performance_period pp ON pp.label IN ('2024','2025')
-WHERE u.username LIKE 'demo_%' AND u.role = 'staff';
+JOIN tmp_demo_period_meta pm ON 1
+JOIN performance_period pp ON pp.label = pm.label
+WHERE u.username LIKE 'demo_%' AND u.role = 'staff'
+ORDER BY u.username, pp.label;
 
 -- Populate questionnaire response items -----------------------------------------
 INSERT INTO questionnaire_response_item (response_id, linkId, answer)
 SELECT qr.id,
-       'core_1',
+       'strategic_results',
        CASE
-           WHEN pp.label = '2024' AND u.work_function IN ('finance','hrm','legal_service') THEN '[{"valueInteger":5,"valueString":"5 - Outstanding"}]'
-           WHEN pp.label = '2024' AND u.work_function IN ('ict','communication','tmd','wim') THEN '[{"valueInteger":4,"valueString":"4 - Exceeds Expectations"}]'
-           WHEN pp.label = '2024' THEN '[{"valueInteger":3,"valueString":"3 - Meets Expectations"}]'
-           WHEN pp.label = '2025' THEN '[{"valueInteger":3,"valueString":"3 - Meets Expectations"}]'
+           WHEN qr.score >= 90 THEN '[{"valueInteger":5,"valueString":"5 - Consistently surpassing delivery targets"}]'
+           WHEN qr.score >= 84 THEN '[{"valueInteger":4,"valueString":"4 - Meeting and occasionally exceeding"}]'
+           WHEN qr.score IS NULL THEN '[{"valueInteger":4,"valueString":"4 - Meeting and occasionally exceeding"}]'
+           ELSE '[{"valueInteger":3,"valueString":"3 - Meeting baseline service levels"}]'
+       END
+FROM questionnaire_response qr
+WHERE qr.questionnaire_id = @demo_qid;
+
+INSERT INTO questionnaire_response_item (response_id, linkId, answer)
+SELECT qr.id,
+       'quality_controls',
+       CASE
+           WHEN pp.label = '2021' AND u.work_function IN ('driver', 'security') THEN '[{"valueBoolean":false}]'
+           WHEN pp.label = '2022' AND u.username = 'demo_field_gondar' THEN '[{"valueBoolean":false}]'
+           WHEN pp.label = '2025' AND u.username = 'demo_field_gondar' THEN '[{"valueBoolean":false}]'
+           ELSE '[{"valueBoolean":true}]'
        END
 FROM questionnaire_response qr
 JOIN users u ON u.id = qr.user_id
@@ -201,10 +317,44 @@ WHERE qr.questionnaire_id = @demo_qid;
 
 INSERT INTO questionnaire_response_item (response_id, linkId, answer)
 SELECT qr.id,
-       'core_2',
+       'achievement_story',
+       CONCAT('[{"valueString":"', pm.narrative_focus, ' within ', u.department, ' during ', pp.label, '."}]')
+FROM questionnaire_response qr
+JOIN users u ON u.id = qr.user_id
+JOIN performance_period pp ON pp.id = qr.performance_period_id
+JOIN tmp_demo_period_meta pm ON pm.label = pp.label
+WHERE qr.questionnaire_id = @demo_qid;
+
+INSERT INTO questionnaire_response_item (response_id, linkId, answer)
+SELECT qr.id,
+       'stretch_contributions',
        CASE
-           WHEN pp.label = '2024' THEN '[{"valueBoolean":true}]'
-           ELSE CASE WHEN u.id % 3 = 0 THEN '[{"valueBoolean":false}]' ELSE '[{"valueBoolean":true}]' END
+           WHEN u.work_function = 'finance' THEN CASE
+               WHEN pp.label IN ('2021', '2022') THEN '[{"valueString":"Reduced financial variances across grants"},{"valueString":"Improved facility-level reporting compliance"}]'
+               ELSE '[{"valueString":"Reduced financial variances across grants"},{"valueString":"Piloted national stock visibility dashboard"}]'
+           END
+           WHEN u.work_function = 'quantification' THEN CASE
+               WHEN pp.label IN ('2024', '2025') THEN '[{"valueString":"Piloted national stock visibility dashboard"},{"valueString":"Mentored regional supply coordinators"}]'
+               ELSE '[{"valueString":"Stood up emergency distribution cell"},{"valueString":"Improved facility-level reporting compliance"}]'
+           END
+           WHEN u.work_function = 'hrm' THEN '[{"valueString":"Mentored regional supply coordinators"},{"valueString":"Advanced leadership coaching for site managers"}]'
+           WHEN u.work_function = 'ict' THEN CASE
+               WHEN pp.label IN ('2023', '2024', '2025') THEN '[{"valueString":"Piloted national stock visibility dashboard"},{"valueString":"Advanced leadership coaching for site managers"}]'
+               ELSE '[{"valueString":"Piloted national stock visibility dashboard"},{"valueString":"Improved facility-level reporting compliance"}]'
+           END
+           WHEN u.work_function = 'general_service' THEN CASE
+               WHEN pp.label = '2021' THEN '[{"valueString":"Stood up emergency distribution cell"}]'
+               WHEN pp.label = '2025' THEN '[{"valueString":"Mentored regional supply coordinators"},{"valueString":"Improved facility-level reporting compliance"}]'
+               ELSE '[{"valueString":"Stood up emergency distribution cell"},{"valueString":"Mentored regional supply coordinators"}]'
+           END
+           WHEN u.work_function = 'security' THEN '[{"valueString":"Stood up emergency distribution cell"},{"valueString":"Improved facility-level reporting compliance"}]'
+           WHEN u.work_function = 'driver' THEN CASE
+               WHEN pp.label = '2021' THEN '[{"valueString":"Stood up emergency distribution cell"}]'
+               ELSE '[{"valueString":"Improved facility-level reporting compliance"}]'
+           END
+           WHEN u.work_function IN ('pme', 'wim', 'records_documentation') THEN '[{"valueString":"Mentored regional supply coordinators"},{"valueString":"Advanced leadership coaching for site managers"}]'
+           WHEN u.work_function = 'communication' THEN '[{"valueString":"Mentored regional supply coordinators"},{"valueString":"Improved facility-level reporting compliance"}]'
+           ELSE '[{"valueString":"Improved facility-level reporting compliance"}]'
        END
 FROM questionnaire_response qr
 JOIN users u ON u.id = qr.user_id
@@ -213,78 +363,87 @@ WHERE qr.questionnaire_id = @demo_qid;
 
 INSERT INTO questionnaire_response_item (response_id, linkId, answer)
 SELECT qr.id,
-       'goal_1',
-       CONCAT('[{"valueString":"',
-           CASE
-               WHEN pp.label = '2024' THEN 'Delivered key initiative for '
-               ELSE 'On track initiative for '
+       'development_focus',
+       CONCAT('[{"valueString":"', pm.dev_theme, ' focusing on ',
+           CASE u.work_function
+               WHEN 'finance' THEN 'data driven supply planning'
+               WHEN 'quantification' THEN 'collaborative forecasting'
+               WHEN 'hrm' THEN 'talent pipelines and wellbeing dashboards'
+               WHEN 'ict' THEN 'systems integration and analytics'
+               WHEN 'general_service' THEN 'regional coordination practices'
+               WHEN 'security' THEN 'risk mitigation playbooks'
+               WHEN 'driver' THEN 'fleet mentoring routines'
+               WHEN 'pme' THEN 'monitoring and evaluation storytelling'
+               WHEN 'wim' THEN 'laboratory quality mentorship'
+               WHEN 'records_documentation' THEN 'knowledge capture routines'
+               WHEN 'communication' THEN 'stakeholder engagement campaigns'
+               ELSE 'cross functional collaboration'
            END,
-           u.department,
-           '"}]')
+       '."}]')
 FROM questionnaire_response qr
 JOIN users u ON u.id = qr.user_id
 JOIN performance_period pp ON pp.id = qr.performance_period_id
+JOIN tmp_demo_period_meta pm ON pm.label = pp.label
 WHERE qr.questionnaire_id = @demo_qid;
 
 INSERT INTO questionnaire_response_item (response_id, linkId, answer)
 SELECT qr.id,
-       'goal_2',
+       'mobility_readiness',
        CASE
-           WHEN u.work_function IN ('finance','quantification') THEN '[{"valueString":"Reduced compliance incidents"},{"valueString":"Implemented process automation"}]'
-           WHEN u.work_function IN ('ict','communication') THEN '[{"valueString":"Implemented process automation"},{"valueString":"Cross-functional project delivery"}]'
-           WHEN u.work_function IN ('security','security_driver','driver') THEN '[{"valueString":"Reduced compliance incidents"}]'
-           ELSE '[{"valueString":"Mentored junior colleagues"},{"valueString":"Improved customer satisfaction scores"}]'
+           WHEN qr.score >= 92 THEN '[{"valueInteger":5,"valueString":"5 - Ready to lead national initiatives"}]'
+           WHEN qr.score >= 86 THEN '[{"valueInteger":4,"valueString":"4 - Ready for large multi-region assignments"}]'
+           WHEN qr.score IS NULL THEN CASE
+               WHEN u.work_function IN ('driver', 'security') THEN '[{"valueInteger":3,"valueString":"3 - Ready for expanded responsibilities"}]'
+               ELSE '[{"valueInteger":4,"valueString":"4 - Ready for large multi-region assignments"}]'
+           END
+           ELSE '[{"valueInteger":3,"valueString":"3 - Ready for expanded responsibilities"}]'
        END
 FROM questionnaire_response qr
 JOIN users u ON u.id = qr.user_id
-JOIN performance_period pp ON pp.id = qr.performance_period_id
 WHERE qr.questionnaire_id = @demo_qid;
 
-INSERT INTO questionnaire_response_item (response_id, linkId, answer)
-SELECT qr.id,
-       'dev_1',
-       CONCAT('[{"valueString":"Plan to enhance ', u.work_function, ' capabilities next quarter."}]')
-FROM questionnaire_response qr
-JOIN users u ON u.id = qr.user_id
-WHERE qr.questionnaire_id = @demo_qid;
-
-INSERT INTO questionnaire_response_item (response_id, linkId, answer)
-SELECT qr.id,
-       'dev_2',
-       CASE
-           WHEN pp.label = '2024' AND u.work_function IN ('leadership_tn','legal_service','cmd') THEN '[{"valueInteger":5,"valueString":"5 - Ready to Lead Projects"}]'
-           WHEN pp.label = '2024' AND u.work_function IN ('ict','communication','pme','quantification') THEN '[{"valueInteger":4,"valueString":"4 - Ready for Advanced Tasks"}]'
-           WHEN pp.label = '2024' THEN '[{"valueInteger":3,"valueString":"3 - Solid in Current Role"}]'
-           WHEN pp.label = '2025' AND u.id % 4 = 0 THEN '[{"valueInteger":2,"valueString":"2 - Requires Coaching"}]'
-           ELSE '[{"valueInteger":3,"valueString":"3 - Solid in Current Role"}]'
-       END
-FROM questionnaire_response qr
-JOIN users u ON u.id = qr.user_id
-JOIN performance_period pp ON pp.id = qr.performance_period_id
-WHERE qr.questionnaire_id = @demo_qid;
-
--- Training recommendations based on scores ---------------------------------------
+-- Training recommendations based on outcomes ------------------------------------
 INSERT INTO training_recommendation (questionnaire_response_id, course_id, recommendation_reason)
 SELECT qr.id,
        cc.id,
-       CONCAT('Score ', qr.score, ' suggests focus on ', cc.title)
+       CONCAT('Score ', qr.score, ' indicates value in ', cc.title)
 FROM questionnaire_response qr
 JOIN users u ON u.id = qr.user_id
 JOIN performance_period pp ON pp.id = qr.performance_period_id
 JOIN course_catalogue cc ON cc.code = CASE
-    WHEN u.work_function = 'finance' THEN 'DEMO-FIN-301'
-    WHEN u.work_function = 'ict' THEN 'DEMO-ICT-205'
-    WHEN u.work_function = 'hrm' THEN 'DEMO-HRM-260'
-    WHEN u.work_function = 'security' THEN 'DEMO-SEC-180'
-    WHEN u.work_function = 'leadership_tn' THEN 'DEMO-LEAD-400'
-    ELSE 'DEMO-GEN-120'
+    WHEN u.work_function = 'finance' THEN 'EPSA-FIN-410'
+    WHEN u.work_function = 'quantification' THEN 'EPSA-OPS-375'
+    WHEN u.work_function = 'hrm' THEN 'EPSA-HRM-215'
+    WHEN u.work_function = 'ict' THEN 'EPSA-ICT-320'
+    WHEN u.work_function = 'general_service' THEN 'EPSA-OPS-375'
+    WHEN u.work_function = 'security' THEN 'EPSA-SEC-190'
+    WHEN u.work_function = 'driver' THEN 'EPSA-DRV-220'
+    WHEN u.work_function IN ('pme', 'wim', 'records_documentation') THEN 'EPSA-MEL-360'
+    WHEN u.work_function = 'communication' THEN 'EPSA-COM-240'
+    ELSE 'EPSA-OPS-375'
 END
-WHERE qr.questionnaire_id = @demo_qid AND pp.label = '2024' AND qr.score < 90;
+WHERE qr.questionnaire_id = @demo_qid
+  AND qr.status = 'approved'
+  AND qr.score IS NOT NULL
+  AND qr.score < 90;
 
 -- Analytics report schedules -----------------------------------------------------
 INSERT INTO analytics_report_schedule (recipients, frequency, next_run_at, last_run_at, created_by, questionnaire_id, include_details, active)
 VALUES
-('demo.supervisor@example.com,demo.supervisor2@example.com', 'weekly', DATE_ADD(NOW(), INTERVAL 2 DAY), DATE_SUB(NOW(), INTERVAL 5 DAY), @demo_admin_id, @demo_qid, 1, 1),
-('executive@example.com', 'monthly', DATE_ADD(NOW(), INTERVAL 15 DAY), NULL, @demo_admin_id, @demo_qid, 0, 1);
+('demo.people.lead@example.com,demo.supply.lead@example.com', 'weekly', DATE_ADD(NOW(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 4 DAY), @demo_admin_id, @demo_qid, 1, 1),
+('executive.board@example.com', 'monthly', DATE_ADD(NOW(), INTERVAL 12 DAY), DATE_SUB(NOW(), INTERVAL 26 DAY), @demo_admin_id, @demo_qid, 0, 1),
+('regional.leads@example.com', 'quarterly', DATE_ADD(NOW(), INTERVAL 35 DAY), DATE_SUB(NOW(), INTERVAL 96 DAY), @demo_admin_id, @demo_qid, 1, 1);
 
--- End of comprehensive demo dataset ---------------------------------------------
+-- Additional logs capturing submission activities --------------------------------
+INSERT INTO logs (user_id, action, meta)
+SELECT qr.user_id,
+       'submit_review',
+       CONCAT('{"period":"', pp.label, '","status":"', qr.status, '"}')
+FROM questionnaire_response qr
+JOIN performance_period pp ON pp.id = qr.performance_period_id
+WHERE qr.questionnaire_id = @demo_qid
+  AND pp.label IN ('2024', '2025');
+
+DROP TEMPORARY TABLE IF EXISTS tmp_demo_period_meta;
+
+-- End of realistic demo dataset --------------------------------------------------


### PR DESCRIPTION
## Summary
- replace the random demo seed with a realistic five-year EPSA scenario featuring distinct admin, supervisor, and staff personas
- seed the annual performance review questionnaire, assignments, responses, training recommendations, and analytics schedules to reflect multi-year activity
- ensure performance periods for 2021-2025 exist and populate linked response items with narrative-rich content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6683d6dec832dad89b3d8c3acad99