### PR TITLE
Add request throttling to harden public endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Environment variables are read directly via `getenv`. Set them in your shell or 
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS`
 - `BASE_URL` (defaults to `/`)
 - `APP_DEBUG` (`1` to show errors in development, otherwise disable display of errors)
+- `RATE_LIMIT_REQUESTS` (optional; requests allowed per IP during the window, defaults to 240)
+- `RATE_LIMIT_WINDOW_SECONDS` (optional; rolling window length in seconds, defaults to 60)
 
 ### Single sign-on
 

--- a/config.php
+++ b/config.php
@@ -10,6 +10,9 @@ if (!defined('APP_BOOTSTRAPPED')) {
     ini_set('display_errors', $appDebug ? '1' : '0');
     error_reporting(E_ALL);
 
+    require_once __DIR__ . '/lib/rate_limiter.php';
+    enforce_rate_limit($_SERVER);
+
     if (session_status() !== PHP_SESSION_ACTIVE) {
         session_start();
     }

--- a/docs/security-assessment.md
+++ b/docs/security-assessment.md
@@ -1,0 +1,19 @@
+# Security assessment – HRassess v3.0.1
+
+Date: 2025-11-03
+
+## Scope
+- Public landing and authentication endpoints (e.g. `index.php`, `login.php`, `oauth.php`).
+- Shared bootstrap (`config.php`) and supporting libraries used by all user-facing requests.
+
+## Summary of findings
+- **Strengths**: The application enables strict transport security, a Content Security Policy with nonces, and disables dangerous legacy browser features via modern security headers.
+- **Gap**: No request throttling was in place. This left `login.php`, the API explorer, and other heavy database-backed pages vulnerable to resource exhaustion via repeated unauthenticated requests, increasing the impact of volumetric or application-layer DDoS attacks.
+
+## Remediation
+- Added a lightweight IP-based rate limiter that enforces a rolling quota (default 240 requests per minute) before sessions and database connections are initialised. Responses over the limit receive HTTP 429 with a `Retry-After` header.
+- Exposed `RATE_LIMIT_REQUESTS` and `RATE_LIMIT_WINDOW_SECONDS` environment variables so operators can tune limits to their deployment size.
+
+## Residual risk & recommendations
+- The file-backed limiter is suitable for single-node deployments. For clustered environments, migrate the limiter storage to a shared cache such as Redis or Memcached to retain global visibility of request volume.
+- Continue to deploy the service behind a network-layer DDoS mitigation provider (cloud WAF or CDN) to block volumetric floods before they hit the origin.

--- a/lib/rate_limiter.php
+++ b/lib/rate_limiter.php
@@ -1,0 +1,79 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Lightweight IP-based rate limiter to slow abusive traffic and support DDoS resilience.
+ */
+function enforce_rate_limit(array $server, ?int $limit = null, ?int $intervalSeconds = null): void
+{
+    if (PHP_SAPI === 'cli') {
+        return;
+    }
+
+    $limit = $limit ?? (int) (getenv('RATE_LIMIT_REQUESTS') ?: 240);
+    $intervalSeconds = $intervalSeconds ?? (int) (getenv('RATE_LIMIT_WINDOW_SECONDS') ?: 60);
+
+    if ($limit <= 0 || $intervalSeconds <= 0) {
+        return;
+    }
+
+    $clientIp = trim((string) ($server['REMOTE_ADDR'] ?? ''));
+    if ($clientIp === '') {
+        $clientIp = 'unknown';
+    }
+
+    $storageDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'hrassess-rate-limiter';
+    if (!is_dir($storageDir) && !@mkdir($storageDir, 0770, true) && !is_dir($storageDir)) {
+        return;
+    }
+
+    $key = hash('sha256', $clientIp);
+    $filePath = $storageDir . DIRECTORY_SEPARATOR . $key . '.json';
+
+    $now = time();
+    $windowStart = $now - $intervalSeconds;
+
+    $handle = @fopen($filePath, 'c+');
+    if ($handle === false) {
+        return;
+    }
+
+    try {
+        if (!flock($handle, LOCK_EX)) {
+            return;
+        }
+
+        $contents = stream_get_contents($handle);
+        $records = [];
+        if ($contents !== false && $contents !== '') {
+            $decoded = json_decode($contents, true);
+            if (is_array($decoded)) {
+                $records = array_values(array_filter($decoded, static fn($ts) => is_int($ts) && $ts >= $windowStart));
+            }
+        }
+
+        if (count($records) >= $limit) {
+            send_rate_limited_response($intervalSeconds);
+        }
+
+        $records[] = $now;
+        ftruncate($handle, 0);
+        rewind($handle);
+        $encoded = json_encode($records);
+        if ($encoded !== false) {
+            fwrite($handle, $encoded);
+        }
+    } finally {
+        flock($handle, LOCK_UN);
+        fclose($handle);
+    }
+}
+
+function send_rate_limited_response(int $intervalSeconds): void
+{
+    http_response_code(429);
+    header('Content-Type: text/plain; charset=utf-8');
+    header('Retry-After: ' . max(1, $intervalSeconds));
+    echo 'Too many requests. Please try again later.';
+    exit;
+}


### PR DESCRIPTION
## Summary
- document the results of a security assessment covering public-facing endpoints
- add an IP-based rate limiter that executes before session and database initialisation
- expose new environment variables for tuning request limits and update configuration docs

## Testing
- php -l lib/rate_limiter.php

------
https://chatgpt.com/codex/tasks/task_e_6908d8abf6ac832d8a123ddc37c3d949