### PR TITLE
Implement questionnaire status and safe deactivation

### DIFF
--- a/admin/questionnaire_assignments.php
+++ b/admin/questionnaire_assignments.php
@@ -78,7 +78,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $assignedTitles = [];
             if ($staffDetails) {
                 try {
-                    $titlesStmt = $pdo->prepare('SELECT q.title FROM questionnaire_assignment qa JOIN questionnaire q ON q.id = qa.questionnaire_id WHERE qa.staff_id = ? ORDER BY q.title ASC');
+                    $titlesStmt = $pdo->prepare("SELECT q.title FROM questionnaire_assignment qa JOIN questionnaire q ON q.id = qa.questionnaire_id WHERE qa.staff_id = ? AND q.status='published' ORDER BY q.title ASC");
                     $titlesStmt->execute([$selectedStaffId]);
                     $titles = $titlesStmt->fetchAll(PDO::FETCH_COLUMN);
                     $fallbackTitle = t($t, 'questionnaire', 'Questionnaire');
@@ -112,7 +112,7 @@ if ($selectedStaffId <= 0) {
 
 $selectedStaffRecord = $staffById[$selectedStaffId] ?? null;
 try {
-    $questionnaireStmt = $pdo->query('SELECT id, title, description FROM questionnaire ORDER BY title ASC');
+    $questionnaireStmt = $pdo->query("SELECT id, title, description FROM questionnaire WHERE status='published' ORDER BY title ASC");
     $questionnaires = $questionnaireStmt ? $questionnaireStmt->fetchAll(PDO::FETCH_ASSOC) : [];
 } catch (PDOException $e) {
     error_log('questionnaire_assignments questionnaire fetch failed: ' . $e->getMessage());

--- a/admin/users.php
+++ b/admin/users.php
@@ -12,7 +12,7 @@ $defaultWorkFunction = array_key_first($workFunctionOptions) ?? 'general_service
 $questionnaires = [];
 $questionnaireMap = [];
 try {
-    $questionnaireStmt = $pdo->query('SELECT id, title, description FROM questionnaire ORDER BY title ASC');
+    $questionnaireStmt = $pdo->query("SELECT id, title, description FROM questionnaire WHERE status='published' ORDER BY title ASC");
     if ($questionnaireStmt) {
         $questionnaires = $questionnaireStmt->fetchAll(PDO::FETCH_ASSOC);
         foreach ($questionnaires as $row) {

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -338,6 +338,54 @@
   gap: 0.25rem;
 }
 
+.qb-status-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 180px;
+  align-items: flex-start;
+}
+
+.qb-status-select {
+  width: 100%;
+}
+
+.qb-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(107, 114, 128, 0.15);
+  color: #374151;
+}
+
+.qb-status-badge.qb-status-published {
+  background: rgba(16, 185, 129, 0.18);
+  color: #047857;
+}
+
+.qb-status-badge.qb-status-inactive {
+  background: rgba(148, 163, 184, 0.2);
+  color: #475569;
+}
+
+.qb-response-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--app-primary-dark, #1d4ed8);
+  white-space: nowrap;
+  align-self: flex-start;
+}
+
 .qb-section {
   border-left: 4px solid var(--app-primary);
   padding-left: 0.75rem;
@@ -403,6 +451,14 @@
   flex-wrap: wrap;
 }
 
+.qb-inactive {
+  opacity: 0.85;
+}
+
+.qb-section.qb-inactive {
+  border-color: var(--app-border);
+}
+
 .qb-field {
   display: flex;
   flex-direction: column;
@@ -451,6 +507,11 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.9rem;
+}
+
+.qb-status-toggle {
+  font-size: 0.85rem;
+  color: var(--app-muted);
 }
 
 .qb-checkbox input[type="checkbox"] {

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -139,28 +139,28 @@ VALUES
 ('EPSA-DRV-220', 'Fleet Safety Leadership', 'https://moodle.example.com/course/drv220', 'driver', 0, 85);
 
 -- Demo questionnaire -------------------------------------------------------------
-INSERT INTO questionnaire (title, description)
-VALUES ('EPSA Annual Performance Review 360', 'Five-year storyline covering supply chain modernization and people enablement.');
+INSERT INTO questionnaire (title, description, status)
+VALUES ('EPSA Annual Performance Review 360', 'Five-year storyline covering supply chain modernization and people enablement.', 'published');
 SET @demo_qid := LAST_INSERT_ID();
 
-INSERT INTO questionnaire_section (questionnaire_id, title, description, order_index)
+INSERT INTO questionnaire_section (questionnaire_id, title, description, order_index, is_active)
 VALUES
-(@demo_qid, 'Strategic Delivery', 'Measures how teams deliver essential health commodities.', 1),
-(@demo_qid, 'Operational Excellence', 'Assesses compliance and continuous improvement practices.', 2),
-(@demo_qid, 'Growth & Support', 'Captures development focus and mobility planning.', 3);
+(@demo_qid, 'Strategic Delivery', 'Measures how teams deliver essential health commodities.', 1, 1),
+(@demo_qid, 'Operational Excellence', 'Assesses compliance and continuous improvement practices.', 2, 1),
+(@demo_qid, 'Growth & Support', 'Captures development focus and mobility planning.', 3, 1);
 
 SET @section_strategic := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 1);
 SET @section_operational := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 2);
 SET @section_growth := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @demo_qid AND order_index = 3);
 
-INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent, allow_multiple, is_required)
+INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent, allow_multiple, is_required, is_active)
 VALUES
