### PR TITLE
Add progress overlay for admin upgrade workflow

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -565,6 +565,16 @@ $pageHelpKey = 'admin.dashboard';
     <div class="md-alert<?=$alertClass?>"><?=htmlspecialchars($flashMessage, ENT_QUOTES, 'UTF-8')?></div>
   <?php endif; ?>
 
+  <div class="md-upgrade-progress" data-upgrade-progress hidden aria-hidden="true">
+    <div class="md-upgrade-progress__backdrop" aria-hidden="true"></div>
+    <div class="md-upgrade-progress__dialog" role="status" aria-live="assertive">
+      <div class="md-upgrade-progress__spinner" aria-hidden="true"></div>
+      <p class="md-upgrade-progress__message" data-upgrade-progress-message>
+        <?=t($t, 'upgrade_progress_default', 'Applying update. This may take a few moments...')?>
+      </p>
+    </div>
+  </div>
+
     <section class="md-upgrade-surface">
     <div class="md-upgrade-overview-grid">
       <article class="md-card md-upgrade-card md-upgrade-card--accent">
@@ -638,7 +648,7 @@ $pageHelpKey = 'admin.dashboard';
             <input type="hidden" name="action" value="check_upgrade">
             <button type="submit" class="md-button md-elev-1 md-upgrade-action-button"><?=t($t,'check_for_upgrade','Check for Upgrade')?></button>
           </form>
-          <form method="post">
+          <form method="post" data-upgrade-progress-trigger data-upgrade-progress-message="<?=htmlspecialchars(t($t, 'upgrade_progress_install', 'Installing update. Please keep this page open until the process completes.'), ENT_QUOTES, 'UTF-8')?>">
             <input type="hidden" name="csrf" value="<?=csrf_token()?>">
             <input type="hidden" name="action" value="install_upgrade">
             <button type="submit" class="md-button md-primary md-elev-2 md-upgrade-action-button" <?=($upgradeRepoDisplay === '' ? 'disabled' : '')?>><?=t($t,'install_upgrade','Install Upgrade')?></button>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3018,6 +3018,76 @@ body.theme-dark .md-upgrade-select {
 .md-upgrade-hidden-form {
   display: none;
 }
+
+.md-upgrade-progress {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 1200;
+}
+
+.md-upgrade-progress.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.md-upgrade-progress__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.md-upgrade-progress__dialog {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2.25rem 2rem;
+  border-radius: 18px;
+  background: var(--app-surface);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.28);
+  text-align: center;
+  max-width: min(90vw, 360px);
+  width: 100%;
+}
+
+body.theme-dark .md-upgrade-progress__dialog {
+  background: rgba(21, 32, 48, 0.96);
+  color: var(--app-on-surface);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.6);
+}
+
+.md-upgrade-progress__spinner {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 6px solid rgba(32, 115, 191, 0.18);
+  border-top-color: var(--app-primary);
+  animation: md-upgrade-progress-spin 0.95s linear infinite;
+}
+
+.md-upgrade-progress__message {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--app-on-surface-strong);
+}
+
+body.theme-dark .md-upgrade-progress__message {
+  color: var(--app-on-surface);
+}
+
+@keyframes md-upgrade-progress-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 .md-status-badge {
   display: inline-flex;
   align-items: center;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -775,6 +775,68 @@
     }
   });
 
