### PR TITLE
Add questionnaire assignment controls to user management

### DIFF
--- a/admin/users.php
+++ b/admin/users.php
@@ -9,6 +9,44 @@ $cfg = get_site_config($pdo);
 $workFunctionOptions = work_function_choices($pdo);
 $defaultWorkFunction = array_key_first($workFunctionOptions) ?? 'general_service';
 
+$questionnaires = [];
+$questionnaireMap = [];
+try {
+    $questionnaireStmt = $pdo->query('SELECT id, title, description FROM questionnaire ORDER BY title ASC');
+    if ($questionnaireStmt) {
+        $questionnaires = $questionnaireStmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($questionnaires as $row) {
+            $qid = isset($row['id']) ? (int)$row['id'] : 0;
+            if ($qid > 0) {
+                $questionnaireMap[$qid] = $row;
+            }
+        }
+    }
+} catch (PDOException $e) {
+    error_log('Admin user questionnaire list failed: ' . $e->getMessage());
+    $questionnaires = [];
+    $questionnaireMap = [];
+}
+
+$defaultAssignmentsByWorkFunction = [];
+if ($questionnaireMap) {
+    try {
+        $defaultsStmt = $pdo->query('SELECT questionnaire_id, work_function FROM questionnaire_work_function');
+        if ($defaultsStmt) {
+            foreach ($defaultsStmt->fetchAll(PDO::FETCH_ASSOC) as $defaultRow) {
+                $qid = isset($defaultRow['questionnaire_id']) ? (int)$defaultRow['questionnaire_id'] : 0;
+                $wf = trim((string)($defaultRow['work_function'] ?? ''));
+                if ($qid > 0 && $wf !== '') {
+                    $defaultAssignmentsByWorkFunction[$wf][] = $qid;
+                }
+            }
+        }
+    } catch (PDOException $e) {
+        error_log('Admin user questionnaire defaults failed: ' . $e->getMessage());
+        $defaultAssignmentsByWorkFunction = [];
+    }
+}
+
 $msg = $_SESSION['admin_users_flash'] ?? '';
 if ($msg !== '') {
     unset($_SESSION['admin_users_flash']);
@@ -113,6 +151,20 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $workFunction = $_POST['work_function'] ?? $defaultWorkFunction;
         $accountStatus = $_POST['account_status'] ?? 'active';
         $nextAssessment = trim($_POST['next_assessment_date'] ?? '');
+        $questionnaireIds = [];
+        $postedQuestionnaires = $_POST['questionnaire_ids'] ?? [];
+        if (!is_array($postedQuestionnaires)) {
+            $postedQuestionnaires = [$postedQuestionnaires];
+        }
+        foreach ($postedQuestionnaires as $value) {
+            if (is_numeric($value)) {
+                $qid = (int)$value;
+                if ($qid > 0 && isset($questionnaireMap[$qid])) {
+                    $questionnaireIds[$qid] = $qid;
+                }
+            }
+        }
+        $questionnaireIds = array_values($questionnaireIds);
         if (!in_array($accountStatus, ['active','pending','disabled'], true)) {
             $accountStatus = 'active';
         }
@@ -135,6 +187,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             } else {
                 if (!isset($workFunctionOptions[$workFunction])) { $workFunction = $defaultWorkFunction; }
                 $existingUser = null;
+                $existingAssignments = [];
                 if ($id > 0) {
                     try {
                         $existingStmt = $pdo->prepare('SELECT id, email, full_name, username, account_status, next_assessment_date FROM users WHERE id = ?');
@@ -142,6 +195,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $existingUser = $existingStmt->fetch(PDO::FETCH_ASSOC) ?: null;
                     } catch (PDOException $e) {
                         error_log('Admin user existing fetch failed: ' . $e->getMessage());
+                    }
+                    try {
+                        $assignmentStmt = $pdo->prepare('SELECT questionnaire_id FROM questionnaire_assignment WHERE staff_id = ? ORDER BY questionnaire_id');
+                        $assignmentStmt->execute([$id]);
+                        $existingAssignments = array_map('intval', $assignmentStmt->fetchAll(PDO::FETCH_COLUMN));
+                    } catch (PDOException $e) {
+                        error_log('Admin user assignment fetch failed: ' . $e->getMessage());
+                        $existingAssignments = [];
                     }
                 }
                 $fields = ['role = ?', 'work_function = ?', 'account_status = ?', 'next_assessment_date = ?'];
@@ -156,8 +217,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
                 $sql = 'UPDATE users SET ' . implode(', ', $fields) . $profileReset . ' WHERE id = ?';
                 try {
+                    $pdo->beginTransaction();
                     $stm = $pdo->prepare($sql);
                     $stm->execute($params);
+                    $assignmentChanged = false;
+                    if ($role !== 'staff') {
+                        if ($existingAssignments) {
+                            $assignmentChanged = true;
+                        }
+                        $deleteAssignments = $pdo->prepare('DELETE FROM questionnaire_assignment WHERE staff_id = ?');
+                        $deleteAssignments->execute([$id]);
+                        $questionnaireIds = [];
+                    } else {
+                        $normalizedExisting = $existingAssignments;
+                        sort($normalizedExisting);
+                        $normalizedNew = $questionnaireIds;
+                        sort($normalizedNew);
+                        $assignmentChanged = $normalizedExisting !== $normalizedNew;
+                        $deleteAssignments = $pdo->prepare('DELETE FROM questionnaire_assignment WHERE staff_id = ?');
+                        $deleteAssignments->execute([$id]);
+                        if ($questionnaireIds) {
+                            $insertAssignment = $pdo->prepare('INSERT INTO questionnaire_assignment (staff_id, questionnaire_id, assigned_by) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE assigned_by = VALUES(assigned_by), assigned_at = CURRENT_TIMESTAMP');
+                            $assignerId = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : null;
+                            foreach ($questionnaireIds as $qid) {
+                                $insertAssignment->execute([$id, $qid, $assignerId]);
+                            }
+                        }
+                    }
+                    $pdo->commit();
                     if ($accountStatus === 'active' && $nextAssessment) {
                         try {
                             $updatedStmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');
@@ -174,9 +261,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                                 notify_user_next_assessment($cfg, $updatedUser, $nextAssessment);
                             }
                         }
+                    } else {
+                        try {
+                            $updatedStmt = $pdo->prepare('SELECT * FROM users WHERE id = ?');
+                            $updatedStmt->execute([$id]);
+                            $updatedUser = $updatedStmt->fetch(PDO::FETCH_ASSOC);
+                        } catch (PDOException $e) {
+                            $updatedUser = null;
+                            error_log('Admin user update post-fetch failed: ' . $e->getMessage());
+                        }
+                    }
+                    if (!isset($updatedUser)) {
+                        $updatedUser = null;
+                    }
+                    if (($role === 'staff') && $assignmentChanged && $updatedUser) {
+                        $assignedTitles = [];
+                        foreach ($questionnaireIds as $qid) {
+                            $title = trim((string)($questionnaireMap[$qid]['title'] ?? ''));
+                            if ($title === '') {
+                                $title = t($t, 'questionnaire', 'Questionnaire');
+                            }
+                            $assignedTitles[] = $title;
+                        }
+                        sort($assignedTitles, SORT_NATURAL | SORT_FLAG_CASE);
+                        $assigner = $_SESSION['user'] ?? null;
+                        notify_questionnaire_assignment_update($cfg, $updatedUser, $assignedTitles, $assigner);
                     }
                     $msg = t($t, 'user_updated', 'User updated successfully.');
                 } catch (PDOException $e) {
+                    if ($pdo->inTransaction()) {
+                        $pdo->rollBack();
+                    }
                     error_log('Admin user update failed: ' . $e->getMessage());
                     $msg = t($t, 'user_update_failed', 'Unable to update user. Please try again.');
                 }
