### PR TITLE
Document and test normalize_email_templates

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/lib/email_templates.php';
+
 if (!defined('APP_BOOTSTRAPPED')) {
     define('APP_BOOTSTRAPPED', true);
 
@@ -28,7 +30,6 @@ if (!defined('APP_BOOTSTRAPPED')) {
     require_once __DIR__ . '/lib/path.php';
     require_once __DIR__ . '/lib/security.php';
     require_once __DIR__ . '/lib/mailer.php';
-    require_once __DIR__ . '/lib/email_templates.php';
     require_once __DIR__ . '/lib/notifications.php';
 
     $locale = ensure_locale();

--- a/lib/email_templates.php
+++ b/lib/email_templates.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+/**
+ * Return the built-in set of email templates used by the application.
+ *
+ * @return array<string, array{subject: string, html: string}>
+ */
 function default_email_templates(): array
 {
     return [
@@ -51,6 +56,12 @@ HTML,
     ];
 }
 
+/**
+ * Normalize stored email template configuration values.
+ *
+ * @param array<string, array{subject?: string, html?: string}>|string $value
+ * @return array<string, array{subject: string, html: string}>
+ */
 function normalize_email_templates($value): array
 {
     $defaults = default_email_templates();

--- a/tests/email_templates_test.php
+++ b/tests/email_templates_test.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../lib/email_templates.php';
+
+function assert_same($expected, $actual, string $message): void
+{
+    if ($expected !== $actual) {
+        throw new RuntimeException($message . "\nExpected: " . var_export($expected, true) . "\nActual: " . var_export($actual, true));
+    }
+}
+
+function test_normalize_email_templates_from_json(): void
+{
+    $templates = [
+        'pending_user' => [
+            'subject' => 'Custom subject',
+            'html' => '<p>Hi</p>',
+        ],
+        'account_approved' => [
+            'subject' => '',
+            'html' => '  ',
+        ],
+    ];
+    $json = json_encode($templates, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    $normalized = normalize_email_templates($json ?: '');
+
+    $defaults = default_email_templates();
+    assert_same('Custom subject', $normalized['pending_user']['subject'], 'Custom subject should be preserved.');
+    assert_same('<p>Hi</p>', $normalized['pending_user']['html'], 'Custom HTML should be preserved.');
+    assert_same($defaults['account_approved']['subject'], $normalized['account_approved']['subject'], 'Empty subject should fall back to default.');
+    assert_same($defaults['account_approved']['html'], $normalized['account_approved']['html'], 'Empty HTML should fall back to default.');
+}
+
+function test_normalize_email_templates_from_array(): void
+{
+    $input = [
+        'pending_user' => [
+            'subject' => '   ',
+            'html' => '',
+        ],
+    ];
+    $normalized = normalize_email_templates($input);
+    $defaults = default_email_templates();
+
+    assert_same($defaults['pending_user']['subject'], $normalized['pending_user']['subject'], 'Whitespace subject should revert to default.');
+    assert_same($defaults['pending_user']['html'], $normalized['pending_user']['html'], 'Whitespace HTML should revert to default.');
+}
+
+function test_encode_email_templates_returns_json(): void
+{
+    $input = [
+        'next_assessment' => [
+            'subject' => 'Reminder',
+            'html' => '<p>Hello</p>',
+        ],
+    ];
+    $json = encode_email_templates($input);
+    $decoded = json_decode($json, true);
+
+    if (!is_array($decoded)) {
+        throw new RuntimeException('encode_email_templates should return valid JSON.');
+    }
+
+    assert_same('Reminder', $decoded['next_assessment']['subject'], 'Encoded JSON should include normalized subject.');
+    assert_same('<p>Hello</p>', $decoded['next_assessment']['html'], 'Encoded JSON should include normalized HTML.');
+}
+
+function run_email_template_tests(): void
+{
+    test_normalize_email_templates_from_json();
+    test_normalize_email_templates_from_array();
+    test_encode_email_templates_returns_json();
+}
+
+run_email_template_tests();
+
+echo "Email template tests passed.\n";


### PR DESCRIPTION
## Summary
- ensure the email template helper file is loaded even when config.php is included after defining APP_BOOTSTRAPPED
- document the normalize_email_templates helper and its default template definitions
- add regression tests covering normalization and encoding of email templates

## Testing
- php tests/email_templates_test.php
- php tests/smtp_config_test.php

------
https://chatgpt.com/codex/tasks/task_e_690630baf4f8832d986c6f6361376e3d