### PR TITLE
Add editable HTML email templates

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1533,6 +1533,52 @@ body.theme-dark .md-help-bubble::before {
   }
 }
 
+.email-template-block {
+  border: 1px solid var(--md-border-color, rgba(0, 0, 0, 0.12));
+  border-radius: 6px;
+  padding: 1rem;
+  margin: 1rem 0 1.5rem;
+  background: var(--md-surface-alt, rgba(0, 0, 0, 0.02));
+}
+
+.email-template-block h4.md-subhead {
+  margin-top: 0;
+}
+
+.email-template-block .md-field {
+  margin-top: 0.75rem;
+}
+
+.email-template-block textarea {
+  min-height: 160px;
+  font-family: inherit;
+}
+
+.email-template-placeholders {
+  margin: 0.5rem 0 0.75rem;
+}
+
+.email-template-placeholders ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.email-template-placeholders code {
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
+body.theme-dark .email-template-block {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+body.theme-dark .email-template-placeholders code {
+  background: rgba(255, 255, 255, 0.08);
+}
+
 .md-login-actions {
   margin-top: 1.25rem;
 }

--- a/init.sql
+++ b/init.sql
@@ -54,7 +54,8 @@ CREATE TABLE site_config (
   smtp_from_email VARCHAR(255) NULL,
   smtp_from_name VARCHAR(255) NULL,
   smtp_timeout INT NULL,
-  upgrade_repo VARCHAR(255) NULL
+  upgrade_repo VARCHAR(255) NULL,
+  email_templates LONGTEXT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE users (
@@ -263,7 +264,8 @@ INSERT INTO site_config (
   smtp_from_email,
   smtp_from_name,
   smtp_timeout,
-  upgrade_repo
+  upgrade_repo,
+  email_templates
 ) VALUES (
   1,
   'My Performance',
@@ -302,7 +304,8 @@ INSERT INTO site_config (
   NULL,
   NULL,
   20,
-  'khoppenworth/HRassessv300'
+  'khoppenworth/HRassessv300',
+  '{}'
 );
 
 -- default users are disabled by default; update the passwords and enable accounts after installation

--- a/lib/email_templates.php
+++ b/lib/email_templates.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+function default_email_templates(): array
+{
+    return [
+        'pending_user' => [
+            'subject' => 'Approval needed: {{user_display}}',
+            'html' => <<<'HTML'
+<p>A new single sign-on user requires approval before accessing the HR Assessment portal.</p>
+<ul>
+  <li>Name: {{user_display}}</li>
+  <li>Email: {{user_email}}</li>
+  <li>Submitted on: {{submitted_at}}</li>
+</ul>
+<p><a href="{{pending_accounts_url}}">Review pending accounts</a></p>
+HTML,
+        ],
+        'account_approved' => [
+            'subject' => 'Your HR Assessment access has been approved',
+            'html' => <<<'HTML'
+<p>Hello {{user_name}},</p>
+<p>Your supervisor has approved your access to the HR Assessment portal. You can now sign in and complete your assessments.</p>
+{{next_assessment_block}}
+<p><a href="{{login_url}}">Sign in to the portal</a></p>
+<p>Thank you.</p>
+HTML,
+        ],
+        'next_assessment' => [
+            'subject' => 'Upcoming assessment scheduled',
+            'html' => <<<'HTML'
+<p>Hello {{user_name}},</p>
+<p>A supervisor has scheduled your next assessment for {{next_assessment_date}}.</p>
+<p>Please log in to the HR Assessment portal to prepare and complete any required steps.</p>
+<p><a href="{{portal_url}}">Open the HR Assessment portal</a></p>
+<p>Thank you.</p>
+HTML,
+        ],
+        'assignment_update' => [
+            'subject' => 'Questionnaire assignments updated',
+            'html' => <<<'HTML'
+<p>Hello {{user_name}},</p>
+{{assignment_summary}}
+{{next_assessment_block}}
+{{assigner_block}}
+<p>You can review your questionnaires here: <a href="{{dashboard_url}}">{{dashboard_url}}</a></p>
+<p>Thank you.</p>
+HTML,
+        ],
+    ];
+}
+
+function normalize_email_templates($value): array
+{
+    $defaults = default_email_templates();
+    $decoded = [];
+
+    if (is_string($value) && $value !== '') {
+        $maybe = json_decode($value, true);
+        if (is_array($maybe)) {
+            $decoded = $maybe;
+        }
+    } elseif (is_array($value)) {
+        $decoded = $value;
+    }
+
+    $result = $defaults;
+    foreach ($decoded as $key => $template) {
+        if (!isset($defaults[$key]) || !is_array($template)) {
+            continue;
+        }
+        $subject = isset($template['subject']) ? (string)$template['subject'] : '';
+        $html = isset($template['html']) ? (string)$template['html'] : '';
+        $subject = trim($subject) !== '' ? $subject : $defaults[$key]['subject'];
+        $html = trim($html) !== '' ? $html : $defaults[$key]['html'];
+        $result[$key] = [
+            'subject' => $subject,
+            'html' => $html,
+        ];
+    }
+
+    return $result;
+}
+
+function encode_email_templates(array $templates): string
+{
+    $normalized = normalize_email_templates($templates);
+    $json = json_encode($normalized, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    return $json === false ? '{}' : $json;
+}

--- a/lib/notifications.php
+++ b/lib/notifications.php
@@ -4,6 +4,41 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/mailer.php';
 
+function notification_resolve_template(array $cfg, string $key, array $variables): array
+{
+    $templates = normalize_email_templates($cfg['email_templates'] ?? []);
+    $defaults = default_email_templates();
+    $template = $templates[$key] ?? ($defaults[$key] ?? ['subject' => '', 'html' => '']);
+    $subjectTemplate = (string)($template['subject'] ?? '');
+    $htmlTemplate = (string)($template['html'] ?? '');
+
+    $plainReplacements = [];
+    $htmlReplacements = [];
+    foreach ($variables as $name => $value) {
+        $token = '{{' . $name . '}}';
+        if (is_array($value)) {
+            $textValue = isset($value['text']) ? (string)$value['text'] : '';
+            $htmlValue = isset($value['html']) ? (string)$value['html'] : $textValue;
+            $plainReplacements[$token] = $textValue;
+            $htmlReplacements[$token] = $htmlValue;
+        } else {
+            $textValue = (string)$value;
+            $plainReplacements[$token] = $textValue;
+            $htmlReplacements[$token] = htmlspecialchars($textValue, ENT_QUOTES, 'UTF-8');
+        }
+    }
+
+    $subject = strtr($subjectTemplate, $plainReplacements);
+    $html = strtr($htmlTemplate, $htmlReplacements);
+    $text = mail_html_to_text($html);
+
+    return [
+        'subject' => $subject,
+        'html' => $html,
+        'text' => $text,
+    ];
+}
+
 function notify_supervisors_of_pending_user(PDO $pdo, array $cfg, array $user): void
 {
     $recipients = [];
@@ -26,14 +61,17 @@ function notify_supervisors_of_pending_user(PDO $pdo, array $cfg, array $user): 
     }
 
     $profileUrl = url_for('admin/pending_accounts.php');
-    $subject = sprintf('Approval needed: %s', $display);
-    $body = "A new single sign-on user requires approval before accessing the HR Assessment portal.\n\n" .
-        'Name: ' . $display . "\n" .
-        'Email: ' . ($user['email'] ?? 'not provided') . "\n" .
-        'Submitted on: ' . date('Y-m-d H:i') . "\n\n" .
-        'Review pending accounts: ' . $profileUrl . "\n";
+    $template = notification_resolve_template($cfg, 'pending_user', [
+        'user_display' => $display,
+        'user_email' => (string)($user['email'] ?? 'not provided'),
+        'submitted_at' => date('Y-m-d H:i'),
+        'pending_accounts_url' => $profileUrl,
+    ]);
 
-    send_notification_email($cfg, $recipients, $subject, $body);
+    send_notification_email($cfg, $recipients, $template['subject'], [
+        'text' => $template['text'],
+        'html' => $template['html'],
+    ]);
 }
 
 function notify_user_account_approved(array $cfg, array $user, ?string $nextAssessmentDate): void
@@ -43,15 +81,27 @@ function notify_user_account_approved(array $cfg, array $user, ?string $nextAsse
         return;
     }
     $loginUrl = url_for('login.php');
-    $subject = 'Your HR Assessment access has been approved';
-    $body = "Hello " . ($user['full_name'] ?? $user['username'] ?? 'team member') . ",\n\n" .
-        "Your supervisor has approved your access to the HR Assessment portal. You can now sign in and complete your assessments." . "\n\n" .
-        "Sign in: $loginUrl\n";
+    $name = trim((string)($user['full_name'] ?? $user['username'] ?? 'team member'));
+    $nextAssessmentBlock = '';
+    $nextAssessmentText = '';
     if ($nextAssessmentDate) {
-        $body .= "\nYour next assessment has been scheduled for: $nextAssessmentDate\n";
+        $nextAssessmentBlock = '<p>Your next assessment has been scheduled for ' . htmlspecialchars($nextAssessmentDate, ENT_QUOTES, 'UTF-8') . '.</p>';
+        $nextAssessmentText = 'Your next assessment has been scheduled for: ' . $nextAssessmentDate;
     }
-    $body .= "\nThank you.";
-    send_notification_email($cfg, [$email], $subject, $body);
+
+    $template = notification_resolve_template($cfg, 'account_approved', [
+        'user_name' => $name,
+        'login_url' => $loginUrl,
+        'next_assessment_block' => [
+            'html' => $nextAssessmentBlock,
+            'text' => $nextAssessmentText,
+        ],
+    ]);
+
+    send_notification_email($cfg, [$email], $template['subject'], [
+        'text' => $template['text'],
+        'html' => $template['html'],
+    ]);
 }
 
 function notify_user_next_assessment(array $cfg, array $user, string $nextAssessmentDate): void
@@ -60,13 +110,16 @@ function notify_user_next_assessment(array $cfg, array $user, string $nextAssess
     if ($email === '') {
         return;
     }
-    $subject = 'Upcoming assessment scheduled';
-    $body = "Hello " . ($user['full_name'] ?? $user['username'] ?? 'team member') . ",\n\n" .
-        'A supervisor has scheduled your next assessment for ' . $nextAssessmentDate . ".\n" .
-        'Please log in to the HR Assessment portal to prepare and complete any required steps.' . "\n\n" .
-        'Portal: ' . url_for('login.php') . "\n\n" .
-        'Thank you.';
-    send_notification_email($cfg, [$email], $subject, $body);
+    $template = notification_resolve_template($cfg, 'next_assessment', [
+        'user_name' => trim((string)($user['full_name'] ?? $user['username'] ?? 'team member')),
+        'next_assessment_date' => $nextAssessmentDate,
+        'portal_url' => url_for('login.php'),
+    ]);
+
+    send_notification_email($cfg, [$email], $template['subject'], [
+        'text' => $template['text'],
+        'html' => $template['html'],
+    ]);
 }
 
 function notify_questionnaire_assignment_update(array $cfg, array $staff, array $assignedTitles, ?array $assigner = null): void
@@ -90,34 +143,54 @@ function notify_questionnaire_assignment_update(array $cfg, array $staff, array 
     $staffName = trim((string)($staff['full_name'] ?? $staff['username'] ?? 'team member'));
     $assignerName = $assigner ? trim((string)($assigner['full_name'] ?? $assigner['username'] ?? '')) : '';
 
-    $subject = 'Questionnaire assignments updated';
-    $lines = [];
-    $lines[] = 'Hello ' . ($staffName !== '' ? $staffName : 'team member') . ',';
-    $lines[] = '';
     if ($assignedTitles) {
-        $lines[] = 'The following questionnaires are now assigned to you:';
+        $summaryHtml = '<p>The following questionnaires are now assigned to you:</p><ul>';
+        $summaryTextLines = ['The following questionnaires are now assigned to you:'];
         foreach ($assignedTitles as $title) {
-            $lines[] = ' - ' . $title;
+            $summaryHtml .= '<li>' . htmlspecialchars((string)$title, ENT_QUOTES, 'UTF-8') . '</li>';
+            $summaryTextLines[] = ' - ' . (string)$title;
         }
+        $summaryHtml .= '</ul>';
+        $summaryText = implode("\n", $summaryTextLines);
     } else {
-        $lines[] = 'All previously assigned questionnaires have been removed from your profile.';
+        $summaryHtml = '<p>All previously assigned questionnaires have been removed from your profile.</p>';
+        $summaryText = 'All previously assigned questionnaires have been removed from your profile.';
     }
 
     $nextAssessment = trim((string)($staff['next_assessment_date'] ?? ''));
+    $nextAssessmentBlock = '';
+    $nextAssessmentText = '';
     if ($nextAssessment !== '') {
-        $lines[] = '';
-        $lines[] = 'Your next assessment date: ' . $nextAssessment;
+        $nextAssessmentBlock = '<p>Your next assessment date: ' . htmlspecialchars($nextAssessment, ENT_QUOTES, 'UTF-8') . '.</p>';
+        $nextAssessmentText = 'Your next assessment date: ' . $nextAssessment;
     }
 
+    $assignerBlock = '';
+    $assignerText = '';
     if ($assignerName !== '') {
-        $lines[] = '';
-        $lines[] = 'Assignments updated by: ' . $assignerName;
+        $assignerBlock = '<p>Assignments updated by: ' . htmlspecialchars($assignerName, ENT_QUOTES, 'UTF-8') . '.</p>';
+        $assignerText = 'Assignments updated by: ' . $assignerName;
     }
 
-    $lines[] = '';
-    $lines[] = 'You can review your questionnaires here: ' . url_for('dashboard.php');
-    $lines[] = '';
-    $lines[] = 'Thank you.';
+    $template = notification_resolve_template($cfg, 'assignment_update', [
+        'user_name' => $staffName !== '' ? $staffName : 'team member',
+        'assignment_summary' => [
+            'html' => $summaryHtml,
+            'text' => $summaryText,
+        ],
+        'next_assessment_block' => [
+            'html' => $nextAssessmentBlock,
+            'text' => $nextAssessmentText,
+        ],
+        'assigner_block' => [
+            'html' => $assignerBlock,
+            'text' => $assignerText,
+        ],
+        'dashboard_url' => url_for('dashboard.php'),
+    ]);
 
-    send_notification_email($cfg, $recipients, $subject, implode("\n", $lines));
+    send_notification_email($cfg, $recipients, $template['subject'], [
+        'text' => $template['text'],
+        'html' => $template['html'],
+    ]);
 }

--- a/migration.sql
+++ b/migration.sql
@@ -110,7 +110,8 @@ CREATE TABLE IF NOT EXISTS site_config (
   microsoft_oauth_tenant VARCHAR(255) NULL,
   color_theme VARCHAR(50) NOT NULL DEFAULT 'light',
   enabled_locales TEXT NULL,
-  upgrade_repo VARCHAR(255) NULL
+  upgrade_repo VARCHAR(255) NULL,
+  email_templates LONGTEXT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS landing_metric_submissions INT NULL AFTER contact,
@@ -144,7 +145,8 @@ ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS smtp_from_name VARCHAR(255) NULL AFTER smtp_from_email,
   ADD COLUMN IF NOT EXISTS smtp_timeout INT NULL AFTER smtp_from_name,
   ADD COLUMN IF NOT EXISTS enabled_locales TEXT NULL AFTER smtp_timeout,
-  ADD COLUMN IF NOT EXISTS upgrade_repo VARCHAR(255) NULL AFTER enabled_locales;
+  ADD COLUMN IF NOT EXISTS upgrade_repo VARCHAR(255) NULL AFTER enabled_locales,
+  ADD COLUMN IF NOT EXISTS email_templates LONGTEXT NULL AFTER upgrade_repo;
 INSERT IGNORE INTO site_config (
   id,
   site_name,
@@ -183,7 +185,8 @@ INSERT IGNORE INTO site_config (
   smtp_from_name,
   smtp_timeout,
   enabled_locales,
-  upgrade_repo
+  upgrade_repo,
+  email_templates
 ) VALUES (
   1,
   'My Performance',
@@ -222,7 +225,8 @@ INSERT IGNORE INTO site_config (
   NULL,
   20,
   '["en","fr","am"]',
-  'khoppenworth/HRassessv300'
+  'khoppenworth/HRassessv300',
+  '{}'
 );
 
 -- Add supporting index for faster timeline queries without full table scans.

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS site_config (
   smtp_from_email VARCHAR(255) NULL,
   smtp_from_name VARCHAR(255) NULL,
   smtp_timeout INT NULL,
-  upgrade_repo VARCHAR(255) NULL
+  upgrade_repo VARCHAR(255) NULL,
+  email_templates LONGTEXT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 ALTER TABLE site_config
@@ -74,7 +75,8 @@ ALTER TABLE site_config
   ADD COLUMN IF NOT EXISTS smtp_from_email VARCHAR(255) NULL,
   ADD COLUMN IF NOT EXISTS smtp_from_name VARCHAR(255) NULL,
   ADD COLUMN IF NOT EXISTS smtp_timeout INT NULL,
-  ADD COLUMN IF NOT EXISTS upgrade_repo VARCHAR(255) NULL;
+  ADD COLUMN IF NOT EXISTS upgrade_repo VARCHAR(255) NULL,
+  ADD COLUMN IF NOT EXISTS email_templates LONGTEXT NULL;
 
 INSERT INTO site_config (
   id, site_name, landing_text, address, contact, logo_path,
@@ -83,7 +85,7 @@ INSERT INTO site_config (
   footer_rights, google_oauth_enabled, google_oauth_client_id, google_oauth_client_secret,
   microsoft_oauth_enabled, microsoft_oauth_client_id, microsoft_oauth_client_secret, microsoft_oauth_tenant,
   color_theme, brand_color, enabled_locales, smtp_enabled, smtp_host, smtp_port, smtp_username, smtp_password,
-  smtp_encryption, smtp_from_email, smtp_from_name, smtp_timeout, upgrade_repo
+  smtp_encryption, smtp_from_email, smtp_from_name, smtp_timeout, upgrade_repo, email_templates
 ) VALUES (
   1, 'My Performance', NULL, NULL, NULL, NULL,
   'Ethiopian Pharmaceutical Supply Service', 'EPSS / EPS', 'epss.gov.et', 'https://epss.gov.et',
@@ -91,7 +93,7 @@ INSERT INTO site_config (
   'All rights reserved.', 0, NULL, NULL,
   0, NULL, NULL, 'common',
   'light', '#2073bf', '["en","fr","am"]', 0, NULL, 587, NULL, NULL,
-  'none', NULL, NULL, 20, 'khoppenworth/HRassessv300'
+  'none', NULL, NULL, 20, 'khoppenworth/HRassessv300', '{}'
 ) ON DUPLICATE KEY UPDATE
   site_name = COALESCE(site_config.site_name, VALUES(site_name)),
   brand_color = IFNULL(site_config.brand_color, VALUES(brand_color)),
@@ -99,7 +101,8 @@ INSERT INTO site_config (
   enabled_locales = IFNULL(site_config.enabled_locales, VALUES(enabled_locales)),
   smtp_port = IFNULL(site_config.smtp_port, VALUES(smtp_port)),
   smtp_timeout = IFNULL(site_config.smtp_timeout, VALUES(smtp_timeout)),
-  upgrade_repo = IFNULL(site_config.upgrade_repo, VALUES(upgrade_repo));
+  upgrade_repo = IFNULL(site_config.upgrade_repo, VALUES(upgrade_repo)),
+  email_templates = IFNULL(site_config.email_templates, VALUES(email_templates));
 
 -- Ensure users table columns match the application expectations.
 ALTER TABLE users


### PR DESCRIPTION
## Summary
- add default HTML email templates and persist them in site configuration
- allow administrators to edit template subjects and bodies from the settings screen with helper styling
- send notifications as multipart HTML emails using the saved templates and update schema migrations for the new storage

## Testing
- php -l admin/settings.php
- php -l lib/mailer.php
- php -l lib/notifications.php
- php -l lib/email_templates.php
- php -l config.php

------
https://chatgpt.com/codex/tasks/task_e_6905fa077a90832db55241f5f73e8839