### PR TITLE
Improve questionnaire question field styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1902,6 +1902,33 @@ body.theme-dark .email-template-placeholders code {
   padding-bottom: 5rem;
 }
 
+.md-assessment-form .md-field {
+  margin: 0 0 1.15rem;
+  padding: 1rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid var(--app-border, #d0d5dd);
+  background: color-mix(in srgb, var(--md-surface) 95%, var(--app-primary-soft) 5%);
+  box-shadow: 0 10px 28px var(--floating-shadow);
+}
+
+.md-assessment-form .md-field > span {
+  color: var(--app-heading, var(--md-primary-dark));
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+}
+
+.md-assessment-form .md-field input,
+.md-assessment-form .md-field select,
+.md-assessment-form .md-field textarea {
+  width: 100%;
+  background: var(--app-surface, #ffffff);
+  border-radius: 12px;
+}
+
+.md-assessment-form .md-field textarea {
+  min-height: 120px;
+}
+
 .md-floating-save-draft {
   position: fixed;
   bottom: 1.75rem;


### PR DESCRIPTION
## Summary
- enhance assessment form question fields with padding, border, and shadow styling
- restore clearer heading colors for question labels and ensure inputs span full width
- enlarge textarea height to reduce cramped appearance

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939c7b38cc8832d91f29e2892a30b21)