### PR TITLE
Define work function labels and add assignment test

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -6,6 +6,29 @@ declare(strict_types=1);
  *
  * @return array<string,string>
  */
+function default_work_function_definitions(): array
+{
+    return [
+        'cmd' => 'Change Management & Development',
+        'communication' => 'Communications & Partnerships',
+        'dfm' => 'Demand Forecasting & Management',
+        'driver' => 'Driver Services',
+        'ethics' => 'Ethics & Compliance',
+        'finance' => 'Finance & Grants',
+        'general_service' => 'General Services',
+        'hrm' => 'Human Resources Management',
+        'ict' => 'Information & Communication Technology',
+        'leadership_tn' => 'Leadership & Team Nurturing',
+        'legal_service' => 'Legal Services',
+        'pme' => 'Planning, Monitoring & Evaluation',
+        'quantification' => 'Quantification & Procurement',
+        'records_documentation' => 'Records & Documentation',
+        'security' => 'Security Operations',
+        'security_driver' => 'Security & Driver Management',
+        'tmd' => 'Training & Mentorship Development',
+        'wim' => 'Warehouse & Inventory Management',
+    ];
+}
 
 /**
  * Normalize a work function identifier to the canonical key.
@@ -294,4 +317,27 @@ function available_work_functions(PDO $pdo, bool $forceRefresh = false): array
     $cache[$cacheKey] = $labels;
 
     return $labels;
+}
+
+/**
+ * Resolve the display label for a work function key.
+ */
+function work_function_label(PDO $pdo, string $workFunction): string
+{
+    $canonical = canonical_work_function_key($workFunction);
+    if ($canonical === '') {
+        return '';
+    }
+
+    $options = available_work_functions($pdo);
+    if (isset($options[$canonical])) {
+        return (string) $options[$canonical];
+    }
+
+    $definitions = default_work_function_definitions();
+    if (isset($definitions[$canonical])) {
+        return (string) $definitions[$canonical];
+    }
+
+    return ucwords(str_replace('_', ' ', $canonical));
 }

--- a/tests/work_function_assignments_test.php
+++ b/tests/work_function_assignments_test.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/work_functions.php';
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE questionnaire (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, status TEXT)');
+$pdo->exec('CREATE TABLE questionnaire_work_function (questionnaire_id INT NOT NULL, work_function TEXT NOT NULL)');
+$pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, work_function TEXT)');
+
+$pdo->exec("INSERT INTO questionnaire (id, title, status) VALUES (1, 'Annual Review', 'published'), (2, 'Specialist', 'published')");
+$pdo->exec("INSERT INTO users (work_function) VALUES ('finance'), ('hrm'), ('wim')");
+
+$initialAssignments = [
+    'finance' => [1, 2],
+    'hrm' => [1],
+];
+
+save_work_function_assignments($pdo, $initialAssignments);
+
+$rows = $pdo
+    ->query('SELECT questionnaire_id, work_function FROM questionnaire_work_function ORDER BY work_function, questionnaire_id')
+    ->fetchAll(PDO::FETCH_ASSOC);
+
+$expected = [
+    ['questionnaire_id' => 1, 'work_function' => 'finance'],
+    ['questionnaire_id' => 2, 'work_function' => 'finance'],
+    ['questionnaire_id' => 1, 'work_function' => 'hrm'],
+];
+
+if ($rows !== $expected) {
+    fwrite(STDERR, "Initial assignment save did not match expectations.\n");
+    exit(1);
+}
+
+$normalized = normalize_work_function_assignments(
+    [
+        'finance' => [1, '2', 'ignore-me'],
+        'hrm' => ['2'],
+        'unknown' => [1],
+        'wim' => ['999'],
+    ],
+    ['finance', 'hrm', 'wim'],
+    [1, 2]
+);
+
+if ($normalized !== [
+    'finance' => [1, 2],
+    'hrm' => [2],
+    'wim' => [],
+]) {
+    fwrite(STDERR, "Normalization failed to filter assignments properly.\n");
+    exit(1);
+}
+
+save_work_function_assignments($pdo, $normalized);
+
+$rows = $pdo
+    ->query('SELECT questionnaire_id, work_function FROM questionnaire_work_function ORDER BY work_function, questionnaire_id')
+    ->fetchAll(PDO::FETCH_ASSOC);
+
+$expected = [
+    ['questionnaire_id' => 1, 'work_function' => 'finance'],
+    ['questionnaire_id' => 2, 'work_function' => 'finance'],
+    ['questionnaire_id' => 2, 'work_function' => 'hrm'],
+];
+
+if ($rows !== $expected) {
+    fwrite(STDERR, "Second assignment save did not match expectations.\n");
+    exit(1);
+}
+
+save_work_function_assignments($pdo, ['hrm' => [2], 'wim' => [1]]);
+
+$rows = $pdo
+    ->query('SELECT questionnaire_id, work_function FROM questionnaire_work_function ORDER BY work_function, questionnaire_id')
+    ->fetchAll(PDO::FETCH_ASSOC);
+
+$expected = [
+    ['questionnaire_id' => 2, 'work_function' => 'hrm'],
+    ['questionnaire_id' => 1, 'work_function' => 'wim'],
+];
+
+if ($rows !== $expected) {
+    fwrite(STDERR, "Final assignment save did not match expectations.\n");
+    exit(1);
+}
+
+if (work_function_label($pdo, 'finance') !== 'Finance & Grants') {
+    fwrite(STDERR, "Failed to resolve finance label.\n");
+    exit(1);
+}
+
+if (work_function_label($pdo, 'Finance') !== 'Finance & Grants') {
+    fwrite(STDERR, "Canonical lookup for Finance failed.\n");
+    exit(1);
+}
+
+if (work_function_label($pdo, 'custom squad') !== 'Custom Squad') {
+    fwrite(STDERR, "Fallback label formatting failed.\n");
+    exit(1);
+}
+
+if (work_function_label($pdo, '') !== '') {
+    fwrite(STDERR, "Empty work function should return an empty label.\n");
+    exit(1);
+}
+
+echo "Work function assignment tests passed.\n";


### PR DESCRIPTION
## Summary
- add a default catalogue of work function labels used across the admin tools
- expose a helper to resolve canonical work function labels with sensible fallbacks
- add a regression test that verifies saving and normalising questionnaire assignments

## Testing
- php tests/work_function_assignments_test.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691682ddd290832dba9d30e4fc34f80a)