### PR TITLE
Reduce spacing on System Information page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -592,8 +592,8 @@ html.has-js .md-topnav-backdrop.is-visible {
 
 .md-section {
   display: grid;
-  gap: 1.35rem;
-  margin-top: 1.35rem;
+  gap: 1rem;
+  margin-top: 0.9rem;
 }
 
 .md-page-header {
@@ -602,9 +602,9 @@ html.has-js .md-topnav-backdrop.is-visible {
   flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 1rem;
-  padding: 1.8rem 2rem;
-  border-radius: 24px;
+  gap: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 18px;
   background: var(--app-surface);
   border: 1px solid var(--app-border);
   box-shadow: 0 18px 32px rgba(31, 42, 68, 0.1);
@@ -2632,13 +2632,13 @@ body.theme-dark .md-button.md-primary {
 .md-upgrade-surface {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  margin-bottom: 1.5rem;
+  gap: 1rem;
+  margin-bottom: 1rem;
 }
 
 .md-upgrade-overview-grid {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
@@ -2646,9 +2646,9 @@ body.theme-dark .md-button.md-primary {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 1.5rem;
-  border-radius: 18px;
+  gap: 0.6rem;
+  padding: 1.15rem;
+  border-radius: 16px;
   background: var(--app-surface);
   border: 1px solid var(--app-border);
   box-shadow: 0 12px 24px rgba(31, 42, 68, 0.08);


### PR DESCRIPTION
## Summary
- tighten the layout spacing for the System Information dashboard header and content cards
- adjust upgrade card spacing to reduce extra whitespace across the overview grid

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a117b71a0832d9e3f001e24eab91c