### PR TITLE
Enhance login page layout and styling

### DIFF
--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -509,6 +509,233 @@ body.md-bg {
   overflow: visible;
 }
 
+body.md-login-page {
+  background:
+    radial-gradient(140% 140% at 15% 20%, color-mix(in srgb, var(--md-primary) 18%, transparent) 0%, transparent 72%),
+    radial-gradient(120% 120% at 85% 5%, color-mix(in srgb, var(--md-accent) 14%, transparent) 0%, transparent 74%),
+    color-mix(in srgb, var(--md-bg) 78%, #0f172a 22%);
+  color: var(--app-text, inherit);
+}
+
+body.md-login-page .md-container {
+  background: transparent;
+  align-items: stretch;
+  padding: clamp(2rem, 6vw, 4rem);
+}
+
+body.md-login-page .md-container::before {
+  opacity: 0.85;
+  mix-blend-mode: screen;
+}
+
+body.md-login-page .md-container::after {
+  content: "";
+  position: absolute;
+  inset: auto -18% -32% auto;
+  width: clamp(18rem, 32vw, 34rem);
+  height: clamp(18rem, 32vw, 34rem);
+  background: radial-gradient(circle at center, color-mix(in srgb, var(--md-primary) 32%, transparent) 0%, transparent 70%);
+  opacity: 0.32;
+  z-index: 0;
+}
+
+body.md-login-page .md-login {
+  max-width: 1080px;
+}
+
+body.md-login-page .md-login-grid {
+  position: relative;
+  z-index: 1;
+  background: color-mix(in srgb, var(--md-surface) 92%, transparent);
+  backdrop-filter: blur(26px);
+  border: 1px solid color-mix(in srgb, var(--app-border) 65%, transparent);
+  box-shadow: 0 32px 80px color-mix(in srgb, var(--app-shadow-soft) 85%, transparent);
+}
+
+body.md-login-page .md-login-panel--brand {
+  position: relative;
+  overflow: hidden;
+}
+
+body.md-login-page .md-login-panel--brand::before,
+body.md-login-page .md-login-panel--brand::after {
+  content: "";
+  position: absolute;
+  inset: auto;
+  border-radius: 999px;
+  pointer-events: none;
+  opacity: 0.35;
+  filter: blur(0);
+  mix-blend-mode: screen;
+}
+
+body.md-login-page .md-login-panel--brand::before {
+  width: clamp(12rem, 20vw, 18rem);
+  height: clamp(12rem, 20vw, 18rem);
+  top: -10%;
+  right: -8%;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.4) 0%, transparent 70%);
+}
+
+body.md-login-page .md-login-panel--brand::after {
+  width: clamp(16rem, 26vw, 24rem);
+  height: clamp(16rem, 26vw, 24rem);
+  bottom: -18%;
+  left: -15%;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.32) 0%, transparent 72%);
+}
+
+body.md-login-page .md-login-panel--brand > * {
+  position: relative;
+  z-index: 1;
+}
+
+body.md-login-page .md-login-panel--form {
+  background: color-mix(in srgb, var(--md-surface) 96%, transparent);
+  border-left: 1px solid color-mix(in srgb, var(--app-border) 60%, transparent);
+}
+
+.md-login-brand-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: center;
+  align-items: center;
+}
+
+.md-login-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.42);
+  background: rgba(255, 255, 255, 0.18);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: inherit;
+}
+
+.md-login-benefits {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  width: min(100%, 24rem);
+}
+
+.md-login-benefits li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.md-login-benefit-bullet {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.15);
+  margin-top: 0.25rem;
+}
+
+.md-login-form-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: min(100%, 420px);
+  margin: 0 auto;
+}
+
+.md-login-form-header {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.md-login-form-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--md-primary) 80%, #ffffff 20%);
+  background: color-mix(in srgb, var(--md-primary) 18%, transparent);
+  width: max-content;
+}
+
+.md-login-form-title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.2vw, 2.05rem);
+  color: var(--app-heading, var(--md-primary-dark));
+}
+
+.md-login-form-subtitle {
+  margin: 0;
+  color: var(--app-text-secondary, var(--md-muted));
+  font-size: 0.95rem;
+  line-height: 1.7;
+}
+
+body.md-login-page .md-alert.error {
+  border-radius: var(--md-radius);
+  border: 1px solid color-mix(in srgb, var(--status-error) 45%, transparent);
+  background: color-mix(in srgb, var(--status-error-soft) 65%, transparent);
+}
+
+body.md-login-page .md-login-divider {
+  color: var(--app-text-secondary, var(--md-muted));
+}
+
+body.md-login-page .md-login-footer {
+  border-top-color: color-mix(in srgb, var(--app-border) 65%, transparent);
+}
+
+body.md-login-page .md-login-footer-label {
+  color: color-mix(in srgb, var(--app-text-secondary) 92%, var(--md-muted) 8%);
+}
+
+body.md-login-page .md-login-footer-value {
+  color: color-mix(in srgb, var(--app-text-secondary) 88%, var(--md-muted) 12%);
+}
+
+@media (max-width: 767px) {
+  body.md-login-page .md-login-grid {
+    backdrop-filter: blur(18px);
+  }
+
+  .md-login-form-body {
+    width: 100%;
+  }
+}
+
+@media (min-width: 768px) {
+  .md-login--split .md-login-brand-inner {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .md-login--split .md-login-benefits {
+    width: min(100%, 22rem);
+  }
+}
+
+@media (min-width: 1024px) {
+  .md-login-form-body {
+    width: min(100%, 460px);
+  }
+}
+
 .md-card-media {
   display: flex;
   align-items: center;

--- a/login.php
+++ b/login.php
@@ -78,7 +78,8 @@ $landingTextRaw = $cfg['landing_text'] ?? '';
 $landingText = htmlspecialchars($landingTextRaw, ENT_QUOTES, 'UTF-8');
 $address = htmlspecialchars($cfg['address'] ?? '', ENT_QUOTES, 'UTF-8');
 $contact = htmlspecialchars($cfg['contact'] ?? '', ENT_QUOTES, 'UTF-8');
-$bodyClass = htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8');
+$bodyClassRaw = trim(site_body_classes($cfg) . ' md-login-page');
+$bodyClass = htmlspecialchars($bodyClassRaw, ENT_QUOTES, 'UTF-8');
 $bodyStyle = htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8');
 $baseUrl = htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8');
 $langAttr = htmlspecialchars($locale, ENT_QUOTES, 'UTF-8');
@@ -95,6 +96,19 @@ $introText = $landingText !== ''
         'UTF-8'
     );
 $languageLabel = htmlspecialchars(t($t, 'language_label', 'Language'), ENT_QUOTES, 'UTF-8');
+$brandBadge = t($t, 'login_brand_badge', 'Employee Success Platform');
+$signInBadge = t($t, 'sign_in_badge', 'Secure sign-in');
+$signInHeading = t($t, 'sign_in_heading', 'Welcome back');
+$signInSubheading = t(
+    $t,
+    'sign_in_subheading',
+    'Use your credentials to continue to your personalized workspace.'
+);
+$benefits = array_values(array_filter(array_map('trim', [
+    t($t, 'login_benefit_assess', 'Assess strengths and opportunities with guided check-ins.'),
+    t($t, 'login_benefit_visualize', 'Visualize growth trends with intuitive dashboards.'),
+    t($t, 'login_benefit_collaborate', 'Collaborate on goals with your manager in one place.'),
+])));
 ?>
 <!doctype html>
 <html lang="<?= $langAttr ?>" data-base-url="<?= $baseUrl ?>">
@@ -116,80 +130,107 @@ $languageLabel = htmlspecialchars(t($t, 'language_label', 'Language'), ENT_QUOTE
     <div class="md-card md-elev-3 md-login md-login--split">
       <div class="md-login-grid">
         <section class="md-login-panel md-login-panel--brand">
-          <img src="<?= $logo ?>" alt="<?= $logoAlt ?>" class="md-logo">
-          <h1 class="md-title"><?= $siteName ?></h1>
-          <?php if ($introText !== ''): ?>
-            <p class="md-login-tagline"><?= $introText ?></p>
-          <?php endif; ?>
+          <div class="md-login-brand-inner">
+            <?php if (trim($brandBadge) !== ''): ?>
+              <span class="md-login-badge"><?= htmlspecialchars($brandBadge, ENT_QUOTES, 'UTF-8') ?></span>
+            <?php endif; ?>
+            <img src="<?= $logo ?>" alt="<?= $logoAlt ?>" class="md-logo">
+            <h1 class="md-title"><?= $siteName ?></h1>
+            <?php if ($introText !== ''): ?>
+              <p class="md-login-tagline"><?= $introText ?></p>
+            <?php endif; ?>
+            <?php if (!empty($benefits)): ?>
+              <ul class="md-login-benefits" role="list">
+                <?php foreach ($benefits as $benefit): ?>
+                  <li>
+                    <span class="md-login-benefit-bullet" aria-hidden="true"></span>
+                    <span><?= htmlspecialchars($benefit, ENT_QUOTES, 'UTF-8') ?></span>
+                  </li>
+                <?php endforeach; ?>
+              </ul>
+            <?php endif; ?>
+          </div>
         </section>
         <section class="md-login-panel md-login-panel--form">
-          <?php if ($err !== ''): ?>
-            <div class="md-alert error"><?= htmlspecialchars($err, ENT_QUOTES, 'UTF-8') ?></div>
-          <?php endif; ?>
+          <div class="md-login-form-body">
+            <header class="md-login-form-header">
+              <?php if (trim($signInBadge) !== ''): ?>
+                <span class="md-login-form-badge"><?= htmlspecialchars($signInBadge, ENT_QUOTES, 'UTF-8') ?></span>
+              <?php endif; ?>
+              <h2 class="md-login-form-title"><?= htmlspecialchars($signInHeading, ENT_QUOTES, 'UTF-8') ?></h2>
+              <?php if (trim($signInSubheading) !== ''): ?>
+                <p class="md-login-form-subtitle"><?= htmlspecialchars($signInSubheading, ENT_QUOTES, 'UTF-8') ?></p>
+              <?php endif; ?>
+            </header>
 
-          <form
-            method="post"
-            class="md-form md-login-form"
-            action="<?= htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8') ?>"
-            data-offline-redirect="<?= htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8') ?>"
-            data-offline-unavailable="<?= htmlspecialchars(t($t, 'offline_login_unavailable', 'Offline login is not available yet. Connect to the internet and sign in once to enable offline access.'), ENT_QUOTES, 'UTF-8') ?>"
-            data-offline-invalid="<?= htmlspecialchars(t($t, 'offline_login_invalid', 'Offline sign-in failed. Double-check your username and password.'), ENT_QUOTES, 'UTF-8') ?>"
-            data-offline-error="<?= htmlspecialchars(t($t, 'offline_login_error', 'We could not complete offline sign-in. Try again when you have a connection.'), ENT_QUOTES, 'UTF-8') ?>"
-            data-offline-warm-routes="<?= htmlspecialchars(implode(',', [
-              url_for('my_performance.php'),
-              url_for('submit_assessment.php'),
-              url_for('profile.php'),
-              url_for('dashboard.php'),
-            ]), ENT_QUOTES, 'UTF-8') ?>"
-          >
-            <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
-            <label class="md-field">
-              <span><?= t($t, 'username', 'Username') ?></span>
-              <input name="username" autocomplete="username" required>
-            </label>
-            <label class="md-field">
-              <span><?= t($t, 'password', 'Password') ?></span>
-              <input type="password" name="password" autocomplete="current-password" required>
-            </label>
-            <div class="md-form-actions md-form-actions--center md-login-actions">
-              <button class="md-button md-primary md-elev-2" type="submit">
-                <?= t($t, 'sign_in', 'Sign In') ?>
-              </button>
-            </div>
-          </form>
-
-          <?php if (!empty($oauthProviders)): ?>
-            <div class="md-login-divider"><span><?= htmlspecialchars(t($t, 'or_continue_with', 'or continue with'), ENT_QUOTES, 'UTF-8') ?></span></div>
-            <div class="md-sso-buttons">
-              <?php foreach ($oauthProviders as $provider => $label): ?>
-                <a
-                  class="md-button md-elev-1 md-sso-btn <?= htmlspecialchars($provider, ENT_QUOTES, 'UTF-8') ?>"
-                  href="<?= htmlspecialchars(url_for('oauth.php?provider=' . $provider), ENT_QUOTES, 'UTF-8') ?>"
-                ><?= $label ?></a>
-              <?php endforeach; ?>
-            </div>
-          <?php endif; ?>
-
-          <div class="md-login-footer">
-            <?php if ($address !== ''): ?>
-              <div class="md-login-footer-item">
-                <span class="md-login-footer-label"><?= t($t, 'address_label', 'Address') ?></span>
-                <span class="md-login-footer-value"><?= $address ?></span>
-              </div>
+            <?php if ($err !== ''): ?>
+              <div class="md-alert error" role="alert"><?= htmlspecialchars($err, ENT_QUOTES, 'UTF-8') ?></div>
             <?php endif; ?>
