### PR TITLE
Fix performance timeline ordering and analytics heatmaps

### DIFF
--- a/my_performance.php
+++ b/my_performance.php
@@ -282,7 +282,22 @@ $belowThreshold = array_values(array_filter($rows, static function ($row) {
 
 $chartLabels = [];
 $chartScores = [];
-foreach ($rows as $row) {
+$timelineRows = $rows;
+usort($timelineRows, static function (array $a, array $b): int {
+    $aTime = isset($a['created_at']) ? strtotime((string)$a['created_at']) : false;
+    $bTime = isset($b['created_at']) ? strtotime((string)$b['created_at']) : false;
+    if ($aTime === $bTime) {
+        return (int)($a['id'] ?? 0) <=> (int)($b['id'] ?? 0);
+    }
+    if ($aTime === false) {
+        return -1;
+    }
+    if ($bTime === false) {
+        return 1;
+    }
+    return $aTime <=> $bTime;
+});
+foreach ($timelineRows as $row) {
     $chartLabels[] = date('Y-m-d', strtotime($row['created_at'])) . ' · ' . $row['period_label'];
     $chartScores[] = $row['score'] !== null ? (int)$row['score'] : null;
 }


### PR DESCRIPTION
## Summary
- ensure the My Performance timeline feeds Chart.js with chronologically sorted rows so the x-axis progresses from the earliest assessment
- make the Analytics heatmaps compatible with both modern and legacy Chart.js builds so the bar charts render reliably with tooltips

## Testing
- php -l my_performance.php
- php -l admin/analytics.php

------
https://chatgpt.com/codex/tasks/task_e_68f79cea617c832da28d5dd15ff160a6