-(@demo_qid, @section_strategic, 'strategic_results', 'Delivery reliability to health facilities', 'likert', 1, 30, 0, 1),
-(@demo_qid, @section_operational, 'quality_controls', 'All mandatory compliance and safety trainings completed', 'boolean', 2, 15, 0, 1),
-(@demo_qid, @section_operational, 'achievement_story', 'Summarize the most significant contribution this cycle', 'textarea', 3, 20, 0, 1),
-(@demo_qid, @section_operational, 'stretch_contributions', 'Select notable stretch contributions achieved', 'choice', 4, 10, 1, 0),
-(@demo_qid, @section_growth, 'development_focus', 'Describe a development focus for the next cycle', 'textarea', 5, 15, 0, 1),
-(@demo_qid, @section_growth, 'mobility_readiness', 'Readiness for broader national responsibilities', 'likert', 6, 10, 0, 0);
+(@demo_qid, @section_strategic, 'strategic_results', 'Delivery reliability to health facilities', 'likert', 1, 30, 0, 1, 1),
+(@demo_qid, @section_operational, 'quality_controls', 'All mandatory compliance and safety trainings completed', 'boolean', 2, 15, 0, 1, 1),
+(@demo_qid, @section_operational, 'achievement_story', 'Summarize the most significant contribution this cycle', 'textarea', 3, 20, 0, 1, 1),
+(@demo_qid, @section_operational, 'stretch_contributions', 'Select notable stretch contributions achieved', 'choice', 4, 10, 1, 0, 1),
+(@demo_qid, @section_growth, 'development_focus', 'Describe a development focus for the next cycle', 'textarea', 5, 15, 0, 1, 1),
+(@demo_qid, @section_growth, 'mobility_readiness', 'Readiness for broader national responsibilities', 'likert', 6, 10, 0, 0, 1);
 
 INSERT INTO questionnaire_item_option (questionnaire_item_id, value, order_index)
 SELECT qi.id, opt.value, opt.order_index
@@ -415,25 +415,25 @@ JOIN users u ON u.id = qr.user_id
 WHERE qr.questionnaire_id = @demo_qid;
 
 -- Leadership confidence pulse questionnaire --------------------------------------
-INSERT INTO questionnaire (title, description)
-VALUES ('EPSA Leadership Confidence Pulse', 'Quarterly signal on leadership alignment and support needs.');
+INSERT INTO questionnaire (title, description, status)
+VALUES ('EPSA Leadership Confidence Pulse', 'Quarterly signal on leadership alignment and support needs.', 'published');
 SET @pulse_qid := LAST_INSERT_ID();
 
-INSERT INTO questionnaire_section (questionnaire_id, title, description, order_index)
+INSERT INTO questionnaire_section (questionnaire_id, title, description, order_index, is_active)
 VALUES
-(@pulse_qid, 'Leadership Behaviors', 'Signals from senior leaders on vision and coaching.', 1),
-(@pulse_qid, 'Support Systems', 'Escalation readiness and organisational clarity needs.', 2);
+(@pulse_qid, 'Leadership Behaviors', 'Signals from senior leaders on vision and coaching.', 1, 1),
+(@pulse_qid, 'Support Systems', 'Escalation readiness and organisational clarity needs.', 2, 1);
 
 SET @pulse_section_leadership := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @pulse_qid AND order_index = 1);
 SET @pulse_section_support := (SELECT id FROM questionnaire_section WHERE questionnaire_id = @pulse_qid AND order_index = 2);
 
-INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent, allow_multiple, is_required)
+INSERT INTO questionnaire_item (questionnaire_id, section_id, linkId, text, type, order_index, weight_percent, allow_multiple, is_required, is_active)
 VALUES
