### PR TITLE
Refine system information layout

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2733,27 +2733,28 @@ body.theme-dark .md-button.md-primary {
 
 .md-dashboard-grid {
   display: grid;
-  gap: 1.35rem;
+  gap: 1.1rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: stretch;
 }
 
 .md-dashboard-card {
-  padding: 1.5rem;
+  padding: 1.25rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .md-upgrade-surface {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
 }
 
 .md-upgrade-overview-grid {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.65rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
@@ -2761,12 +2762,12 @@ body.theme-dark .md-button.md-primary {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  padding: 1.15rem;
-  border-radius: 16px;
+  gap: 0.5rem;
+  padding: 1rem;
+  border-radius: 14px;
   background: var(--app-surface);
   border: 1px solid var(--app-border);
-  box-shadow: 0 12px 24px rgba(31, 42, 68, 0.08);
+  box-shadow: 0 10px 20px rgba(31, 42, 68, 0.07);
 }
 
 .md-upgrade-card--accent {
@@ -2841,7 +2842,7 @@ body.theme-dark .md-upgrade-card--accent {
 .md-upgrade-meta {
   font-size: 0.85rem;
   color: var(--app-on-surface-muted);
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
 .md-upgrade-meta--strong {
@@ -2869,31 +2870,21 @@ body.theme-dark .md-upgrade-card--accent {
 
 .md-upgrade-layout {
   display: grid;
-  gap: 1.5rem;
-}
-
-@media (min-width: 960px) {
-  .md-upgrade-layout {
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  }
-}
-
-.md-upgrade-column {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
 }
 
 .md-upgrade-form {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
 .md-upgrade-field {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.3rem;
 }
 
 .md-upgrade-field-label {
@@ -2904,7 +2895,7 @@ body.theme-dark .md-upgrade-card--accent {
 
 .md-upgrade-input {
   width: 100%;
-  padding: 0.65rem 0.75rem;
+  padding: 0.6rem 0.75rem;
   border-radius: 12px;
   border: 1px solid var(--app-border);
   background: var(--app-surface);
@@ -2923,19 +2914,16 @@ body.theme-dark .md-upgrade-card--accent {
   align-self: flex-start;
 }
 
-.md-upgrade-action-grid {
-  display: grid;
-  gap: 0.75rem;
-}
 
-@media (min-width: 640px) {
-  .md-upgrade-action-grid {
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  }
-}
-
-.md-upgrade-action-grid form {
+.md-upgrade-inline-actions {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.md-upgrade-inline-actions form {
+  display: flex;
+  flex: 1 1 180px;
 }
 
 .md-upgrade-action-button {
@@ -2960,12 +2948,12 @@ body.theme-dark .md-upgrade-card--accent {
 .md-upgrade-restore-form {
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 0.75rem;
 }
 
 .md-upgrade-select {
   width: 100%;
-  padding: 0.75rem 0.9rem;
+  padding: 0.7rem 0.9rem;
   padding-right: 2.75rem;
   border-radius: 12px;
   border: 1px solid var(--app-border);
@@ -2973,7 +2961,7 @@ body.theme-dark .md-upgrade-card--accent {
   color: var(--app-on-surface);
   font-size: 0.95rem;
   line-height: 1.4;
-  box-shadow: 0 8px 16px rgba(31, 42, 68, 0.08);
+  box-shadow: 0 6px 14px rgba(31, 42, 68, 0.07);
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
   appearance: none;
   background-image:
@@ -3019,11 +3007,11 @@ body.theme-dark .md-upgrade-select {
 .md-upgrade-backup-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .md-upgrade-backup-toolbar .md-button {
-  flex: 1 1 180px;
+  flex: 1 1 160px;
   justify-content: center;
 }
 


### PR DESCRIPTION
## Summary
- embed upgrade actions directly within the update status card for a more efficient workflow
- flatten the upgrade layout so supporting cards align in an auto-fitting grid and reduce whitespace
- tighten dashboard and upgrade styling to shrink padding, gaps, and form spacing across the system information view

## Testing
- php -l admin/dashboard.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ddb6baab8832d837c3478cfc6dc2f)