-            <?php if ($contact !== ''): ?>
-              <div class="md-login-footer-item">
-                <span class="md-login-footer-label"><?= t($t, 'contact_label', 'Contact') ?></span>
-                <span class="md-login-footer-value"><?= $contact ?></span>
+
+            <form
+              method="post"
+              class="md-form md-login-form"
+              action="<?= htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8') ?>"
+              data-offline-redirect="<?= htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8') ?>"
+              data-offline-unavailable="<?= htmlspecialchars(t($t, 'offline_login_unavailable', 'Offline login is not available yet. Connect to the internet and sign in once to enable offline access.'), ENT_QUOTES, 'UTF-8') ?>"
+              data-offline-invalid="<?= htmlspecialchars(t($t, 'offline_login_invalid', 'Offline sign-in failed. Double-check your username and password.'), ENT_QUOTES, 'UTF-8') ?>"
+              data-offline-error="<?= htmlspecialchars(t($t, 'offline_login_error', 'We could not complete offline sign-in. Try again when you have a connection.'), ENT_QUOTES, 'UTF-8') ?>"
+              data-offline-warm-routes="<?= htmlspecialchars(implode(',', [
+                url_for('my_performance.php'),
+                url_for('submit_assessment.php'),
+                url_for('profile.php'),
+                url_for('dashboard.php'),
+              ]), ENT_QUOTES, 'UTF-8') ?>"
+            >
+              <input type="hidden" name="csrf" value="<?= csrf_token() ?>">
+              <label class="md-field">
+                <span><?= t($t, 'username', 'Username') ?></span>
+                <input name="username" autocomplete="username" required>
+              </label>
+              <label class="md-field">
+                <span><?= t($t, 'password', 'Password') ?></span>
+                <input type="password" name="password" autocomplete="current-password" required>
+              </label>
+              <div class="md-form-actions md-form-actions--center md-login-actions">
+                <button class="md-button md-primary md-elev-2" type="submit">
+                  <?= t($t, 'sign_in', 'Sign In') ?>
+                </button>
               </div>
