### PR TITLE
Improve upgrade UX and reliability

### DIFF
--- a/admin/download_backup.php
+++ b/admin/download_backup.php
@@ -1,0 +1,29 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/upgrade.php';
+
+auth_required(['admin']);
+
+$filename = trim((string)($_GET['file'] ?? ''));
+if ($filename === '') {
+    http_response_code(400);
+    echo 'Invalid backup request.';
+    exit;
+}
+
+$resolvedPath = upgrade_resolve_manual_backup_path($filename);
+if ($resolvedPath === null || !is_file($resolvedPath)) {
+    http_response_code(404);
+    echo 'Backup not found.';
+    exit;
+}
+
+try {
+    upgrade_stream_download($resolvedPath, $filename);
+} catch (Throwable $e) {
+    error_log('Manual backup download failed: ' . $e->getMessage());
+    if (!headers_sent()) {
+        http_response_code(500);
+    }
+    echo 'Unable to download the requested backup file.';
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2017,19 +2017,19 @@ body.theme-dark .md-button.md-primary {
 
 @media (min-width: 768px) {
   .md-upgrade-config {
-    max-width: 720px;
+    max-width: 100%;
   }
 }
 
 .md-upgrade-actions {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: 0.75rem;
 }
 
 .md-upgrade-meta {
   font-size: 0.85rem;
-  color: var(--app-muted-light);
+  color: var(--app-on-surface-muted);
+  line-height: 1.5;
 }
 
 .md-status-badge {
@@ -2068,6 +2068,108 @@ body.theme-dark .md-button.md-primary {
   text-decoration: none;
 }
 
+.md-button-block {
+  width: 100%;
+  justify-content: center;
+}
+
+.md-upgrade-header {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+.md-upgrade-item {
+  background: var(--app-surface-muted);
+  border: 1px solid var(--app-border);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  box-shadow: 0 12px 28px rgba(31, 42, 68, 0.08);
+}
+
+.md-upgrade-item-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--app-muted);
+}
+
+.md-upgrade-item-value {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--app-on-surface-strong);
+}
+
+.md-upgrade-tag {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: var(--app-primary-soft);
+  color: var(--app-primary-dark);
+  font-weight: 600;
+}
+
+.md-upgrade-link {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.md-upgrade-link:hover,
+.md-upgrade-link:focus {
+  text-decoration: none;
+}
+
+.md-upgrade-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 900px) {
+  .md-upgrade-grid {
+    grid-template-columns: minmax(260px, 1.1fr) minmax(220px, 1fr);
+  }
+}
+
+.md-upgrade-panel {
+  background: var(--app-surface-muted);
+  border: 1px solid var(--app-border);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 16px 32px rgba(31, 42, 68, 0.08);
+}
+
+.md-upgrade-panel-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--app-on-surface-strong);
+}
+
+.md-upgrade-field-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--app-on-surface-muted);
+  margin-bottom: 0.35rem;
+}
+
+.md-upgrade-config {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
 .md-upgrade-actions form {
-  display: inline-flex;
+  display: flex;
 }

--- a/lang/am.json
+++ b/lang/am.json
@@ -384,6 +384,8 @@
   "upgrade_failed": "The upgrade could not be completed. Review the logs and database permissions, then try again.",
   "upgrade_hint": "Ensure a recent backup has been downloaded before applying upgrades.",
   "upgrade_hint_script": "The upgrade script automatically creates backups before applying changes. Download manual backups whenever you need an extra copy.",
+  "upgrade_actions_heading": "Upgrade actions",
+  "upgrade_installed_at": "Installed on %s",
   "upgrade_latest": "You are already on the latest version.",
   "upgrade_command_success": "Upgrade command completed successfully. Review the logs for details.",
   "upgrade_command_failed": "The upgrade command returned a non-zero exit code. Review the log for details.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -370,6 +370,8 @@
   "upgrade_failed": "The upgrade could not be completed. Review the logs and database permissions, then try again.",
   "upgrade_hint": "Ensure a recent backup has been downloaded before applying upgrades.",
   "upgrade_hint_script": "The upgrade script automatically creates backups before applying changes. Download manual backups whenever you need an extra copy.",
+  "upgrade_actions_heading": "Upgrade actions",
+  "upgrade_installed_at": "Installed on %s",
   "upgrade_latest": "You are already on the latest version.",
   "upgrade_command_success": "Upgrade command completed successfully. Review the logs for details.",
   "upgrade_command_failed": "The upgrade command returned a non-zero exit code. Review the log for details.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -384,6 +384,8 @@
   "upgrade_failed": "The upgrade could not be completed. Review the logs and database permissions, then try again.",
   "upgrade_hint": "Ensure a recent backup has been downloaded before applying upgrades.",
   "upgrade_hint_script": "Le script de mise à jour crée automatiquement des sauvegardes avant d'appliquer les modifications. Téléchargez des sauvegardes manuelles lorsque vous avez besoin d'une copie supplémentaire.",
+  "upgrade_actions_heading": "Actions de mise à jour",
+  "upgrade_installed_at": "Installé le %s",
   "upgrade_latest": "You are already on the latest version.",
   "upgrade_command_success": "La commande de mise à jour s'est terminée avec succès. Consultez les journaux pour plus de détails.",
   "upgrade_command_failed": "La commande de mise à jour a retourné un code de sortie non nul. Consultez le journal pour plus de détails.",


### PR DESCRIPTION
## Summary
- fetch and persist the currently installed release so the dashboard shows accurate GitHub version metadata
- move manual backups into a dedicated directory with a secure download endpoint and improved database export fallback when CLI tools are unavailable
- refresh the upgrade panel layout with higher contrast styling and streamlined action buttons

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68f7fb135794832db53ec84b741458d0