### PR TITLE
Improve questionnaire builder selection and upgrade UX

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1114,7 +1114,6 @@ if (isset($_POST['import'])) {
             <label class="qb-select-label" for="qb-selector"><?=t($t,'choose_questionnaire','Questionnaire')?></label>
             <div class="qb-select-wrap">
               <select id="qb-selector" class="qb-select-input"></select>
-              <button class="md-button md-outline md-elev-1" id="qb-upgrade" type="button"><?=t($t,'qb_upgrade_structure','Update structure')?></button>
             </div>
           </div>
           <div class="qb-toolbar-actions">


### PR DESCRIPTION
## Summary
- fix questionnaire builder fetch helper and add meaningful selector placeholders so existing questionnaires populate the dropdown
- move the update structure control onto each questionnaire card and disable it until the questionnaire is saved

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2cc93790832d89404c6c142ea4b7)