### PR TITLE
Improve questionnaire builder scoring tools

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -15,6 +15,47 @@ $qbStrings = [
         'qb_weight_hint',
         'Only weighted questions contribute to scoring and analytics. Items left at 0 are excluded from scores and charts.'
     ),
+    'scoringSummaryTitle' => t($t, 'qb_scoring_summary_heading', 'Scoring summary'),
+    'scoringSummaryManualLabel' => t($t, 'qb_scoring_manual_total', 'Manual weight total'),
+    'scoringSummaryEffectiveLabel' => t($t, 'qb_scoring_effective_total', 'Effective score total'),
+    'scoringSummaryCountLabel' => t($t, 'qb_scoring_count_label', 'Scorable items'),
+    'scoringSummaryWeightedLabel' => t($t, 'qb_scoring_weighted_label', 'Items counted'),
+    'scoringSummaryActionsLabel' => t($t, 'qb_scoring_actions_label', 'Scoring tools'),
+    'normalizeWeights' => t($t, 'qb_scoring_normalize', 'Normalize to 100%'),
+    'evenWeights' => t($t, 'qb_scoring_even', 'Split evenly'),
+    'clearWeights' => t($t, 'qb_scoring_clear', 'Clear weights'),
+    'likertAutoNote' => t(
+        $t,
+        'qb_scoring_likert_note',
+        'Likert questions automatically share 100% of the score in analytics.'
+    ),
+    'nonLikertIgnoredNote' => t(
+        $t,
+        'qb_scoring_nonlikert_note',
+        'While a questionnaire contains Likert questions, other question types are excluded from scoring.'
+    ),
+    'missingWeightsWarning' => t(
+        $t,
+        'qb_scoring_missing_warning',
+        'Dashboards will show “Not scored” unless at least one question has weight.'
+    ),
+    'manualTotalOffWarning' => t(
+        $t,
+        'qb_scoring_manual_total_warning',
+        'Manual weights currently add up to %s%%.'
+    ),
+    'manualTotalOk' => t($t, 'qb_scoring_manual_total_ok', 'Manual weights currently add up to %s%%.'),
+    'noScorableNote' => t(
+        $t,
+        'qb_scoring_no_scorable',
+        'Add Likert or weighted questions to enable scoring.'
+    ),
+    'normalizeSuccess' => t($t, 'qb_scoring_normalize_success', 'Weights normalized to total 100%.'),
+    'normalizeNoop' => t($t, 'qb_scoring_normalize_noop', 'Add weights to questions before normalizing.'),
+    'evenSuccess' => t($t, 'qb_scoring_even_success', 'Split weights evenly across scorable questions.'),
+    'evenNoop' => t($t, 'qb_scoring_even_noop', 'Add scorable questions before splitting weights.'),
+    'clearSuccess' => t($t, 'qb_scoring_clear_success', 'Cleared all question weights.'),
+    'clearNoop' => t($t, 'qb_scoring_clear_noop', 'No weights to clear.'),
 ];
 
 const LIKERT_DEFAULT_OPTIONS = [

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -201,6 +201,101 @@
   margin: 0;
 }
 
+.qb-scoring-summary {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  background: var(--app-surface-alt, rgba(32, 84, 147, 0.05));
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.qb-scoring-summary-heading {
+  margin: 0;
+}
+
+.qb-scoring-metrics {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.qb-scoring-metric {
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.qb-scoring-metric dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--app-muted);
+}
+
+.qb-scoring-metric dd {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--app-primary-dark, var(--app-primary));
+}
+
+.qb-scoring-messages {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.qb-scoring-message {
+  font-size: 0.85rem;
+  color: var(--app-muted);
+}
+
+.qb-scoring-message[data-type="warning"] {
+  color: var(--app-danger, #b10d0d);
+}
+
+.qb-scoring-message[data-type="success"] {
+  color: var(--status-success-text, #1a7f37);
+}
+
+.qb-scoring-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.qb-scoring-actions-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--app-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.qb-scoring-actions-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.qb-scoring-actions-buttons .md-button {
+  --md-button-padding-x: 0.85rem;
+  --md-button-padding-y: 0.35rem;
+  font-size: 0.85rem;
+}
+
 .qb-list {
   margin-top: 1rem;
   display: flex;


### PR DESCRIPTION
## Summary
- add localized questionnaire builder strings for scoring summary messaging and actions
- show a scoring summary panel with live weight validation plus normalize/even/clear helpers in the questionnaire builder UI
- style the new scoring summary block to match existing material design cues

## Testing
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_69064f994128832dbdb167da77989fe8