### PR TITLE
Simplify questionnaire builder layout

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1029,14 +1029,6 @@ if (isset($_POST['import'])) {
           <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
         </div>
         <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
-        <div class="qb-scoring-note">
-          <strong><?=t($t, 'qb_scoring_hint_title', 'Scoring & analytics')?></strong>
-          <p><?=t(
-              $t,
-              'qb_scoring_hint_text',
-              'Assign weights so priority questions total about 100%. Items left at 0 are informational only and do not affect scores or analytics.'
-          )?></p>
-        </div>
         <div id="qb-list" class="qb-list" aria-live="polite"></div>
       </div>
     </div>
@@ -1047,6 +1039,16 @@ if (isset($_POST['import'])) {
         <nav id="qb-section-nav" class="qb-section-nav" aria-label="<?=htmlspecialchars(t($t,'section_navigation','Section navigation'), ENT_QUOTES, 'UTF-8')?>" data-empty-label="<?=htmlspecialchars(t($t,'select_questionnaire_to_view_sections','Select a questionnaire to view its sections'), ENT_QUOTES, 'UTF-8')?>" data-root-label="<?=htmlspecialchars(t($t,'items_without_section','Items without a section'), ENT_QUOTES, 'UTF-8')?>" data-untitled-label="<?=htmlspecialchars(t($t,'untitled_questionnaire','Untitled questionnaire'), ENT_QUOTES, 'UTF-8')?>">
           <p class="qb-section-nav-empty"><?=t($t,'select_questionnaire_to_view_sections','Select a questionnaire to view its sections')?></p>
         </nav>
+      </div>
+      <div class="md-card md-elev-2 qb-sidebar-card qb-scoring-card">
+        <div class="qb-scoring-note">
+          <strong><?=t($t, 'qb_scoring_hint_title', 'Scoring & analytics')?></strong>
+          <p><?=t(
+              $t,
+              'qb_scoring_hint_text',
+              'Assign weights so priority questions total about 100%. Items left at 0 are informational only and do not affect scores or analytics.'
+          )?></p>
+        </div>
       </div>
       <div class="md-card md-elev-2 qb-sidebar-card">
         <h3 class="md-card-title"><?=t($t,'fhir_import','FHIR Import')?></h3>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -1,20 +1,20 @@
 .qb-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
   align-items: center;
 }
 
 .qb-builder-card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .qb-manager-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
-  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 280px);
+  gap: 1rem;
   align-items: flex-start;
 }
 
