### PR TITLE
Refactor email template registry and fix dependencies

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -24,47 +24,19 @@ try {
     $enabledLocales = site_enabled_locales($cfg);
     $emailTemplates = normalize_email_templates($cfg['email_templates'] ?? []);
 
-    $emailTemplateDefinitions = [
-        'pending_user' => [
-            'title' => t($t, 'email_template_pending_user_title', 'Pending account notification (to supervisors)'),
-            'description' => t($t, 'email_template_pending_user_desc', 'Sent to supervisors and admins when a new single sign-on account requires approval.'),
-            'placeholders' => [
-                '{{user_display}}' => t($t, 'email_template_pending_user_placeholder_display', 'Display name of the pending user'),
-                '{{user_email}}' => t($t, 'email_template_pending_user_placeholder_email', 'Email address of the pending user'),
-                '{{submitted_at}}' => t($t, 'email_template_pending_user_placeholder_submitted', 'Timestamp when the request was submitted'),
-                '{{pending_accounts_url}}' => t($t, 'email_template_pending_user_placeholder_url', 'Link to the pending approvals page'),
-            ],
-        ],
-        'account_approved' => [
-            'title' => t($t, 'email_template_account_approved_title', 'Account approval notice (to staff)'),
-            'description' => t($t, 'email_template_account_approved_desc', 'Sent to a staff member after their access request is approved.'),
-            'placeholders' => [
-                '{{user_name}}' => t($t, 'email_template_account_approved_placeholder_name', 'Name of the recipient'),
-                '{{login_url}}' => t($t, 'email_template_account_approved_placeholder_login', 'Sign-in URL for the portal'),
-                '{{next_assessment_block}}' => t($t, 'email_template_account_approved_placeholder_next', 'HTML paragraph shown when a next assessment date is available'),
-            ],
-        ],
-        'next_assessment' => [
-            'title' => t($t, 'email_template_next_assessment_title', 'Upcoming assessment reminder (to staff)'),
-            'description' => t($t, 'email_template_next_assessment_desc', 'Sent to staff when a supervisor schedules their next assessment.'),
-            'placeholders' => [
-                '{{user_name}}' => t($t, 'email_template_next_assessment_placeholder_name', 'Name of the recipient'),
-                '{{next_assessment_date}}' => t($t, 'email_template_next_assessment_placeholder_date', 'Scheduled assessment date'),
-                '{{portal_url}}' => t($t, 'email_template_next_assessment_placeholder_portal', 'Link to the HR Assessment portal'),
-            ],
-        ],
-        'assignment_update' => [
-            'title' => t($t, 'email_template_assignment_update_title', 'Questionnaire assignment update'),
-            'description' => t($t, 'email_template_assignment_update_desc', 'Sent to staff (and optionally the assigning supervisor) when questionnaire assignments change.'),
-            'placeholders' => [
-                '{{user_name}}' => t($t, 'email_template_assignment_update_placeholder_name', 'Name of the recipient'),
-                '{{assignment_summary}}' => t($t, 'email_template_assignment_update_placeholder_summary', 'HTML list describing assigned questionnaires'),
-                '{{next_assessment_block}}' => t($t, 'email_template_assignment_update_placeholder_next', 'HTML paragraph shown when a next assessment date is set'),
-                '{{assigner_block}}' => t($t, 'email_template_assignment_update_placeholder_assigner', 'HTML paragraph that names the supervisor who made the change'),
-                '{{dashboard_url}}' => t($t, 'email_template_assignment_update_placeholder_dashboard', 'Link to the dashboard for reviewing questionnaires'),
-            ],
-        ],
-    ];
+    $emailTemplateDefinitions = [];
+    foreach (email_template_registry() as $key => $definition) {
+        $placeholders = [];
+        foreach ($definition['placeholders'] as $token => $placeholder) {
+            $placeholders['{{' . $token . '}}'] = t($t, $placeholder['key'], $placeholder['fallback']);
+        }
+
+        $emailTemplateDefinitions[$key] = [
+            'title' => t($t, $definition['title']['key'], $definition['title']['fallback']),
+            'description' => t($t, $definition['description']['key'], $definition['description']['fallback']),
+            'placeholders' => $placeholders,
+        ];
+    }
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         csrf_check();

--- a/lib/email_templates.php
+++ b/lib/email_templates.php
@@ -3,16 +3,30 @@
 declare(strict_types=1);
 
 /**
- * Return the built-in set of email templates used by the application.
+ * Return the canonical registry describing every email template the application supports.
  *
- * @return array<string, array{subject: string, html: string}>
+ * Each registry entry contains the default subject and HTML body along with translation
+ * metadata that other parts of the application can use to build user-facing descriptions.
+ *
+ * @return array<string, array{
+ *     defaults: array{subject: string, html: string},
+ *     title: array{key: string, fallback: string},
+ *     description: array{key: string, fallback: string},
+ *     placeholders: array<string, array{key: string, fallback: string}>
+ * }>
  */
-function default_email_templates(): array
+function email_template_registry(): array
 {
-    return [
+    static $registry = null;
+    if ($registry !== null) {
+        return $registry;
+    }
+
+    $registry = [
         'pending_user' => [
-            'subject' => 'Approval needed: {{user_display}}',
-            'html' => <<<'HTML'
+            'defaults' => [
+                'subject' => 'Approval needed: {{user_display}}',
+                'html' => <<<'HTML'
 <p>A new single sign-on user requires approval before accessing the HR Assessment portal.</p>
 <ul>
   <li>Name: {{user_display}}</li>
@@ -21,30 +35,106 @@ function default_email_templates(): array
 </ul>
 <p><a href="{{pending_accounts_url}}">Review pending accounts</a></p>
 HTML,
+            ],
+            'title' => [
+                'key' => 'email_template_pending_user_title',
+                'fallback' => 'Pending account notification (to supervisors)',
+            ],
+            'description' => [
+                'key' => 'email_template_pending_user_desc',
+                'fallback' => 'Sent to supervisors and admins when a new single sign-on account requires approval.',
+            ],
+            'placeholders' => [
+                'user_display' => [
+                    'key' => 'email_template_pending_user_placeholder_display',
+                    'fallback' => 'Display name of the pending user',
+                ],
+                'user_email' => [
+                    'key' => 'email_template_pending_user_placeholder_email',
+                    'fallback' => 'Email address of the pending user',
+                ],
+                'submitted_at' => [
+                    'key' => 'email_template_pending_user_placeholder_submitted',
+                    'fallback' => 'Timestamp when the request was submitted',
+                ],
+                'pending_accounts_url' => [
+                    'key' => 'email_template_pending_user_placeholder_url',
+                    'fallback' => 'Link to the pending approvals page',
+                ],
+            ],
         ],
         'account_approved' => [
-            'subject' => 'Your HR Assessment access has been approved',
-            'html' => <<<'HTML'
+            'defaults' => [
+                'subject' => 'Your HR Assessment access has been approved',
+                'html' => <<<'HTML'
 <p>Hello {{user_name}},</p>
 <p>Your supervisor has approved your access to the HR Assessment portal. You can now sign in and complete your assessments.</p>
 {{next_assessment_block}}
 <p><a href="{{login_url}}">Sign in to the portal</a></p>
 <p>Thank you.</p>
 HTML,
+            ],
+            'title' => [
+                'key' => 'email_template_account_approved_title',
+                'fallback' => 'Account approval notice (to staff)',
+            ],
+            'description' => [
+                'key' => 'email_template_account_approved_desc',
+                'fallback' => 'Sent to a staff member after their access request is approved.',
+            ],
+            'placeholders' => [
+                'user_name' => [
+                    'key' => 'email_template_account_approved_placeholder_name',
+                    'fallback' => 'Name of the recipient',
+                ],
+                'login_url' => [
+                    'key' => 'email_template_account_approved_placeholder_login',
+                    'fallback' => 'Sign-in URL for the portal',
+                ],
+                'next_assessment_block' => [
+                    'key' => 'email_template_account_approved_placeholder_next',
+                    'fallback' => 'HTML paragraph shown when a next assessment date is available',
+                ],
+            ],
         ],
         'next_assessment' => [
-            'subject' => 'Upcoming assessment scheduled',
-            'html' => <<<'HTML'
+            'defaults' => [
+                'subject' => 'Upcoming assessment scheduled',
+                'html' => <<<'HTML'
 <p>Hello {{user_name}},</p>
 <p>A supervisor has scheduled your next assessment for {{next_assessment_date}}.</p>
 <p>Please log in to the HR Assessment portal to prepare and complete any required steps.</p>
 <p><a href="{{portal_url}}">Open the HR Assessment portal</a></p>
 <p>Thank you.</p>
 HTML,
+            ],
+            'title' => [
+                'key' => 'email_template_next_assessment_title',
+                'fallback' => 'Upcoming assessment reminder (to staff)',
+            ],
+            'description' => [
+                'key' => 'email_template_next_assessment_desc',
+                'fallback' => 'Sent to staff when a supervisor schedules their next assessment.',
+            ],
+            'placeholders' => [
+                'user_name' => [
+                    'key' => 'email_template_next_assessment_placeholder_name',
+                    'fallback' => 'Name of the recipient',
+                ],
+                'next_assessment_date' => [
+                    'key' => 'email_template_next_assessment_placeholder_date',
+                    'fallback' => 'Scheduled assessment date',
+                ],
+                'portal_url' => [
+                    'key' => 'email_template_next_assessment_placeholder_portal',
+                    'fallback' => 'Link to the HR Assessment portal',
+                ],
+            ],
         ],
         'assignment_update' => [
-            'subject' => 'Questionnaire assignments updated',
-            'html' => <<<'HTML'
+            'defaults' => [
+                'subject' => 'Questionnaire assignments updated',
+                'html' => <<<'HTML'
 <p>Hello {{user_name}},</p>
 {{assignment_summary}}
 {{next_assessment_block}}
@@ -52,8 +142,56 @@ HTML,
 <p>You can review your questionnaires here: <a href="{{dashboard_url}}">{{dashboard_url}}</a></p>
 <p>Thank you.</p>
 HTML,
+            ],
+            'title' => [
+                'key' => 'email_template_assignment_update_title',
+                'fallback' => 'Questionnaire assignment update',
+            ],
+            'description' => [
+                'key' => 'email_template_assignment_update_desc',
+                'fallback' => 'Sent to staff (and optionally the assigning supervisor) when questionnaire assignments change.',
+            ],
+            'placeholders' => [
+                'user_name' => [
+                    'key' => 'email_template_assignment_update_placeholder_name',
+                    'fallback' => 'Name of the recipient',
+                ],
+                'assignment_summary' => [
+                    'key' => 'email_template_assignment_update_placeholder_summary',
+                    'fallback' => 'HTML list describing assigned questionnaires',
+                ],
+                'next_assessment_block' => [
+                    'key' => 'email_template_assignment_update_placeholder_next',
+                    'fallback' => 'HTML paragraph shown when a next assessment date is set',
+                ],
+                'assigner_block' => [
+                    'key' => 'email_template_assignment_update_placeholder_assigner',
+                    'fallback' => 'HTML paragraph that names the supervisor who made the change',
+                ],
+                'dashboard_url' => [
+                    'key' => 'email_template_assignment_update_placeholder_dashboard',
+                    'fallback' => 'Link to the dashboard for reviewing questionnaires',
+                ],
+            ],
         ],
     ];
+
+    return $registry;
+}
+
+/**
+ * Return the built-in set of email templates used by the application.
+ *
+ * @return array<string, array{subject: string, html: string}>
+ */
+function default_email_templates(): array
+{
+    $defaults = [];
+    foreach (email_template_registry() as $key => $definition) {
+        $defaults[$key] = $definition['defaults'];
+    }
+
+    return $defaults;
 }
 
 /**
@@ -81,13 +219,13 @@ function normalize_email_templates($value): array
         if (!isset($defaults[$key]) || !is_array($template)) {
             continue;
         }
-        $subject = isset($template['subject']) ? (string)$template['subject'] : '';
-        $html = isset($template['html']) ? (string)$template['html'] : '';
-        $subject = trim($subject) !== '' ? $subject : $defaults[$key]['subject'];
-        $html = trim($html) !== '' ? $html : $defaults[$key]['html'];
+
+        $subject = isset($template['subject']) ? trim((string)$template['subject']) : '';
+        $html = isset($template['html']) ? trim((string)$template['html']) : '';
+
         $result[$key] = [
-            'subject' => $subject,
-            'html' => $html,
+            'subject' => $subject !== '' ? $subject : $defaults[$key]['subject'],
+            'html' => $html !== '' ? $html : $defaults[$key]['html'],
         ];
     }
 

--- a/lib/notifications.php
+++ b/lib/notifications.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/mailer.php';
 require_once __DIR__ . '/path.php';
+require_once __DIR__ . '/email_templates.php';
 
 function notification_resolve_template(array $cfg, string $key, array $variables): array
 {

--- a/tests/email_templates_test.php
+++ b/tests/email_templates_test.php
@@ -67,11 +67,32 @@ function test_encode_email_templates_returns_json(): void
     assert_same('<p>Hello</p>', $decoded['next_assessment']['html'], 'Encoded JSON should include normalized HTML.');
 }
 
+function test_email_template_registry_is_consistent(): void
+{
+    $registry = email_template_registry();
+    $defaults = default_email_templates();
+
+    assert_same(array_keys($defaults), array_keys($registry), 'Registry should define the same templates as the defaults.');
+
+    foreach ($defaults as $key => $template) {
+        assert_same($template, $registry[$key]['defaults'], 'Registry defaults should match default_email_templates.');
+        foreach ($registry[$key]['placeholders'] as $placeholderToken => $metadata) {
+            if (!isset($metadata['key'], $metadata['fallback'])) {
+                throw new RuntimeException('Registry placeholders require translation metadata.');
+            }
+            if (!is_string($metadata['key']) || !is_string($metadata['fallback'])) {
+                throw new RuntimeException('Registry placeholder metadata must be strings.');
+            }
+        }
+    }
+}
+
 function run_email_template_tests(): void
 {
     test_normalize_email_templates_from_json();
     test_normalize_email_templates_from_array();
     test_encode_email_templates_returns_json();
+    test_email_template_registry_is_consistent();
 }
 
 run_email_template_tests();


### PR DESCRIPTION
## Summary
- centralize the email template defaults and translation metadata in a shared registry
- build the admin settings email-template descriptions from the registry and ensure notifications load the helpers
- extend automated coverage for the email template utilities

## Testing
- php tests/email_templates_test.php
- php -l lib/email_templates.php

------
https://chatgpt.com/codex/tasks/task_e_690650f99240832db4c1e655f2736423