### PR TITLE
Add branded header and logo to analytics PDF reports

### DIFF
--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -151,7 +151,12 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
 {
     $pdf = new SimplePdfDocument();
     $siteName = trim((string)($cfg['site_name'] ?? ''));
-    $title = ($siteName !== '' ? $siteName : 'HR Assessment') . ' Analytics Report';
+    $headerTitle = $siteName !== '' ? $siteName : 'HR Assessment';
+    $headerSubtitle = analytics_report_header_tagline($cfg);
+    $logoSpec = analytics_report_header_logo_spec($pdf, $cfg);
+    $pdf->setHeader($headerTitle, $headerSubtitle, $logoSpec);
+
+    $title = $headerTitle . ' Analytics Report';
     $pdf->addHeading($title);
 
     /** @var DateTimeImmutable $generatedAt */
@@ -222,6 +227,402 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
     }
 
     return $pdf->output();
+}
+
+function analytics_report_header_logo_spec(SimplePdfDocument $pdf, array $cfg): ?array
+{
+    $logoData = analytics_report_prepare_logo_payload($cfg);
+    if ($logoData === null) {
+        return null;
+    }
+
+    $imageName = $pdf->registerJpegImage($logoData['data'], $logoData['width'], $logoData['height']);
+    $dimensions = analytics_report_logo_display_dimensions($logoData['width'], $logoData['height']);
+
+    return [
+        'name' => $imageName,
+        'width' => $dimensions['width'],
+        'height' => $dimensions['height'],
+    ];
+}
+
+function analytics_report_prepare_logo_payload(array $cfg): ?array
+{
+    $paths = [];
+    if (function_exists('branding_logo_full_path')) {
+        $candidate = branding_logo_full_path($cfg['logo_path'] ?? null);
+        if (is_string($candidate) && $candidate !== '') {
+            $paths[] = $candidate;
+        }
+    } elseif (!empty($cfg['logo_path']) && function_exists('base_path')) {
+        $paths[] = base_path((string)$cfg['logo_path']);
+    }
+
+    foreach ($paths as $path) {
+        $payload = analytics_report_convert_image_file_to_jpeg($path);
+        if ($payload !== null) {
+            return $payload;
+        }
+    }
+
+    return analytics_report_generate_placeholder_logo($cfg);
+}
+
+function analytics_report_convert_image_file_to_jpeg(string $path): ?array
+{
+    if ($path === '' || !is_file($path)) {
+        return null;
+    }
+
+    $contents = @file_get_contents($path);
+    if ($contents === false) {
+        return null;
+    }
+
+    return analytics_report_convert_image_blob_to_jpeg($contents);
+}
+
+function analytics_report_convert_image_blob_to_jpeg(string $blob): ?array
+{
+    if (!function_exists('imagecreatefromstring') || !function_exists('imagecreatetruecolor') || !function_exists('imagejpeg')) {
+        return null;
+    }
+
+    $source = @imagecreatefromstring($blob);
+    if (!$source) {
+        return null;
+    }
+
+    $width = imagesx($source);
+    $height = imagesy($source);
+    if ($width <= 0 || $height <= 0) {
+        imagedestroy($source);
+        return null;
+    }
+
+    $canvas = imagecreatetruecolor($width, $height);
+    if (!$canvas) {
+        imagedestroy($source);
+        return null;
+    }
+
+    $background = imagecolorallocate($canvas, 255, 255, 255);
+    imagefilledrectangle($canvas, 0, 0, $width, $height, $background);
+    imagealphablending($canvas, true);
+    imagealphablending($source, true);
+    if (function_exists('imagesavealpha')) {
+        imagesavealpha($source, true);
+    }
+    imagecopy($canvas, $source, 0, 0, 0, 0, $width, $height);
+    imagedestroy($source);
+
+    return analytics_report_export_gd_image($canvas);
+}
+
+function analytics_report_export_gd_image($image): ?array
+{
+    if (!function_exists('imagejpeg')) {
+        return null;
+    }
+
+    $validImage = is_resource($image);
+    if (!$validImage && class_exists('GdImage', false)) {
+        $validImage = $image instanceof GdImage;
+    }
+
+    if (!$validImage) {
+        return null;
+    }
+
+    $width = imagesx($image);
+    $height = imagesy($image);
+    if ($width <= 0 || $height <= 0) {
+        imagedestroy($image);
+        return null;
+    }
+
+    ob_start();
+    $success = imagejpeg($image, null, 90);
+    $binary = ob_get_clean();
+    imagedestroy($image);
+
+    if (!$success || !is_string($binary) || $binary === '') {
+        return null;
+    }
+
+    return [
+        'data' => $binary,
+        'width' => $width,
+        'height' => $height,
+    ];
+}
+
+function analytics_report_generate_placeholder_logo(array $cfg): ?array
+{
+    if (!function_exists('imagecreatetruecolor') || !function_exists('imagejpeg')) {
+        return null;
+    }
+
+    $width = 420;
+    $height = 160;
+    $image = imagecreatetruecolor($width, $height);
+    if (!$image) {
+        return null;
+    }
+    imagealphablending($image, true);
+
+    $palette = analytics_report_palette_colors($cfg);
+    $primaryRgb = analytics_report_color_to_rgb($palette['primary']);
+    $accentRgb = analytics_report_color_to_rgb($palette['light']);
+    $borderRgb = analytics_report_color_to_rgb($palette['dark']);
+    $textHex = analytics_report_contrast_for_color($palette['primary']);
+    $textRgb = analytics_report_color_to_rgb($textHex);
+
+    $primaryColor = imagecolorallocate($image, $primaryRgb[0], $primaryRgb[1], $primaryRgb[2]);
+    $accentColor = imagecolorallocate($image, $accentRgb[0], $accentRgb[1], $accentRgb[2]);
+    $borderColor = imagecolorallocate($image, $borderRgb[0], $borderRgb[1], $borderRgb[2]);
+
+    imagefilledrectangle($image, 0, 0, $width, $height, $primaryColor);
+    imagefilledrectangle($image, 12, 12, $width - 12, $height - 12, $accentColor);
+    imagerectangle($image, 0, 0, $width - 1, $height - 1, $borderColor);
+
+    $initials = analytics_report_site_initials((string)($cfg['site_name'] ?? ''));
+    $fontPath = analytics_report_default_font_path();
+    if ($fontPath !== null && is_file($fontPath) && function_exists('imagettftext')) {
+        $fontSize = 72;
+        $maxWidth = $width - 80;
+        while ($fontSize > 32) {
+            $box = imagettfbbox($fontSize, 0, $fontPath, $initials);
+            if ($box !== false && analytics_report_ttf_box_width($box) <= $maxWidth) {
+                break;
+            }
+            $fontSize -= 4;
+        }
+
+        $box = imagettfbbox($fontSize, 0, $fontPath, $initials);
+        if ($box !== false) {
+            $textWidth = analytics_report_ttf_box_width($box);
+            $textHeight = analytics_report_ttf_box_height($box);
+            $textColor = imagecolorallocate($image, $textRgb[0], $textRgb[1], $textRgb[2]);
+            $offsetX = min($box[0], $box[2], $box[4], $box[6]);
+            $offsetY = min($box[5], $box[7], $box[1], $box[3]);
+            $x = (int)round(($width - $textWidth) / 2 - $offsetX);
+            $y = (int)round(($height + $textHeight) / 2 - $offsetY);
+            imagettftext($image, $fontSize, 0, $x, $y, $textColor, $fontPath, $initials);
+        }
+    } else {
+        $textColor = imagecolorallocate($image, $textRgb[0], $textRgb[1], $textRgb[2]);
+        $font = 5;
+        $textWidth = imagefontwidth($font) * strlen($initials);
+        $textHeight = imagefontheight($font);
+        $x = (int)round(($width - $textWidth) / 2);
+        $y = (int)round(($height - $textHeight) / 2);
+        imagestring($image, $font, $x, $y, $initials, $textColor);
+    }
+
+    return analytics_report_export_gd_image($image);
+}
+
+function analytics_report_logo_display_dimensions(int $pixelWidth, int $pixelHeight): array
+{
+    $maxWidth = 140.0;
+    $maxHeight = 72.0;
+    $minWidth = 72.0;
+    $displayWidth = max(1, $pixelWidth) * 0.35;
+    $displayHeight = max(1, $pixelHeight) * 0.35;
+
+    if ($displayWidth > $maxWidth) {
+        $scale = $maxWidth / $displayWidth;
+        $displayWidth = $maxWidth;
+        $displayHeight *= $scale;
+    }
+
+    if ($displayHeight > $maxHeight) {
+        $scale = $maxHeight / $displayHeight;
+        $displayHeight = $maxHeight;
+        $displayWidth *= $scale;
+    }
+
+    if ($displayWidth < $minWidth) {
+        $scale = $minWidth / max(0.1, $displayWidth);
+        $displayWidth = $minWidth;
+        $displayHeight *= $scale;
+        if ($displayHeight > $maxHeight) {
+            $scale = $maxHeight / $displayHeight;
+            $displayHeight = $maxHeight;
+            $displayWidth *= $scale;
+        }
+    }
+
+    return [
+        'width' => round($displayWidth, 2),
+        'height' => round($displayHeight, 2),
+    ];
+}
+
+function analytics_report_header_tagline(array $cfg): ?string
+{
+    $candidates = [
+        $cfg['landing_text'] ?? '',
+        $cfg['footer_org_name'] ?? '',
+        $cfg['footer_org_short'] ?? '',
+        $cfg['contact'] ?? '',
+        $cfg['address'] ?? '',
+    ];
+
+    foreach ($candidates as $candidate) {
+        $text = analytics_report_trim_text($candidate);
+        if ($text !== null) {
+            return $text;
+        }
+    }
+
+    return null;
+}
+
+function analytics_report_trim_text($value, int $limit = 140): ?string
+{
+    if (!is_string($value)) {
+        return null;
+    }
+
+    $normalized = preg_replace('/\s+/u', ' ', $value);
+    $trimmed = trim($normalized ?? '');
+    if ($trimmed === '') {
+        return null;
+    }
+
+    if (function_exists('mb_strlen') && function_exists('mb_substr')) {
+        if (mb_strlen($trimmed) > $limit) {
+            $trimmed = rtrim(mb_substr($trimmed, 0, $limit - 1)) . '…';
+        }
+    } elseif (strlen($trimmed) > $limit) {
+        $trimmed = rtrim(substr($trimmed, 0, $limit - 1)) . '…';
+    }
+
+    return $trimmed;
+}
+
+function analytics_report_site_initials(string $name): string
+{
+    $normalized = trim($name);
+    if ($normalized === '') {
+        return 'HR';
+    }
+
+    $parts = preg_split('/[^A-Za-z0-9]+/u', $normalized);
+    $initials = '';
+    if (is_array($parts)) {
+        foreach ($parts as $part) {
+            $piece = trim($part);
+            if ($piece === '') {
+                continue;
+            }
+            $initials .= function_exists('mb_strtoupper') ? mb_strtoupper(mb_substr($piece, 0, 1)) : strtoupper(substr($piece, 0, 1));
+            if ((function_exists('mb_strlen') ? mb_strlen($initials) : strlen($initials)) >= 3) {
+                break;
+            }
+        }
+    }
+
+    if ($initials === '') {
+        $initials = function_exists('mb_strtoupper') ? mb_strtoupper(mb_substr($normalized, 0, 2)) : strtoupper(substr($normalized, 0, 2));
+    }
+
+    return function_exists('mb_substr') ? mb_substr($initials, 0, 3) : substr($initials, 0, 3);
+}
+
+function analytics_report_palette_colors(array $cfg): array
+{
+    $defaults = [
+        'primary' => '#2073bf',
+        'light' => '#4d94d8',
+        'dark' => '#155a94',
+    ];
+
+    if (function_exists('site_brand_palette')) {
+        try {
+            $palette = site_brand_palette($cfg);
+            if (is_array($palette)) {
+                $defaults['primary'] = $palette['primary'] ?? $defaults['primary'];
+                $defaults['light'] = $palette['primaryLight'] ?? ($palette['secondary'] ?? $defaults['light']);
+                $defaults['dark'] = $palette['primaryDark'] ?? $defaults['dark'];
+            }
+        } catch (Throwable $e) {
+            // ignore palette errors and use defaults
+        }
+    }
+
+    return $defaults;
+}
+
+function analytics_report_color_to_rgb(string $hex): array
+{
+    $value = trim($hex);
+    if ($value === '') {
+        return [0, 0, 0];
+    }
+
+    if ($value[0] === '#') {
+        $value = substr($value, 1);
+    }
+
+    if (strlen($value) === 3) {
+        $value = $value[0] . $value[0] . $value[1] . $value[1] . $value[2] . $value[2];
+    }
+
+    if (strlen($value) !== 6 || preg_match('/[^0-9a-fA-F]/', $value)) {
+        return [0, 0, 0];
+    }
+
+    return [
+        hexdec(substr($value, 0, 2)),
+        hexdec(substr($value, 2, 2)),
+        hexdec(substr($value, 4, 2)),
+    ];
+}
+
+function analytics_report_contrast_for_color(string $hex): string
+{
+    if (function_exists('contrast_color')) {
+        try {
+            return contrast_color($hex);
+        } catch (Throwable $e) {
+            // ignore and use manual fallback
+        }
+    }
+
+    $rgb = analytics_report_color_to_rgb($hex);
+    $luminance = 0.2126 * $rgb[0] + 0.7152 * $rgb[1] + 0.0722 * $rgb[2];
+    return $luminance > 140 ? '#000000' : '#FFFFFF';
+}
+
+function analytics_report_default_font_path(): ?string
+{
+    $candidates = [
+        '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+        '/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf',
+    ];
+
+    foreach ($candidates as $candidate) {
+        if (is_string($candidate) && is_file($candidate)) {
+            return $candidate;
+        }
+    }
+
+    return null;
+}
+
+function analytics_report_ttf_box_width(array $box): float
+{
+    $xs = [$box[0], $box[2], $box[4], $box[6]];
+    return max($xs) - min($xs);
+}
+
+function analytics_report_ttf_box_height(array $box): float
+{
+    $ys = [$box[1], $box[3], $box[5], $box[7]];
+    return max($ys) - min($ys);
 }
 
 function analytics_report_format_number($value): string


### PR DESCRIPTION
## Summary
- add configurable header support to the simple PDF generator and ensure each page reserves A4 dimensions
- embed the configured branding logo (or a generated fallback) alongside the site tagline in analytics report PDFs
- keep text content flowing beneath the new header so exported reports remain within the printable page area

## Testing
- php -l lib/simple_pdf.php
- php -l lib/analytics_report.php
- php -r 'require_once "lib/analytics_report.php"; /* build sample snapshot */'


------
https://chatgpt.com/codex/tasks/task_e_68f799d96860832d99ee1ef88035c6a7