### PR TITLE
Ensure notification helpers load path utilities

### DIFF
--- a/lib/notifications.php
+++ b/lib/notifications.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 require_once __DIR__ . '/mailer.php';
+require_once __DIR__ . '/path.php';
 
 function notify_supervisors_of_pending_user(PDO $pdo, array $cfg, array $user): void
 {


### PR DESCRIPTION
## Summary
- require the shared path helpers when loading notification utilities so url_for is always available

## Testing
- php tests/smtp_config_test.php

------
https://chatgpt.com/codex/tasks/task_e_6905fd416810832d8d542371536d99f9