@@ -23,20 +23,20 @@
 }
 
 .qb-manager-sidebar {
-  max-width: 320px;
+  max-width: 280px;
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
   position: sticky;
-  top: calc(var(--appbar-height) + var(--topnav-height) + 1.5rem);
+  top: calc(var(--appbar-height) + var(--topnav-height) + 1rem);
   align-self: flex-start;
 }
 
 .qb-sidebar-card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .qb-tabs-vertical {
@@ -137,8 +137,8 @@
 .qb-tabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  margin: 1rem 0;
+  gap: 0.4rem;
+  margin: 0.25rem 0 0.75rem;
 }
 
 .qb-tab {
@@ -168,9 +168,9 @@
 }
 
 .qb-message {
-  margin-top: 0.75rem;
+  margin-top: 0.5rem;
   font-size: 0.95rem;
-  min-height: 1.5rem;
+  min-height: 1.25rem;
 }
 
 .qb-message[data-state="error"] {
@@ -186,9 +186,9 @@
   border: 1px solid var(--app-border);
   border-radius: 8px;
   padding: 0.75rem;
-  margin: 0.75rem 0;
+  margin: 0;
   color: var(--app-muted);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
 }
 
 .qb-scoring-note strong {
@@ -203,12 +203,12 @@
 
 .qb-scoring-summary {
   border: 1px solid var(--app-border);
-  border-radius: 10px;
+  border-radius: 8px;
   background: var(--app-surface-alt, rgba(32, 84, 147, 0.05));
-  padding: 0.75rem;
+  padding: 0.6rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .qb-scoring-summary-heading {
@@ -218,18 +218,18 @@
 .qb-scoring-metrics {
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.6rem;
 }
 
 .qb-scoring-metric {
   background: var(--app-surface);
   border: 1px solid var(--app-border);
-  border-radius: 8px;
-  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
   display: flex;
   flex-direction: column;
-  gap: 0.15rem;
+  gap: 0.1rem;
 }
 
 .qb-scoring-metric dt {
@@ -297,52 +297,59 @@
 }
 
 .qb-list {
-  margin-top: 1rem;
+  margin-top: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .qb-questionnaire {
   background: var(--app-surface);
-  border-radius: 12px;
+  border-radius: 8px;
   border: 1px solid var(--app-border);
-  padding: 1.1rem;
-  box-shadow: var(--app-shadow-soft);
+  padding: 0.75rem;
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .qb-questionnaire-header,
 .qb-section-header,
 .qb-item {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.5rem;
   align-items: flex-start;
 }
 
 .qb-questionnaire-header {
   flex-wrap: wrap;
+  align-items: center;
+  column-gap: 0.75rem;
+  row-gap: 0.45rem;
 }
 
 .qb-questionnaire-fields,
 .qb-section-fields {
-  flex: 1 1 280px;
+  flex: 1 1 240px;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .qb-questionnaire-actions,
 .qb-section-actions {
   display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
 .qb-status-control {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  min-width: 180px;
+  gap: 0.35rem;
+  min-width: 160px;
   align-items: flex-start;
 }
 
@@ -387,33 +394,33 @@
 }
 
 .qb-section {
-  border-left: 4px solid var(--app-primary);
-  padding-left: 0.75rem;
-  margin-top: 1rem;
+  border-left: 3px solid var(--app-primary);
+  padding-left: 0.6rem;
+  margin-top: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .qb-section:first-of-type {
-  margin-top: 0.5rem;
+  margin-top: 0.35rem;
 }
 
 .qb-section-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin-top: 0.75rem;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
 }
 
 .qb-item-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .qb-root-items {
-  margin-top: 1rem;
+  margin-top: 0.75rem;
 }
 
 .qb-inline-heading {
@@ -426,7 +433,7 @@
 .qb-select {
   width: 100%;
   font: inherit;
-  padding: 0.5rem;
+  padding: 0.45rem;
   border-radius: 4px;
   border: 1px solid var(--app-border);
   background: var(--app-surface);
@@ -444,10 +451,10 @@
 
 .qb-item {
   align-items: center;
-  background: var(--app-primary-soft);
+  background: var(--app-surface);
   border: 1px solid var(--app-border);
-  border-radius: 10px;
-  padding: 0.5rem;
+  border-radius: 6px;
+  padding: 0.45rem 0.5rem;
   flex-wrap: wrap;
 }
 
@@ -462,7 +469,7 @@
 .qb-field {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
 }
 
 .qb-field-label {
@@ -498,15 +505,15 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
 }
 
 .qb-checkbox {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  gap: 0.4rem;
+  font-size: 0.88rem;
 }
 
 .qb-status-toggle {
@@ -522,17 +529,17 @@
 .qb-option-list {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .qb-option {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  background: var(--app-primary-soft);
+  gap: 0.4rem;
+  background: var(--app-surface-alt, rgba(32, 84, 147, 0.05));
   border: 1px solid var(--app-border);
-  border-radius: 6px;
-  padding: 0.35rem 0.5rem;
+  border-radius: 4px;
+  padding: 0.3rem 0.45rem;
 }
 
 .qb-option-readonly {
@@ -556,7 +563,7 @@
 }
 
 .qb-option .qb-handle {
-  padding: 0.25rem 0.4rem;
+  padding: 0.2rem 0.35rem;
 }
 
 .qb-handle {
@@ -564,7 +571,7 @@
   user-select: none;
   font-size: 1.2rem;
   line-height: 1;
-  padding: 0.35rem 0.5rem;
+  padding: 0.3rem 0.45rem;
   color: var(--app-on-surface-muted);
 }
 
@@ -588,16 +595,20 @@
 .qb-import-form {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.6rem;
+}
+
+.qb-scoring-card {
+  padding: 0.75rem 1rem 1rem;
+}
+
+.qb-scoring-card .qb-scoring-note {
+  border: none;
+  padding: 0;
+  background: transparent;
 }
 
 @media (max-width: 720px) {
-  .qb-questionnaire-actions,
-  .qb-section-actions {
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-
   .qb-item {
     flex-direction: column;
     align-items: stretch;


### PR DESCRIPTION
## Summary
- move the scoring guidance into the sidebar so the builder canvas stays focused
- tighten spacing, padding, and alignments throughout the questionnaire builder to reduce visual bulk
- refresh option and item styling for a flatter appearance and slimmer controls

## Testing
- php -l admin/questionnaire_manage.php

------
https://chatgpt.com/codex/tasks/task_e_690c0cfdb0d4832db85975ff18f9eaf0