### PR TITLE
Improve questionnaire builder usability and scoring upgrade

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -1,8 +1,43 @@
 .qb-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.35rem;
+  gap: 0.5rem 0.75rem;
   align-items: center;
+  justify-content: space-between;
+}
+
+.qb-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.qb-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.qb-select-label {
+  font-weight: 600;
+}
+
+.qb-select-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.qb-select-input {
+  min-width: 240px;
+  padding: 0.4rem 0.55rem;
+  border-radius: 6px;
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.1));
+  font: inherit;
 }
 
 .qb-builder-card {
@@ -613,6 +648,34 @@
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+}
+
+.qb-import-banner {
+  margin-top: 1rem;
+}
+
+.qb-import-card {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem 1rem;
+}
+
+.qb-import-card-header {
+  max-width: 420px;
+}
+
+.qb-import-inline {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex: 1 1 360px;
+  flex-wrap: wrap;
+}
+
+.qb-import-inline .md-field {
+  min-width: 240px;
 }
 
 .qb-scoring-card {


### PR DESCRIPTION
## Summary
- add an upgrade endpoint that rebalances Likert question weights and fills missing defaults for selected questionnaires
- refresh the questionnaire builder toolbar with a selector, upgrade trigger, and streamlined actions
- move the import controls into a horizontal banner above the builder and update styling for easier navigation

## Testing
- php -l admin/questionnaire_manage.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1c29e698832d9960c95ff8e43cd7)