### PR TITLE
Fix admin login redirect handling

### DIFF
--- a/config.php
+++ b/config.php
@@ -160,7 +160,8 @@ function refresh_current_user(PDO $pdo): void {
 function auth_required(array $roles = []): void {
     if (!isset($_SESSION['user'])) {
         $loginTarget = 'login.php';
-        if ($roles && in_array('admin', $roles, true)) {
+        $adminOnly = $roles && empty(array_diff($roles, ['admin']));
+        if ($adminOnly) {
             $loginTarget = 'admin/login.php';
         }
         header('Location: ' . url_for($loginTarget));


### PR DESCRIPTION
## Summary
- restrict admin login redirect to pages that allow only admin access
- preserve staff login flow for pages shared with other roles

## Testing
- php -l config.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f37cc7d34832da3a919ec154bce60)