@@ -196,6 +311,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 }
 $rows = $pdo->query("SELECT * FROM users ORDER BY id DESC")->fetchAll();
+$assignmentsByStaff = [];
+try {
+    $assignmentListStmt = $pdo->query('SELECT staff_id, questionnaire_id FROM questionnaire_assignment ORDER BY staff_id, questionnaire_id');
+    if ($assignmentListStmt) {
+        foreach ($assignmentListStmt->fetchAll(PDO::FETCH_ASSOC) as $assignmentRow) {
+            $sid = isset($assignmentRow['staff_id']) ? (int)$assignmentRow['staff_id'] : 0;
+            $qid = isset($assignmentRow['questionnaire_id']) ? (int)$assignmentRow['questionnaire_id'] : 0;
+            if ($sid > 0 && $qid > 0) {
+                $assignmentsByStaff[$sid][] = $qid;
+            }
+        }
+    }
+} catch (PDOException $e) {
+    error_log('Admin user assignment listing failed: ' . $e->getMessage());
+    $assignmentsByStaff = [];
+}
 $roleLabels = [];
 foreach ($roleOptions as $option) {
     $label = (string)($option['label'] ?? $option['role_key']);
@@ -230,7 +361,8 @@ foreach ($rows as $r) {
     }
     $initials = mb_strtoupper(mb_substr($initials, 0, 2, 'UTF-8'), 'UTF-8');
     $email = trim((string)($r['email'] ?? ''));
-    $workFunctionLabel = work_function_label($pdo, (string)($r['work_function'] ?? ''));
+    $workFunctionKey = (string)($r['work_function'] ?? '');
+    $workFunctionLabel = work_function_label($pdo, $workFunctionKey);
     $nextAssessment = $r['next_assessment_date'] ?? '';
     $nextAssessmentDisplay = '—';
     if ($nextAssessment !== '') {
@@ -245,6 +377,31 @@ foreach ($rows as $r) {
     }
     $roleKey = $r['role'] ?? 'staff';
     $roleLabel = $roleLabels[$roleKey] ?? $roleKey;
+    $userId = (int)$r['id'];
+    $assignedIds = array_map('intval', $assignmentsByStaff[$userId] ?? []);
+    $defaultIds = array_map('intval', $defaultAssignmentsByWorkFunction[$workFunctionKey] ?? []);
+    $defaultIds = array_values(array_unique(array_filter($defaultIds, static fn ($val) => $val > 0)));
+    sort($defaultIds);
+    if ($defaultIds) {
+        $assignedIds = array_values(array_diff($assignedIds, $defaultIds));
+    }
+    sort($assignedIds);
+    $assignedTitles = [];
+    foreach ($assignedIds as $assignedId) {
+        $title = trim((string)($questionnaireMap[$assignedId]['title'] ?? ''));
+        if ($title === '') {
+            $title = t($t, 'questionnaire', 'Questionnaire');
+        }
+        $assignedTitles[] = $title;
+    }
+    $defaultTitles = [];
+    foreach ($defaultIds as $defaultId) {
+        $title = trim((string)($questionnaireMap[$defaultId]['title'] ?? ''));
+        if ($title === '') {
+            $title = t($t, 'questionnaire', 'Questionnaire');
+        }
+        $defaultTitles[] = $title;
+    }
     $lastName = '';
     if ($fullName !== '') {
         $lastNameParts = preg_split('/\s+/u', trim($fullName));
@@ -276,7 +433,11 @@ foreach ($rows as $r) {
         'created_at' => $createdAt,
         'role_key' => $roleKey,
         'role_label' => $roleLabel,
-        'work_function_key' => $r['work_function'] ?? '',
+        'work_function_key' => $workFunctionKey,
+        'assigned_ids' => $assignedIds,
+        'assigned_titles' => $assignedTitles,
+        'default_ids' => $defaultIds,
+        'default_titles' => $defaultTitles,
         'search_last' => $searchLast,
         'search_full' => $searchFull,
         'search_username' => $searchUser,
@@ -309,6 +470,36 @@ foreach ($rows as $r) {
     padding: 1rem;
     color: var(--app-muted);
     font-style: italic;
+  }
+  .md-user-assignment-field select {
+    min-height: 8rem;
+  }
+  .md-user-assignment-hint {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--app-muted);
+  }
+  .md-user-assignment-defaults {
+    margin: 0.5rem 0 0;
+    padding: 0.65rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid var(--app-border, #d0d5dd);
+    background: var(--app-surface-alt, rgba(229, 231, 235, 0.35));
+    font-size: 0.85rem;
+    color: var(--app-muted, #475467);
+  }
+  .md-user-assignment-defaults strong {
+    display: block;
+    margin-bottom: 0.35rem;
+    color: var(--app-text-primary, #1f2937);
+  }
+  .md-user-assignment-defaults ul {
+    margin: 0;
+    padding-left: 1.1rem;
+  }
+  .md-user-assignment-defaults li {
+    margin: 0.2rem 0;
   }
 </style>
 </head>
@@ -349,6 +540,7 @@ foreach ($rows as $r) {
 <button name="create" class="md-button md-primary md-elev-2 md-user-action-button"><?=t($t,'create','Create')?></button>
 </form></div>
 
+<div id="questionnaire-assignments"></div>
 <div class="md-card md-elev-2"><h2 class="md-card-title"><?=t($t,'manage_users','Manage Users')?></h2>
   <?php if (!$rows): ?>
     <p class="md-empty-state"><?=t($t,'no_users_found','No user accounts were found. Create a new account to get started.')?></p>
@@ -438,6 +630,54 @@ foreach ($rows as $r) {
                   <span><?=t($t,'next_assessment','Next Assessment Date')?></span>
                   <input type="date" name="next_assessment_date" value="<?=htmlspecialchars($record['next_assessment'], ENT_QUOTES, 'UTF-8')?>">
                 </label>
+                <label class="md-field md-field--compact md-user-assignment-field">
+                  <span><?=t($t,'assign_questionnaires','Assign Questionnaires')?></span>
+                  <?php $assignmentSelectSize = max(6, min(12, count($questionnaires))); ?>
+                  <select name="questionnaire_ids[]" multiple size="<?=$assignmentSelectSize?>">
+                    <?php foreach ($questionnaires as $questionnaire): ?>
+                      <?php $qid = (int)($questionnaire['id'] ?? 0); ?>
+                      <?php if ($qid <= 0) { continue; } ?>
+                      <?php $title = trim((string)($questionnaire['title'] ?? '')); ?>
+                      <?php if ($title === '') { $title = t($t,'questionnaire','Questionnaire'); } ?>
+                      <?php $description = trim((string)($questionnaire['description'] ?? '')); ?>
+                      <option value="<?=$qid?>" <?=in_array($qid, $record['assigned_ids'], true)?'selected':''?>>
+                        <?=htmlspecialchars($title, ENT_QUOTES, 'UTF-8')?><?php if ($description !== ''): ?> — <?=htmlspecialchars($description, ENT_QUOTES, 'UTF-8')?><?php endif; ?>
+                      </option>
+                    <?php endforeach; ?>
+                  </select>
+                  <small class="md-user-assignment-hint"><?=t($t,'assignment_instructions','Choose the questionnaires that should be available to this staff member.')?></small>
+                </label>
+                <?php if ($record['assigned_titles']): ?>
+                  <div class="md-user-assignment-defaults">
+                    <strong><?=t($t,'currently_assigned','Currently assigned questionnaires:')?></strong>
+                    <ul>
+                      <?php foreach ($record['assigned_titles'] as $assignedTitle): ?>
+                        <li><?=htmlspecialchars($assignedTitle, ENT_QUOTES, 'UTF-8')?></li>
+                      <?php endforeach; ?>
+                    </ul>
+                  </div>
+                <?php endif; ?>
+                <?php if ($record['role_key'] === 'staff'): ?>
+                  <?php if ($record['default_titles']): ?>
+                    <div class="md-user-assignment-defaults">
+                      <strong><?=t($t,'assignment_defaults_hint','These questionnaires are automatically available because of the staff member\'s work function. They cannot be removed here.')?></strong>
+                      <ul>
+                        <?php foreach ($record['default_titles'] as $defaultTitle): ?>
+                          <li><?=htmlspecialchars($defaultTitle, ENT_QUOTES, 'UTF-8')?></li>
+                        <?php endforeach; ?>
+                      </ul>
+                    </div>
+                  <?php else: ?>
+                    <p class="md-user-assignment-defaults"><?=t($t,'assignment_defaults_none','This work function does not have default questionnaires yet.')?></p>
+                  <?php endif; ?>
+                  <?php if (!$questionnaires): ?>
+                    <p class="md-user-assignment-defaults"><?=t($t,'no_questionnaires_configured','No questionnaires are configured yet.')?></p>
+                  <?php endif; ?>
+                <?php elseif (!$questionnaires): ?>
+                  <p class="md-user-assignment-defaults"><?=t($t,'no_questionnaires_configured','No questionnaires are configured yet.')?></p>
+                <?php else: ?>
+                  <p class="md-user-assignment-defaults"><?=t($t,'assignment_staff_only','Questionnaires are only assigned to staff accounts. These selections will take effect once the user role is set to staff.')?></p>
+                <?php endif; ?>
               </div>
               <div class="md-user-form-actions">
                 <button name="reset" class="md-button md-elev-1 md-user-action-button"><?=t($t,'apply','Apply')?></button>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -261,7 +261,7 @@
           };
           const warmRoutes = ['my_performance.php', 'submit_assessment.php', 'profile.php'];
           if (role === 'admin' || role === 'supervisor') {
-            warmRoutes.push('admin/analytics.php', 'admin/questionnaire_assignments.php');
+            warmRoutes.push('admin/analytics.php', 'admin/users.php');
           }
           const warmUrls = Array.from(new Set(warmRoutes.map(baseBuilder)));
           if (warmUrls.length === 0) {

--- a/lang/am.json
+++ b/lang/am.json
@@ -86,6 +86,7 @@
   "assignment_defaults_heading": "በየስራ ተግባር የተመደቡ",
   "assignment_defaults_hint": "እነዚህ ጥያቄዎች በሰራተኛው የስራ ተግባር መሠረት በራሱ ላይ ይጨመራሉ። ከዚህ ገጽ ላይ ማስወገዳቸው አይቻልም።",
   "assignment_defaults_none": "ለዚህ ስራ ተግባር እስካሁን የተመደቡ ጥያቄዎች የሉም።",
+  "assignment_staff_only": "ጥያቄዎች ለሰራተኛ መለያየት ብቻ ይተገበራሉ። እነዚህ ምርጫዎች ሚናው ሰራተኛ ሲሆን ብቻ ይቀናሉ።",
   "assignment_defaults_label": "የስራ ተግባር፡ %s",
   "assignment_default_badge": "ነባሪ",
   "available_version": "Available version",

--- a/lang/en.json
+++ b/lang/en.json
@@ -87,6 +87,7 @@
   "assignment_defaults_heading": "Work-function defaults",
   "assignment_defaults_hint": "These questionnaires are automatically available because of the staff member's work function. They cannot be removed here.",
   "assignment_defaults_none": "This work function does not have default questionnaires yet.",
+  "assignment_staff_only": "Questionnaires are only assigned to staff accounts. These selections will take effect once the user role is set to staff.",
   "assignment_defaults_label": "Work function: %s",
   "assignment_default_badge": "Default",
   "available_version": "Available version",

--- a/templates/header.php
+++ b/templates/header.php
@@ -352,7 +352,11 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
           <li><a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.review_queue')?>><?=t($t, 'review_queue', 'Review Queue')?></a></li>
           <?php endif; ?>
           <li><a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.pending_accounts')?>><?=t($t, 'pending_accounts', 'Pending Approvals')?></a></li>
+          <?php if ($role === 'admin'): ?>
+          <li><a href="<?=htmlspecialchars(url_for('admin/users.php') . '#questionnaire-assignments', ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments','admin.users')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a></li>
+          <?php else: ?>
           <li><a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a></li>
+          <?php endif; ?>
           <li><a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.analytics')?>><?=t($t, 'analytics', 'Analytics')?></a></li>
         </ul>
       </li>


### PR DESCRIPTION
## Summary
- add questionnaire assignment controls and summaries to the admin Manage Users page so staff availability is configured per user
- point the Assign Questionnaires navigation link at the new section for admins and warm the updated route
- extend locale strings to cover the new helper messaging for assignment behaviour

## Testing
- php -l admin/users.php
- php -l templates/header.php
- php -r 'json_decode(file_get_contents("lang/en.json")); if (json_last_error()) { echo json_last_error_msg(); exit(1);} '
- php -r 'json_decode(file_get_contents("lang/am.json")); if (json_last_error()) { echo json_last_error_msg(); exit(1);} '


------
https://chatgpt.com/codex/tasks/task_e_6906a596abd0832db28557abbf68d748