### PR TITLE
Ensure existing questionnaires stay published after status migration

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -93,6 +93,20 @@ UPDATE questionnaire
 SET status = 'draft'
 WHERE status IS NULL OR status NOT IN ('draft','published','inactive');
 
+SET @existing_published := (
+  SELECT COUNT(*)
+  FROM questionnaire
+  WHERE status = 'published'
+);
+SET @publish_existing_sql := IF(
+  @existing_published = 0,
+  'UPDATE questionnaire SET status = ''published'' WHERE status = ''draft'';',
+  'DO 1'
+);
+PREPARE stmt FROM @publish_existing_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 SET @qs_active_exists = (
   SELECT COUNT(1)
   FROM INFORMATION_SCHEMA.COLUMNS

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -150,6 +150,20 @@ UPDATE questionnaire
 SET status = 'draft'
 WHERE status IS NULL OR status NOT IN ('draft','published','inactive');
 
+SET @existing_published := (
+  SELECT COUNT(*)
+  FROM questionnaire
+  WHERE status = 'published'
+);
+SET @publish_existing_sql := IF(
+  @existing_published = 0,
+  'UPDATE questionnaire SET status = ''published'' WHERE status = ''draft'';',
+  'DO 1'
+);
+PREPARE stmt FROM @publish_existing_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
 UPDATE questionnaire_section
 SET is_active = 1
 WHERE is_active IS NULL;


### PR DESCRIPTION
## Summary
- ensure the migration and upgrade scripts republish pre-existing questionnaires when the status column is introduced so admins can assign them

## Testing
- not run (database migration script change)


------
https://chatgpt.com/codex/tasks/task_e_690a0f7b1ec8832db5462f48aba27e39