### PR TITLE
Fix radar report rendering for fewer than three sections

### DIFF
--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -941,8 +941,18 @@ function analytics_report_generate_radar_chart(array $sections, array $palette, 
             $coords[] = (int)round($x);
             $coords[] = (int)round($y);
         }
-        if ($coords) {
+        if ($coords && $count >= 3) {
             imagepolygon($image, $coords, $count, $gridColor);
+        } elseif ($coords && $count === 2) {
+            // Fallback to a simple line when only two sections are available.
+            imageline(
+                $image,
+                $coords[0],
+                $coords[1],
+                $coords[2],
+                $coords[3],
+                $gridColor
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- guard the radar chart grid drawing logic against datasets with fewer than three sections
- fall back to drawing a straight line when only two sections are present so the report still renders

## Testing
- php -l lib/analytics_report.php

------
https://chatgpt.com/codex/tasks/task_e_6908e6cc5800832d9b11267b051d0baa