### PR TITLE
Fix migration locale update statement

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -144,8 +144,8 @@ INSERT IGNORE INTO site_config (
 );
 
 UPDATE site_config
-SET brand_color = NULL
-SET enabled_locales = '["en","fr","am"]'
+SET brand_color = NULL,
+    enabled_locales = '["en","fr","am"]'
 WHERE id = 1 AND (enabled_locales IS NULL OR enabled_locales = '');
 
 UPDATE site_config


### PR DESCRIPTION
## Summary
- correct the `UPDATE site_config` statement to use a single SET clause for brand color and locales

## Testing
- not run (SQL change only)


------
https://chatgpt.com/codex/tasks/task_e_6903f2dd8e08832db04d67e807f37d68