### PR TITLE
Adjust profile save button alignment

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1109,6 +1109,10 @@ body.theme-dark .md-field.md-field--compact select {
   justify-self: start;
 }
 
+.md-form-grid > .md-form-actions {
+  grid-column: 1 / -1;
+}
+
 .md-field.md-field-inline {
   align-items: flex-start;
 }


### PR DESCRIPTION
## Summary
- ensure form action rows inside the profile form grid span the full width so the Save Changes button sits beneath the inputs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a10e7e08c832da2cccbd3486ba482