### PR TITLE
Revamp navigation menu styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -145,16 +145,26 @@ button,
   position: sticky;
   top: var(--appbar-height);
   z-index: 950;
-  background: var(--app-surface);
-  border-radius: 20px;
-  border: 1px solid var(--app-border);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 255, 0.72));
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   margin: 1.35rem auto 1.75rem;
-  padding: 0.5rem 0.85rem;
-  box-shadow: var(--app-shadow-soft);
+  padding: 0.85rem 1.4rem;
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.08);
   display: flex;
   align-items: stretch;
   min-height: var(--topnav-height);
   outline: none;
+  gap: 0.5rem;
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+.md-topnav:hover,
+.md-topnav:focus-within {
+  box-shadow: 0 28px 55px rgba(15, 23, 42, 0.1);
+  transform: translateY(-2px);
 }
 
 .md-topnav::before {
@@ -162,8 +172,8 @@ button,
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0));
-  opacity: 0.85;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+  opacity: 1;
   pointer-events: none;
 }
 
@@ -188,33 +198,68 @@ button,
   align-items: stretch;
 }
 
-.md-topnav-item.is-active > .md-topnav-trigger {
-  background: var(--app-primary-soft);
-  color: var(--app-primary-dark);
+.md-topnav-item.is-active > .md-topnav-trigger,
+.md-topnav-item.is-open > .md-topnav-trigger {
+  background: linear-gradient(135deg, var(--app-primary) 0%, var(--app-primary-dark) 100%);
+  color: var(--md-on-primary);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.18);
 }
 
 .md-topnav-trigger {
-  border: none;
-  background: transparent;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.08);
   color: var(--app-on-surface-strong);
   font-weight: 600;
   font-size: 0.95rem;
