### PR TITLE
Run SQL migrations during system upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,10 @@ questionnaire aligned with EPSA requirements.
 Use the [`scripts/system_upgrade.php`](scripts/system_upgrade.php) CLI to deploy
 new releases safely. The tool backs up the application directory and database
 before applying updates from GitHub and provides downgrade capabilities if an
-upgrade fails. Refer to [`docs/system-upgrade.md`](docs/system-upgrade.md) for
-usage examples and options.
+upgrade fails. During deployment the script also runs bundled SQL migrations
+such as `migration.sql` so database changes are applied automatically. Refer to
+[`docs/system-upgrade.md`](docs/system-upgrade.md) for usage examples and
+options.
 
 ## Quality and compliance
 

--- a/docs/system-upgrade.md
+++ b/docs/system-upgrade.md
@@ -1,8 +1,8 @@
 # System upgrade utility
 
 The `scripts/system_upgrade.php` CLI script automates application and database
-upgrades by downloading release archives, capturing snapshots, and staging
-deployments in a repeatable fashion.
+upgrades by downloading release archives, capturing snapshots, staging
+deployments, and applying bundled SQL migrations in a repeatable fashion.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- run bundled SQL migration scripts as part of the automated upgrade process
- add SQL parsing helpers to the upgrade CLI to execute migration statements safely
- document that the upgrade tool now applies database migrations automatically

## Testing
- php -l scripts/system_upgrade.php

------
https://chatgpt.com/codex/tasks/task_e_6903c34cd7ec832db12b3e0cee3502e0