### PR TITLE
Add canonical helper alias for work function defaults

### DIFF
--- a/config.php
+++ b/config.php
@@ -179,6 +179,16 @@ function canonical_work_function_key(string $value, ?array $defaults = null): st
     return '';
 }
 
+if (!function_exists('canonical')) {
+    /**
+     * @deprecated Use canonical_work_function_key() instead.
+     */
+    function canonical(string $value, ?array $defaults = null): string
+    {
+        return canonical_work_function_key($value, $defaults);
+    }
+}
+
 function work_function_choices(PDO $pdo, bool $forceRefresh = false): array
 {
     static $cache = null;


### PR DESCRIPTION
## Summary
- add a legacy `canonical()` helper that proxies to `canonical_work_function_key()`
- mark the helper as deprecated so new code continues using the canonical_work_function_key helper

## Testing
- composer validate

------
https://chatgpt.com/codex/tasks/task_e_690cdc4eabd0832da8dceb461636222c