### PR TITLE
Center help icon text

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1273,6 +1273,11 @@ body.theme-dark .md-field.md-field--compact select {
 
 .md-help-icon {
   pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
   line-height: 1;
 }
 


### PR DESCRIPTION
## Summary
- ensure the help bubble icon fills its container so the "i" remains centered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690a110eed90832daad684293781482c