-  padding: 0.65rem 1.1rem;
-  border-radius: 14px;
+  padding: 0.75rem 1.1rem;
+  border-radius: 16px;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  justify-content: space-between;
+  gap: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   min-height: var(--app-button-height);
+  text-align: left;
+}
+
+.md-topnav-label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  line-height: 1.2;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.md-topnav-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.md-topnav-desc {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  color: var(--app-on-surface-muted);
+  font-weight: 500;
+}
+
+.md-topnav-item.is-active > .md-topnav-trigger .md-topnav-desc,
+.md-topnav-item.is-open > .md-topnav-trigger .md-topnav-desc,
+.md-topnav-trigger:hover .md-topnav-desc,
+.md-topnav-trigger:focus-visible .md-topnav-desc {
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .md-topnav-trigger:hover,
 .md-topnav-trigger:focus-visible {
-  background: var(--app-primary);
+  background: linear-gradient(135deg, var(--app-primary) 0%, var(--app-primary-dark) 100%);
   color: var(--md-on-primary);
-  box-shadow: var(--app-shadow-soft);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
   outline: none;
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .md-topnav-chevron {
@@ -238,13 +283,14 @@ button,
   left: 0;
   display: none;
   flex-direction: column;
-  min-width: 220px;
-  background: var(--app-surface);
-  border: 1px solid var(--app-border);
-  border-radius: 14px;
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
-  padding: 0.5rem 0.35rem;
+  min-width: 240px;
+  background: linear-gradient(145deg, var(--app-surface), rgba(248, 250, 255, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
+  padding: 0.75rem 0.6rem;
   z-index: 980;
+  gap: 0.35rem;
 }
 
 @media (hover: hover) {
@@ -279,17 +325,18 @@ button,
 }
 
 .md-topnav-link {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0.55rem 0.85rem;
-  border-radius: 10px;
+  justify-content: space-between;
+  padding: 0.75rem 0.95rem;
+  border-radius: 12px;
   color: var(--app-on-surface-strong);
   font-weight: 500;
   text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease;
-  min-height: var(--app-button-height);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  min-height: calc(var(--app-button-height) - 4px);
   width: 100%;
+  gap: 1rem;
 }
 
 .md-topnav-link:hover,
@@ -298,6 +345,53 @@ button,
   background: var(--app-primary-soft);
   color: var(--app-primary-dark);
   outline: none;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.12);
+}
+
+.md-topnav-link-content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  line-height: 1.25;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.md-topnav-link-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.md-topnav-link-desc {
+  font-size: 0.78rem;
+  color: var(--app-on-surface-muted);
+  letter-spacing: 0.015em;
+}
+
+.md-topnav-link.active .md-topnav-link-desc,
+.md-topnav-link:hover .md-topnav-link-desc,
+.md-topnav-link:focus-visible .md-topnav-link-desc {
+  color: var(--app-primary-dark);
+}
+
+.md-topnav-link-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--app-on-surface-muted);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.md-topnav-link:hover .md-topnav-link-icon,
+.md-topnav-link:focus-visible .md-topnav-link-icon,
+.md-topnav-link.active .md-topnav-link-icon {
+  transform: translateX(4px);
+  color: var(--app-primary-dark);
+}
+
+.md-topnav-link--external .md-topnav-link-icon {
+  font-size: 1rem;
 }
 
 .md-topnav-mobile-header {
@@ -2412,13 +2506,14 @@ body.theme-dark .md-button.md-primary {
     flex-direction: column;
     align-items: stretch;
     margin: 0;
-    padding: 1.15rem 1.15rem 2rem;
+    padding: 1.25rem 1.25rem 2rem;
     border-radius: 0;
     border: none;
+    gap: 1.1rem;
   }
 
   .md-topnav::before {
-    opacity: 0.92;
+    opacity: 0.9;
   }
 
   .md-topnav-list {
@@ -2433,8 +2528,14 @@ body.theme-dark .md-button.md-primary {
   .md-topnav-trigger {
     width: 100%;
     justify-content: space-between;
-    padding: 0 0.5rem;
+    padding: 0.9rem 0.75rem;
     font-size: 1.05rem;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .md-topnav-label {
+    gap: 0.35rem;
   }
 
   .md-topnav-submenu {
@@ -2443,10 +2544,10 @@ body.theme-dark .md-button.md-primary {
     box-shadow: none;
     border: none;
     border-radius: 16px;
-    padding: 0.75rem 0.5rem 0.75rem 0.75rem;
+    padding: 0.85rem 0.65rem 0.85rem 0.85rem;
     margin: 0.35rem 0 0.25rem 0.15rem;
-    background: var(--app-surface-elevated, rgba(248, 250, 255, 0.65));
-    gap: 0.5rem;
+    background: var(--app-surface-elevated, rgba(248, 250, 255, 0.82));
+    gap: 0.6rem;
   }
 
   .md-topnav-item.is-open > .md-topnav-submenu,
@@ -2460,9 +2561,14 @@ body.theme-dark .md-button.md-primary {
   }
 
   .md-topnav-link {
-    padding: 0 0.75rem;
+    padding: 0.9rem 0.85rem;
     font-size: 1rem;
     justify-content: flex-start;
+    align-items: flex-start;
+  }
+
+  .md-topnav-link-icon {
+    margin-top: 0.25rem;
   }
 
   html.has-js .md-topnav {

--- a/templates/header.php
+++ b/templates/header.php
@@ -345,12 +345,31 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
     ?>
     <li class="md-topnav-item<?=$workspaceActive ? ' is-active' : ''?>" data-topnav-item>
       <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
-        <span><?=t($t, 'my_workspace', 'My Workspace')?></span>
+        <span class="md-topnav-label">
+          <span class="md-topnav-title"><?=t($t, 'my_workspace', 'My Workspace')?></span>
+          <span class="md-topnav-desc"><?=t($t, 'my_workspace_summary', 'Stay on top of your goals and tasks.')?></span>
+        </span>
         <span class="md-topnav-chevron" aria-hidden="true"></span>
       </button>
       <ul class="md-topnav-submenu">
-        <li><a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.my_performance')?>><?=t($t, 'my_performance', 'My Performance')?></a></li>
-        <li><a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.submit_assessment')?>><?=t($t, 'submit_assessment', 'Submit Assessment')?></a></li>
+        <li>
+          <a href="<?=htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.my_performance')?>>
+            <span class="md-topnav-link-content">
+              <span class="md-topnav-link-title"><?=t($t, 'my_performance', 'My Performance')?></span>
+              <span class="md-topnav-link-desc"><?=t($t, 'my_performance_summary', 'Track your objectives, reviews, and milestones.')?></span>
+            </span>
+            <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+          </a>
+        </li>
+        <li>
+          <a href="<?=htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('workspace.submit_assessment')?>>
+            <span class="md-topnav-link-content">
+              <span class="md-topnav-link-title"><?=t($t, 'submit_assessment', 'Submit Assessment')?></span>
+              <span class="md-topnav-link-desc"><?=t($t, 'submit_assessment_summary', 'Complete or update your latest assessment.')?></span>
+            </span>
+            <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+          </a>
+        </li>
       </ul>
     </li>
     <?php if (in_array($role, ['admin', 'supervisor'], true)): ?>
@@ -363,20 +382,63 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
       ?>
       <li class="md-topnav-item<?=$teamActive ? ' is-active' : ''?>" data-topnav-item>
         <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
-          <span><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
+          <span class="md-topnav-label">
+            <span class="md-topnav-title"><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
+            <span class="md-topnav-desc"><?=t($t, 'team_navigation_summary', 'Support your team with reviews and approvals.')?></span>
+          </span>
           <span class="md-topnav-chevron" aria-hidden="true"></span>
         </button>
         <ul class="md-topnav-submenu">
           <?php if ($reviewEnabled): ?>
-          <li><a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.review_queue')?>><?=t($t, 'review_queue', 'Review Queue')?></a></li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/supervisor_review.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.review_queue')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'review_queue', 'Review Queue')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'review_queue_summary', 'Review submissions that need your feedback.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
           <?php endif; ?>
-          <li><a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.pending_accounts')?>><?=t($t, 'pending_accounts', 'Pending Approvals')?></a></li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/pending_accounts.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.pending_accounts')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'pending_accounts', 'Pending Approvals')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'pending_accounts_summary', 'Approve or reject incoming access requests.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
           <?php if ($role === 'admin'): ?>
-          <li><a href="<?=htmlspecialchars(url_for('admin/users.php') . '#questionnaire-assignments', ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments','admin.users')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a></li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/users.php') . '#questionnaire-assignments', ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments','admin.users')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'assign_questionnaires_summary', 'Send questionnaires to the right people in seconds.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
           <?php else: ?>
-          <li><a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments')?>><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></a></li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.assignments')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'assign_questionnaires', 'Assign Questionnaires')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'assign_questionnaires_summary', 'Send questionnaires to the right people in seconds.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
           <?php endif; ?>
-          <li><a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.analytics')?>><?=t($t, 'analytics', 'Analytics')?></a></li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('team.analytics')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'analytics', 'Analytics')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'analytics_summary', 'Discover trends with interactive analytics.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
         </ul>
       </li>
     <?php endif; ?>
@@ -384,18 +446,85 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
       <?php $adminActive = $isActiveNav('admin.dashboard', 'admin.users', 'admin.manage_questionnaires', 'admin.work_function_defaults', 'admin.export', 'admin.branding', 'admin.settings'); ?>
       <li class="md-topnav-item<?=$adminActive ? ' is-active' : ''?>" data-topnav-item>
         <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
-          <span><?=t($t, 'admin_navigation', 'Administration')?></span>
+          <span class="md-topnav-label">
+            <span class="md-topnav-title"><?=t($t, 'admin_navigation', 'Administration')?></span>
+            <span class="md-topnav-desc"><?=t($t, 'admin_navigation_summary', 'Configure the system and manage advanced tools.')?></span>
+          </span>
           <span class="md-topnav-chevron" aria-hidden="true"></span>
         </button>
         <ul class="md-topnav-submenu">
-          <li><a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.dashboard')?>><?=t($t, 'admin_dashboard', 'System Information')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.users')?>><?=t($t, 'manage_users', 'Manage Users')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.manage_questionnaires')?>><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('admin/work_function_defaults.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.work_function_defaults')?>><?=t($t, 'work_function_defaults_title', 'Work Function Defaults')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.export')?>><?=t($t, 'export_data', 'Export Data')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.branding')?>><?=t($t, 'branding', 'Branding & Landing')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.settings')?>><?=t($t, 'settings', 'Settings')?></a></li>
-          <li><a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link" target="_blank" rel="noopener"><?=t($t,'api_documentation','API Documentation')?></a></li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.dashboard')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'admin_dashboard', 'System Information')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'admin_dashboard_summary', 'Check system health, updates, and alerts.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.users')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'manage_users', 'Manage Users')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'manage_users_summary', 'Create, update, or deactivate user accounts.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.manage_questionnaires')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'manage_questionnaires_summary', 'Build and organize available questionnaires.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/work_function_defaults.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.work_function_defaults')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'work_function_defaults_title', 'Work Function Defaults')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'work_function_defaults_summary', 'Choose default forms for each work function.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.export')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'export_data', 'Export Data')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'export_data_summary', 'Download responses for record keeping or analysis.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.branding')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'branding', 'Branding & Landing')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'branding_summary', 'Update colors, logos, and landing content.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.settings')?>>
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t, 'settings', 'Settings')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'settings_summary', 'Adjust global preferences and integrations.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
+            </a>
+          </li>
+          <li>
+            <a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link md-topnav-link--external" target="_blank" rel="noopener">
+              <span class="md-topnav-link-content">
+                <span class="md-topnav-link-title"><?=t($t,'api_documentation','API Documentation')?></span>
+                <span class="md-topnav-link-desc"><?=t($t, 'api_documentation_summary', 'Open the developer reference in a new tab.')?></span>
+              </span>
+              <span class="md-topnav-link-icon" aria-hidden="true">↗</span>
+            </a>
+          </li>
         </ul>
       </li>
     <?php endif; ?>


### PR DESCRIPTION
## Summary
- restyled the primary navigation shell with a polished glassmorphism-inspired treatment and elevated hover states
- expanded navigation buttons and submenu links with descriptive subtitles to guide users through available actions

## Testing
- php -l templates/header.php

------
https://chatgpt.com/codex/tasks/task_e_690a502e29a8832da0ed7512e02e464b