### PR TITLE
Normalize work function defaults and simplify assignment UI

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3130,6 +3130,127 @@ body.theme-dark .md-work-function-card {
   flex: 0 0 auto;
 }
 
+.md-work-function-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.md-work-function-search {
+  position: relative;
+  flex: 1 1 220px;
+}
+
+.md-work-function-search input[type="search"] {
+  width: 100%;
+  border: 1px solid var(--app-border, #d0d5dd);
+  border-radius: 999px;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.95rem;
+  background: var(--app-surface, #ffffff);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.md-work-function-search input[type="search"]:focus {
+  outline: none;
+  border-color: var(--md-primary, #2563eb);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--md-primary) 18%, transparent);
+}
+
+body.theme-dark .md-work-function-search input[type="search"] {
+  background: color-mix(in srgb, var(--md-surface) 88%, transparent);
+  border-color: color-mix(in srgb, var(--app-border, #94a3b8) 60%, transparent);
+}
+
+.md-work-function-options {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.md-work-function-option {
+  border: 1px solid var(--app-border, #d0d5dd);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--md-surface) 97%, transparent);
+  padding: 0.6rem 0.75rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.md-work-function-option[hidden] {
+  display: none !important;
+}
+
+.md-work-function-option:hover {
+  border-color: color-mix(in srgb, var(--md-primary, #2563eb) 35%, transparent);
+  background: color-mix(in srgb, var(--md-primary, #2563eb) 6%, var(--md-surface) 94%);
+}
+
+body.theme-dark .md-work-function-option {
+  background: color-mix(in srgb, var(--md-surface) 90%, transparent);
+  border-color: color-mix(in srgb, var(--app-border, #94a3b8) 45%, transparent);
+}
+
+.md-work-function-option label {
+  display: flex;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.md-work-function-option input[type="checkbox"] {
+  margin-top: 0.35rem;
+}
+
+.md-checkbox.md-checkbox-stacked {
+  align-items: flex-start;
+}
+
+.md-questionnaire-copy {
+  display: block;
+  flex: 1 1 auto;
+}
+
+.md-questionnaire-title {
+  display: block;
+  font-weight: 600;
+  color: var(--app-heading, var(--md-primary-dark));
+}
+
+.md-questionnaire-desc {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  color: var(--app-text-secondary, var(--md-muted));
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.md-work-function-filter-empty {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--app-text-secondary, var(--md-muted));
+}
+
+.md-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 
 
 .md-help-overlay {

--- a/lang/am.json
+++ b/lang/am.json
@@ -47,6 +47,7 @@
   "available_questionnaires": "የሚገኙ ጥያቄ ሰነዶች",
   "filter_questionnaires": "ጥያቄ ሰነዶችን አጣራ",
   "filter_questionnaires_placeholder": "ዝርዝሩን ለማጠቃለል ይፃፉ…",
+  "filter_no_results": "ምንም ጥያቄ በፍለጋዎ አልተገኘም።",
   "select_all": "ሁሉንም ምረጥ",
   "clear_all": "ሁሉንም አጥፋ",
   "selected_staff": "የተመረጠ ሰራተኛ",

--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,7 @@
   "available_questionnaires": "Available questionnaires",
   "filter_questionnaires": "Filter questionnaires",
   "filter_questionnaires_placeholder": "Type to narrow the list…",
+  "filter_no_results": "No questionnaires match your search.",
   "select_all": "Select All",
   "clear_all": "Clear All",
   "selected_staff": "Selected staff",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -47,6 +47,7 @@
   "available_questionnaires": "Questionnaires disponibles",
   "filter_questionnaires": "Filtrer les questionnaires",
   "filter_questionnaires_placeholder": "Tapez pour réduire la liste…",
+  "filter_no_results": "Aucun questionnaire ne correspond à votre recherche.",
   "select_all": "Tout sélectionner",
   "clear_all": "Tout effacer",
   "selected_staff": "Employé sélectionné",


### PR DESCRIPTION
## Summary
- normalize work function keys before saving defaults so assignments persist even when values vary in case or formatting
- redesign the work function defaults card to add search filtering, condensed questionnaire text, and contextual select/clear actions
- add supporting styles and translations for the streamlined chooser

## Testing
- php -l config.php
- php -l admin/work_function_defaults.php

------
https://chatgpt.com/codex/tasks/task_e_690c0cc4a238832da673f19deaec0173