+  const upgradeProgressOverlay = document.querySelector('[data-upgrade-progress]');
+  if (upgradeProgressOverlay) {
+    const progressMessageEl = upgradeProgressOverlay.querySelector('[data-upgrade-progress-message]');
+    const showUpgradeProgress = (messageText) => {
+      if (progressMessageEl && typeof messageText === 'string' && messageText.trim() !== '') {
+        progressMessageEl.textContent = messageText.trim();
+      }
+      upgradeProgressOverlay.hidden = false;
+      upgradeProgressOverlay.setAttribute('aria-hidden', 'false');
+      upgradeProgressOverlay.setAttribute('aria-busy', 'true');
+      if (document.body) {
+        document.body.classList.add('md-lock-scroll');
+      }
+      if (typeof window.requestAnimationFrame === 'function') {
+        window.requestAnimationFrame(() => {
+          upgradeProgressOverlay.classList.add('is-visible');
+        });
+      } else {
+        upgradeProgressOverlay.classList.add('is-visible');
+      }
+    };
+
+    const disableSubmitControls = (form) => {
+      if (!(form instanceof HTMLFormElement)) {
+        return;
+      }
+      const interactiveSelector = 'button, input[type="submit"], input[type="button"], input[type="reset"]';
+      form.querySelectorAll(interactiveSelector).forEach((control) => {
+        if (control instanceof HTMLButtonElement || control instanceof HTMLInputElement) {
+          if (control.type === 'hidden') {
+            return;
+          }
+          control.disabled = true;
+          control.setAttribute('aria-busy', 'true');
+        }
+      });
+    };
+
+    const upgradeForms = document.querySelectorAll('[data-upgrade-progress-trigger]');
+    upgradeForms.forEach((form) => {
+      form.addEventListener('submit', () => {
+        if (!(form instanceof HTMLFormElement)) {
+          return;
+        }
+        if (form.dataset.upgradeProgressActive === '1') {
+          return;
+        }
+        form.dataset.upgradeProgressActive = '1';
+        disableSubmitControls(form);
+        const customMessage = form.getAttribute('data-upgrade-progress-message') || '';
+        showUpgradeProgress(customMessage);
+        if (document.activeElement instanceof HTMLElement) {
+          try {
+            document.activeElement.blur();
+          } catch (err) {
+            // Ignore focus errors.
+          }
+        }
+      });
+    });
+  }
+
   const offlineStorageKeys = {
     credentials: 'hrassess:offlineCredentials',
     pending: 'hrassess:offlineCredentials:pending',

--- a/lang/am.json
+++ b/lang/am.json
@@ -480,6 +480,8 @@
   "upgrade_failed": "The upgrade could not be completed. Review the logs and database permissions, then try again.",
   "upgrade_hint": "Ensure a recent backup has been downloaded before applying upgrades.",
   "upgrade_hint_script": "The upgrade script automatically creates backups before applying changes. Download manual backups whenever you need an extra copy.",
+  "upgrade_progress_default": "Applying update. This may take a few moments...",
+  "upgrade_progress_install": "Installing update. Please keep this page open until the process completes.",
   "upgrade_actions_heading": "Upgrade actions",
   "upgrade_overview_current": "Current release",
   "upgrade_overview_status": "Update status",

--- a/lang/en.json
+++ b/lang/en.json
@@ -471,6 +471,8 @@
   "upgrade_failed": "The upgrade could not be completed. Review the logs and database permissions, then try again.",
   "upgrade_hint": "Ensure a recent backup has been downloaded before applying upgrades.",
   "upgrade_hint_script": "The upgrade script automatically creates backups before applying changes. Download manual backups whenever you need an extra copy.",
+  "upgrade_progress_default": "Applying update. This may take a few moments...",
+  "upgrade_progress_install": "Installing update. Please keep this page open until the process completes.",
   "upgrade_actions_heading": "Upgrade actions",
   "upgrade_overview_current": "Current release",
   "upgrade_overview_status": "Update status",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -479,6 +479,8 @@
   "upgrade_failed": "The upgrade could not be completed. Review the logs and database permissions, then try again.",
   "upgrade_hint": "Ensure a recent backup has been downloaded before applying upgrades.",
   "upgrade_hint_script": "Le script de mise à jour crée automatiquement des sauvegardes avant d'appliquer les modifications. Téléchargez des sauvegardes manuelles lorsque vous avez besoin d'une copie supplémentaire.",
+  "upgrade_progress_default": "Application de la mise à jour. Cela peut prendre quelques instants...",
+  "upgrade_progress_install": "Installation de la mise à jour. Veuillez laisser cette page ouverte jusqu'à la fin du processus.",
   "upgrade_actions_heading": "Actions de mise à jour",
   "upgrade_overview_current": "Version installée",
   "upgrade_overview_status": "État des mises à jour",


### PR DESCRIPTION
## Summary
- add a progress overlay to the admin upgrade screen to show status while an install runs
- add styling for the new upgrade progress spinner overlay
- provide localized strings for the progress messaging across supported locales

## Testing
- php -l admin/dashboard.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916906094f0832d880710223bf88dfd)