### PR TITLE
Fix work function default handling

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -1,14 +1,6 @@
 <?php
 require_once __DIR__ . '/../config.php';
 require_once __DIR__ . '/../lib/work_functions.php';
-if (!function_exists('canonical_work_function_key')) {
-    function canonical_work_function_key(string $key): string
-    {
-        $key = trim($key);
-        $key = str_replace([' ', '-'], '_', $key);
-        return strtolower($key);
-    }
-}
 auth_required(['admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);

--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -43,25 +43,38 @@ function canonical_work_function_key(string $value, ?array $definitions = null):
     }
 
     $definitions = $definitions ?? default_work_function_definitions();
+    $normalizedDefinitions = [];
+    foreach ($definitions as $key => $label) {
+        $normalizedDefinitions[strtolower((string)$key)] = (string)$key;
+    }
+
     if (isset($definitions[$value])) {
-        return $value;
+        return (string)$value;
+    }
+
+    $lowerValue = strtolower($value);
+    if (isset($normalizedDefinitions[$lowerValue])) {
+        return $normalizedDefinitions[$lowerValue];
     }
 
     foreach ($definitions as $key => $label) {
-        if (strcasecmp($value, (string)$key) === 0 || strcasecmp($value, (string)$label) === 0) {
+        if (strcasecmp($value, (string)$label) === 0) {
             return (string)$key;
         }
     }
 
-    $normalized = strtolower($value);
-    $normalized = preg_replace('/[^a-z0-9]+/i', '_', $normalized) ?? '';
+    $normalized = preg_replace('/[^a-z0-9]+/i', '_', $lowerValue) ?? '';
     $normalized = trim($normalized, '_');
 
-    if ($normalized !== '' && isset($definitions[$normalized])) {
-        return $normalized;
+    if ($normalized === '') {
+        return '';
     }
 
-    return '';
+    if (isset($normalizedDefinitions[$normalized])) {
+        return $normalizedDefinitions[$normalized];
+    }
+
+    return $normalized;
 }
 
 function canonical(string $value, ?array $definitions = null): string


### PR DESCRIPTION
## Summary
- rely on the shared helpers from config.php within the work function defaults screen instead of redeclaring them locally
- enhance work function canonicalisation so custom identifiers persist consistently when saving defaults

## Testing
- php -l admin/work_function_defaults.php
- php -l lib/work_functions.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e28f5012c832d8382209038b3fa9f)