### PR TITLE
Auto-approve submissions when reviews are disabled

### DIFF
--- a/lang/am.json
+++ b/lang/am.json
@@ -386,6 +386,8 @@
   "review_queue": "የግምገማ ሰሌዳ",
   "review_disabled_notice": "የተቆጣጣሪ ግምገማዎች በአሁኑ ጊዜ በቅንብሮች ውስጥ ተዘግተዋል።",
   "review_disabled_settings_link": "የግምገማ ቅንብሮችን ያዘምኑ",
+  "auto_approve_notice": "Pending submissions were automatically approved.",
+  "auto_approve_failed": "Settings saved, but pending submissions could not be finalized automatically.",
   "no_pending_reviews": "በአሁኑ ጊዜ ለግምገማ የሚጠብቁ ማቅረቦች የሉም።",
   "role": "ሚና",
   "role_admin": "አስተዳዳሪ",

--- a/lang/en.json
+++ b/lang/en.json
@@ -380,6 +380,8 @@
   "review_queue": "Review Queue",
   "review_disabled_notice": "Supervisor reviews are currently disabled in Settings.",
   "review_disabled_settings_link": "Update review settings",
+  "auto_approve_notice": "Pending submissions were automatically approved.",
+  "auto_approve_failed": "Settings saved, but pending submissions could not be finalized automatically.",
   "no_pending_reviews": "There are no submissions awaiting review right now.",
   "role": "Role",
   "role_admin": "admin",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -386,6 +386,8 @@
   "review_queue": "File d'examen",
   "review_disabled_notice": "Les revues des superviseurs sont actuellement désactivées dans les paramètres.",
   "review_disabled_settings_link": "Mettre à jour les paramètres de revue",
+  "auto_approve_notice": "Les soumissions en attente ont été approuvées automatiquement.",
+  "auto_approve_failed": "Paramètres enregistrés, mais les soumissions en attente n'ont pas pu être finalisées automatiquement.",
   "no_pending_reviews": "Aucune soumission n'attend actuellement de revue.",
   "role": "Rôle",
   "role_admin": "administrateur",


### PR DESCRIPTION
## Summary
- automatically approve existing submitted responses when supervisors disable the review workflow in settings and show a notice when approvals are applied
- auto-approve new questionnaire submissions whenever the review workflow is turned off so staff are not blocked
- add translation strings for the new auto-approval messaging

## Testing
- php tests/email_templates_test.php
- php tests/smtp_config_test.php

------
https://chatgpt.com/codex/tasks/task_e_6906a42ee1a4832dabef31440dc2e8fe