### PR TITLE
Add tooltip help icons for settings and profile hints

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -190,17 +190,21 @@ try {
         </select>
       </label>
       <label class="md-field md-field-inline">
-        <span><?=t($t,'brand_color','Brand Color')?></span>
+        <span>
+          <?=t($t,'brand_color','Brand Color')?>
+          <?=render_help_icon(t($t,'brand_color_hint','Pick any brand color to personalize buttons, highlights, and gradients.'))?>
+        </span>
         <div class="md-color-picker" data-brand-color-picker data-default-color="<?=htmlspecialchars(site_default_brand_color($cfg), ENT_QUOTES, 'UTF-8')?>">
           <input type="color" name="brand_color" value="<?=htmlspecialchars(site_brand_color($cfg), ENT_QUOTES, 'UTF-8')?>" aria-label="<?=t($t,'brand_color_picker','Choose a brand color')?>">
           <span class="md-color-value"><?=htmlspecialchars(strtoupper(site_brand_color($cfg)), ENT_QUOTES, 'UTF-8')?></span>
           <button type="button" class="md-button md-outline md-compact" data-brand-color-reset><?=t($t,'brand_color_reset','Use default brand color')?></button>
           <input type="hidden" name="brand_color_reset" value="0" data-brand-color-reset-field>
         </div>
-        <small class="md-field-hint"><?=t($t,'brand_color_hint','Pick any brand color to personalize buttons, highlights, and gradients.')?></small>
       </label>
-      <h3 class="md-subhead"><?=t($t,'language_settings','Languages')?></h3>
-      <p class="md-field-hint"><?=t($t,'language_settings_hint','Choose which interface languages are available to users.')?></p>
+      <h3 class="md-subhead">
+        <?=t($t,'language_settings','Languages')?>
+        <?=render_help_icon(t($t,'language_settings_hint','Choose which interface languages are available to users.'))?>
+      </h3>
       <?php foreach (SUPPORTED_LOCALES as $localeOption): ?>
         <?php $isChecked = in_array($localeOption, $enabledLocales, true); ?>
         <div class="md-control">
@@ -210,7 +214,9 @@ try {
           </label>
         </div>
       <?php endforeach; ?>
-      <p class="md-field-hint"><?=t($t,'language_required_notice','At least English or French must remain enabled.')?></p>
+      <div class="md-help-note">
+        <?=render_help_icon(t($t,'language_required_notice','At least English or French must remain enabled.'), true)?>
+      </div>
       <h3 class="md-subhead"><?=t($t,'sso_settings','Single Sign-On (SSO)')?></h3>
       <div class="md-control">
         <label>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1021,6 +1021,118 @@ body.theme-dark .md-field.md-field--compact select {
   color: var(--app-muted-light);
 }
 
+.md-help-bubble {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  background: var(--app-primary-soft);
+  color: var(--app-primary-dark);
+  font-weight: 700;
+  font-size: 0.75rem;
+  margin-left: 0.45rem;
+  cursor: help;
+  box-shadow: 0 6px 16px var(--app-primary-soft);
+  transition: box-shadow 0.18s ease, transform 0.18s ease;
+  flex-shrink: 0;
+}
+
+.md-help-bubble::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.6rem);
+  transform: translate(-50%, 0.4rem);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  min-width: 12rem;
+  max-width: min(22rem, calc(100vw - 3rem));
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: var(--app-surface, #ffffff);
+  color: var(--app-on-surface-strong, #1f2933);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.18);
+  line-height: 1.4;
+  text-align: left;
+  z-index: 80;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+}
+
+.md-help-bubble::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.15rem);
+  transform: translateX(-50%);
+  border-width: 0.45rem 0.45rem 0;
+  border-style: solid;
+  border-color: var(--app-surface, #ffffff) transparent transparent transparent;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.18s ease;
+  z-index: 79;
+}
+
+.md-help-bubble:hover,
+.md-help-bubble:focus-visible {
+  box-shadow: 0 10px 22px var(--app-primary-soft);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.md-help-bubble:hover::after,
+.md-help-bubble:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
+.md-help-bubble:hover::before,
+.md-help-bubble:focus-visible::before {
+  opacity: 1;
+  visibility: visible;
+}
+
+.md-help-bubble--standalone {
+  margin-left: 0;
+}
+
+.md-help-icon {
+  pointer-events: none;
+  line-height: 1;
+}
+
+.md-help-note {
+  display: flex;
+  align-items: center;
+  margin: 0.35rem 0 0.6rem;
+}
+
+body.theme-dark .md-help-bubble {
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--app-on-surface-strong, #f1f5f9);
+  box-shadow: none;
+}
+
+body.theme-dark .md-help-bubble:hover,
+body.theme-dark .md-help-bubble:focus-visible {
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.42);
+}
+
+body.theme-dark .md-help-bubble::after {
+  background: rgba(15, 23, 42, 0.94);
+  color: #f8fafc;
+  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.48);
+}
+
+body.theme-dark .md-help-bubble::before {
+  border-color: rgba(15, 23, 42, 0.94) transparent transparent transparent;
+}
+
 .md-field select,
 .md-field input,
 .md-field textarea {

--- a/config.php
+++ b/config.php
@@ -967,6 +967,22 @@ function site_body_style(array $cfg): string
     return site_brand_style($cfg);
 }
 