-(@pulse_qid, @pulse_section_leadership, 'vision_alignment', 'Alignment with EPSA transformation vision', 'likert', 1, 35, 0, 1),
-(@pulse_qid, @pulse_section_leadership, 'coaching_frequency', 'How frequently do you coach your team?', 'likert', 2, 25, 0, 1),
-(@pulse_qid, @pulse_section_support, 'escalation_clear', 'Escalation paths are clear and used effectively', 'boolean', 3, 10, 0, 0),
-(@pulse_qid, @pulse_section_support, 'priority_support', 'Where do you need senior support next?', 'textarea', 4, 15, 0, 0),
-(@pulse_qid, @pulse_section_support, 'org_clarity', 'Organisational direction is clear', 'likert', 5, 15, 0, 1);
+(@pulse_qid, @pulse_section_leadership, 'vision_alignment', 'Alignment with EPSA transformation vision', 'likert', 1, 35, 0, 1, 1),
+(@pulse_qid, @pulse_section_leadership, 'coaching_frequency', 'How frequently do you coach your team?', 'likert', 2, 25, 0, 1, 1),
+(@pulse_qid, @pulse_section_support, 'escalation_clear', 'Escalation paths are clear and used effectively', 'boolean', 3, 10, 0, 0, 1),
+(@pulse_qid, @pulse_section_support, 'priority_support', 'Where do you need senior support next?', 'textarea', 4, 15, 0, 0, 1),
+(@pulse_qid, @pulse_section_support, 'org_clarity', 'Organisational direction is clear', 'likert', 5, 15, 0, 1, 1);
 
 INSERT INTO questionnaire_item_option (questionnaire_item_id, value, order_index)
 SELECT qi.id, opt.value, opt.order_index

--- a/fhir/Questionnaire.php
+++ b/fhir/Questionnaire.php
@@ -1,9 +1,9 @@
 <?php
 require_once __DIR__.'/utils.php';
 $entries = array();
-$qs = $pdo->query('SELECT * FROM questionnaire ORDER BY id DESC');
+$qs = $pdo->query("SELECT * FROM questionnaire WHERE status='published' ORDER BY id DESC");
 foreach ($qs as $q) {
-    $itemsStmt = $pdo->prepare('SELECT id, linkId, text, type, allow_multiple, COALESCE(weight_percent,0) AS weight_percent FROM questionnaire_item WHERE questionnaire_id=? ORDER BY order_index ASC');
+    $itemsStmt = $pdo->prepare('SELECT id, linkId, text, type, allow_multiple, COALESCE(weight_percent,0) AS weight_percent FROM questionnaire_item WHERE questionnaire_id=? AND is_active=1 ORDER BY order_index ASC');
     $itemsStmt->execute(array($q['id']));
     $items = $itemsStmt->fetchAll();
     $optionsMap = array();

--- a/init.sql
+++ b/init.sql
@@ -97,6 +97,7 @@ CREATE TABLE questionnaire (
   id INT AUTO_INCREMENT PRIMARY KEY,
   title VARCHAR(255) NOT NULL,
   description TEXT NULL,
+  status ENUM('draft','published','inactive') NOT NULL DEFAULT 'draft',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -114,6 +115,7 @@ CREATE TABLE questionnaire_section (
   title VARCHAR(255) NOT NULL,
   description TEXT NULL,
   order_index INT NOT NULL DEFAULT 0,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
   FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -128,6 +130,7 @@ CREATE TABLE questionnaire_item (
   weight_percent INT NOT NULL DEFAULT 0,
   allow_multiple TINYINT(1) NOT NULL DEFAULT 0,
   is_required TINYINT(1) NOT NULL DEFAULT 0,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
   FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE CASCADE,
   FOREIGN KEY (section_id) REFERENCES questionnaire_section(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -131,8 +131,29 @@ EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 
 -- Ensure questionnaire_item includes the is_required flag.
+ALTER TABLE questionnaire
+  ADD COLUMN IF NOT EXISTS status ENUM('draft','published','inactive') NOT NULL DEFAULT 'draft' AFTER description;
+
+ALTER TABLE questionnaire_section
+  ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER order_index;
+
 ALTER TABLE questionnaire_item
   ADD COLUMN IF NOT EXISTS is_required TINYINT(1) NOT NULL DEFAULT 0 AFTER allow_multiple;
+
+ALTER TABLE questionnaire_item
+  ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER is_required;
+
+UPDATE questionnaire
+SET status = 'draft'
+WHERE status IS NULL OR status NOT IN ('draft','published','inactive');
+
+UPDATE questionnaire_section
+SET is_active = 1
+WHERE is_active IS NULL;
+
+UPDATE questionnaire_item
+SET is_active = 1
+WHERE is_active IS NULL;
 
 -- Ensure questionnaire_work_function exists and is keyed properly.
 CREATE TABLE IF NOT EXISTS questionnaire_work_function (


### PR DESCRIPTION
## Summary
- add questionnaire status management with publish/draft/inactive UI controls and serialization safeguards
- ensure sections and items can be deactivated when responses exist while preventing destructive deletes
- update database schema, seed data, exports, and assignment flows to honor status and active flags

## Testing
- php -l admin/questionnaire_manage.php
- php -l submit_assessment.php
- php -l admin/questionnaire_assignments.php
- php -l admin/users.php
- php -l fhir/Questionnaire.php

------
https://chatgpt.com/codex/tasks/task_e_6908df67935c832d977c78d123b4a229