### PR TITLE
Add scroll-to-top helper to questionnaire builder

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1212,6 +1212,12 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
 <body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>" style="<?=htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8')?>">
 <?php include __DIR__.'/../templates/header.php'; ?>
 <section class="md-section">
+  <header class="md-page-header qb-page-header">
+    <div class="md-page-header__content">
+      <h1 class="md-page-title" id="qb-page-title" tabindex="-1"><?=t($t,'manage_questionnaires','Manage Questionnaires')?></h1>
+      <p class="md-page-subtitle"><?=t($t,'qb_builder_intro','Build and organize questionnaires for upcoming assessments.')?></p>
+    </div>
+  </header>
   <?php if ($msg): ?>
     <div class="md-alert"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div>
   <?php endif; ?>
@@ -1276,6 +1282,10 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
       </div>
     </aside>
     <div class="qb-manager-main">
+      <button type="button" class="md-button md-secondary md-elev-2 qb-scroll-top" id="qb-scroll-top" aria-label="<?=t($t,'qb_scroll_to_top','Back to top')?>" aria-hidden="true" tabindex="-1">
+        <span class="qb-scroll-top-icon" aria-hidden="true">⇧</span>
+        <span class="qb-scroll-top-label"><?=t($t,'qb_scroll_to_top','Back to top')?></span>
+      </button>
       <div class="md-card md-elev-2 qb-builder-card">
         <div class="qb-toolbar">
           <div class="qb-toolbar-actions">

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -88,6 +88,47 @@
 
 .qb-manager-main {
   min-width: 0;
+  position: relative;
+}
+
+.qb-scroll-top {
+  position: fixed;
+  bottom: 1.25rem;
+  right: clamp(1rem, 2vw, 1.75rem);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  --md-button-padding-x: 0.9rem;
+  --md-button-padding-y: 0.55rem;
+  z-index: 10;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+
+.qb-scroll-top.is-visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.qb-scroll-top-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: var(--app-primary);
+  background: color-mix(in srgb, var(--app-primary) 85%, transparent);
+  color: var(--md-on-primary, #fff);
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.qb-scroll-top-label {
+  white-space: nowrap;
 }
 
 .qb-manager-sidebar {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -29,6 +29,8 @@ const Builder = (() => {
     selector: '#qb-selector',
     sectionNav: '#qb-section-nav',
     metaCsrf: 'meta[name="csrf-token"]',
+    scrollTopButton: '#qb-scroll-top',
+    pageTitle: '#qb-page-title',
   };
 
   const QUESTION_TYPES = ['likert', 'choice', 'text', 'textarea', 'boolean'];
@@ -188,6 +190,7 @@ const Builder = (() => {
     const selector = document.querySelector(selectors.selector);
     const list = document.querySelector(selectors.list);
     const tabs = document.querySelector(selectors.tabs);
+    const scrollTopBtn = document.querySelector(selectors.scrollTopButton);
 
     addBtn?.addEventListener('click', () => {
       addQuestionnaire();
@@ -196,6 +199,7 @@ const Builder = (() => {
     saveBtn?.addEventListener('click', () => saveAll(false));
     publishBtn?.addEventListener('click', () => saveAll(true));
     exportBtn?.addEventListener('click', handleExport);
+    scrollTopBtn?.addEventListener('click', handleScrollToTop);
 
     selector?.addEventListener('change', (event) => {
       const key = event.target.value;
@@ -212,6 +216,11 @@ const Builder = (() => {
     list?.addEventListener('input', handleListInput);
     list?.addEventListener('change', handleListInput);
     list?.addEventListener('click', handleListClick);
+
+    if (scrollTopBtn) {
+      window.addEventListener('scroll', toggleScrollTopVisibility, { passive: true });
+      toggleScrollTopVisibility();
+    }
   }
 
   function fetchData({ silent = false } = {}) {
@@ -591,6 +600,42 @@ const Builder = (() => {
       target = document.querySelector(`.qb-section[data-section="${sectionKey}"]`);
     }
     target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function toggleScrollTopVisibility() {
+    const btn = document.querySelector(selectors.scrollTopButton);
+    if (!btn) return;
+    const shouldShow = window.scrollY > 280;
+    btn.classList.toggle('is-visible', shouldShow);
+    if (shouldShow) {
+      btn.removeAttribute('aria-hidden');
+      btn.removeAttribute('tabindex');
+    } else {
+      btn.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('tabindex', '-1');
+    }
+  }
+
+  function handleScrollToTop(event) {
+    event?.preventDefault?.();
+    const focusTarget = document.querySelector(selectors.pageTitle);
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
+
+    if (!focusTarget) return;
+    if (reduceMotion) {
+      focusTarget.focus({ preventScroll: true });
+      return;
+    }
+
+    const waitForTop = () => {
+      if (window.scrollY <= 2) {
+        focusTarget.focus({ preventScroll: true });
+      } else {
+        window.requestAnimationFrame(waitForTop);
+      }
+    };
+    window.requestAnimationFrame(waitForTop);
   }
 
   function toggleSaveButtons() {


### PR DESCRIPTION
## Summary
- add a dedicated page header and floating back-to-top control for the questionnaire builder
- style the scroll-to-top action to match existing buttons and fade in after scrolling
- implement smooth scrolling with focus returning to the builder heading for accessibility

## Testing
- php -l admin/questionnaire_manage.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b006cff80832db4a689832b76a4a2)