### PR TITLE
Prevent forwarding untrusted absolute redirects

### DIFF
--- a/config.php
+++ b/config.php
@@ -302,7 +302,7 @@ function require_profile_completion(PDO $pdo, string $redirect = 'profile.php'):
     $target = $defaultTarget;
 
     if ($redirectString !== '') {
-        $candidate = $redirectString;
+        $candidate = null;
         $parsedRedirect = $parsedRedirect === false ? null : $parsedRedirect;
         $hasScheme = is_array($parsedRedirect) && isset($parsedRedirect['scheme']) && $parsedRedirect['scheme'] !== '';
 


### PR DESCRIPTION
## Summary
- initialize the profile completion redirect candidate to null so untrusted absolute URLs cannot leak through when validation fails

## Testing
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_6903ac9c4b50832dac371cbf5e89847e