### PR TITLE
Close available_work_functions helper definition

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -338,6 +338,8 @@ function available_work_functions(PDO $pdo, bool $forceRefresh = false): array
     $cache[$cacheKey] = $labels;
 
     return $labels;
+}
+
 use PDO;
 use PDOException;
 
@@ -365,7 +367,6 @@ if (!function_exists('default_work_function_definitions')) {
             'ethics' => 'Ethics',
         ];
     }
-}
 
 /**
  * Normalize a work function identifier to the canonical key.
@@ -675,4 +676,6 @@ function available_work_functions(PDO $pdo, bool $forceRefresh = false): array
     $cache[$cacheKey] = $labels;
 
     return $labels;
+}
+
 }


### PR DESCRIPTION
## Summary
- add the missing closing brace to the new available_work_functions() helper so the file parses correctly
- extend the legacy work function fallback guard to wrap the entire block and avoid redeclaration errors once the helper loads

## Testing
- php -l lib/work_functions.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914962cd1dc832d9eda0ac347b46f65)