### PR TITLE
Fix withBase selector reference in questionnaire builder

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -95,11 +95,6 @@ const Builder = (() => {
   function withBase(path) {
     if (!path.startsWith('/')) {
       path = '/' + path;
-    } else if (selector) {
-      const placeholder = document.createElement('option');
-      placeholder.value = '';
-      placeholder.textContent = 'No questionnaires yet';
-      selector.appendChild(placeholder);
     }
     return normalizedBase + path;
   }


### PR DESCRIPTION
## Summary
- remove undefined selector usage in withBase when normalizing fetch paths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f37172054832d95e6179072a5b23e)