+function render_help_icon(string $tooltip, bool $standalone = false): string
+{
+    $escaped = htmlspecialchars($tooltip, ENT_QUOTES, 'UTF-8');
+    $classes = ['md-help-bubble'];
+    if ($standalone) {
+        $classes[] = 'md-help-bubble--standalone';
+    }
+
+    return sprintf(
+        '<span class="%s" tabindex="0" data-tooltip="%s" aria-label="%s"><span class="md-help-icon" aria-hidden="true">i</span></span>',
+        implode(' ', $classes),
+        $escaped,
+        $escaped
+    );
+}
+
 function site_theme_tokens(array $cfg): array
 {
     $palette = site_brand_palette($cfg);

--- a/profile.php
+++ b/profile.php
@@ -202,7 +202,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <input type="date" name="date_of_birth" value="<?=htmlspecialchars($user['date_of_birth'] ?? '')?>" required>
       </label>
       <label class="md-field md-field-inline">
-        <span><?=t($t,'phone','Phone Number')?></span>
+        <span>
+          <?=t($t,'phone','Phone Number')?>
+          <?=render_help_icon(t($t,'phone_number_hint','Choose a country code and enter digits only.'))?>
+        </span>
         <div class="md-phone-input" data-phone-field>
           <span class="md-phone-flag" data-phone-flag><?=htmlspecialchars($phoneFlagValue, ENT_QUOTES, 'UTF-8')?></span>
           <select class="md-phone-country" name="phone_country" id="phone_country" data-phone-country aria-label="<?=htmlspecialchars(t($t,'phone_country','Country code'), ENT_QUOTES, 'UTF-8')?>">
@@ -215,7 +218,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <input class="md-phone-local" type="text" name="phone_local" id="phone_local" data-phone-local inputmode="numeric" pattern="[0-9]*" minlength="6" maxlength="12" placeholder="<?=htmlspecialchars(t($t,'phone_number_placeholder','9-digit number'), ENT_QUOTES, 'UTF-8')?>" value="<?=htmlspecialchars($phoneLocalValue, ENT_QUOTES, 'UTF-8')?>" aria-label="<?=htmlspecialchars(t($t,'phone','Phone Number'), ENT_QUOTES, 'UTF-8')?>" required>
           <input type="hidden" name="phone" value="<?=htmlspecialchars($phoneCountryValue . $phoneLocalValue, ENT_QUOTES, 'UTF-8')?>" data-phone-full>
         </div>
-        <small class="md-field-hint"><?=t($t,'phone_number_hint','Choose a country code and enter digits only.')?></small>
       </label>
       <label class="md-field">
         <span><?=t($t,'department','Department')?></span>


### PR DESCRIPTION
## Summary
- add a reusable render_help_icon helper for rendering tooltip info icons
- update the settings and profile forms to surface existing help text as hoverable icons
- style the new help bubble for both light and dark themes

## Testing
- php -l admin/settings.php
- php -l profile.php
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_6903af9500bc832db4b7ba23b4ca5c58