-            <?php endif; ?>
-            <div class="md-login-footer-item">
-              <span class="md-login-footer-label"><?= $languageLabel ?></span>
-              <nav class="md-login-footer-value md-login-footer-locale lang-switch" aria-label="<?= $languageLabel ?>">
-                <?php foreach ($availableLocales as $loc): ?>
-                  <a href="<?= htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars(strtoupper($loc), ENT_QUOTES, 'UTF-8') ?></a>
+            </form>
+
+            <?php if (!empty($oauthProviders)): ?>
+              <div class="md-login-divider"><span><?= htmlspecialchars(t($t, 'or_continue_with', 'or continue with'), ENT_QUOTES, 'UTF-8') ?></span></div>
+              <div class="md-sso-buttons">
+                <?php foreach ($oauthProviders as $provider => $label): ?>
+                  <a
+                    class="md-button md-elev-1 md-sso-btn <?= htmlspecialchars($provider, ENT_QUOTES, 'UTF-8') ?>"
+                    href="<?= htmlspecialchars(url_for('oauth.php?provider=' . $provider), ENT_QUOTES, 'UTF-8') ?>"
+                  ><?= $label ?></a>
                 <?php endforeach; ?>
-              </nav>
+              </div>
+            <?php endif; ?>
+
+            <div class="md-login-footer">
+              <?php if ($address !== ''): ?>
+                <div class="md-login-footer-item">
+                  <span class="md-login-footer-label"><?= t($t, 'address_label', 'Address') ?></span>
+                  <span class="md-login-footer-value"><?= $address ?></span>
+                </div>
+              <?php endif; ?>
+              <?php if ($contact !== ''): ?>
+                <div class="md-login-footer-item">
+                  <span class="md-login-footer-label"><?= t($t, 'contact_label', 'Contact') ?></span>
+                  <span class="md-login-footer-value"><?= $contact ?></span>
+                </div>
+              <?php endif; ?>
+              <div class="md-login-footer-item">
+                <span class="md-login-footer-label"><?= $languageLabel ?></span>
+                <nav class="md-login-footer-value md-login-footer-locale lang-switch" aria-label="<?= $languageLabel ?>">
+                  <?php foreach ($availableLocales as $loc): ?>
+                    <a href="<?= htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars(strtoupper($loc), ENT_QUOTES, 'UTF-8') ?></a>
+                  <?php endforeach; ?>
+                </nav>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Refresh the login layout with a branded header, benefits list, and welcoming copy
- Apply a richer background treatment and refined styling for the split panels and form content

## Testing
- php -l login.php

------
https://chatgpt.com/codex/tasks/task_e_68f7f61c08cc832d88853c60fe09058b