### PR TITLE
Add questionnaire navigator sidebar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -8,6 +8,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -1896,6 +1900,202 @@ body.theme-dark .email-template-placeholders code {
 .md-radar-canvas canvas {
   width: 100% !important;
   height: 100% !important;
+}
+
+.md-questionnaire-layout {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(240px, 280px) 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+.md-questionnaire-content {
+  min-width: 0;
+}
+
+.md-questionnaire-nav {
+  position: sticky;
+  top: calc(var(--appbar-height) + 24px);
+  background: var(--app-surface, #ffffff);
+  border: 1px solid var(--app-border, #d0d5dd);
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: 0 12px 30px var(--floating-shadow);
+  max-height: calc(100vh - var(--appbar-height) - 48px);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.md-questionnaire-nav__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.md-questionnaire-nav__title {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 700;
+  color: var(--app-heading, var(--md-primary-dark));
+}
+
+.md-questionnaire-nav__glyph,
+.md-questionnaire-nav__icon {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+.md-questionnaire-nav__body {
+  margin-top: 0.5rem;
+  max-height: calc(100vh - var(--appbar-height) - 96px);
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.md-questionnaire-nav__group + .md-questionnaire-nav__group {
+  margin-top: 0.85rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--app-border, #d0d5dd);
+}
+
+.md-questionnaire-nav__section,
+.md-questionnaire-nav__link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.3rem;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 10px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.md-questionnaire-nav__section:hover,
+.md-questionnaire-nav__section:focus-visible,
+.md-questionnaire-nav__link:hover,
+.md-questionnaire-nav__link:focus-visible {
+  background: color-mix(in srgb, var(--app-primary-softer) 35%, var(--app-surface, #ffffff) 65%);
+  color: var(--app-primary-dark);
+  outline: none;
+}
+
+.md-questionnaire-nav__link {
+  padding-left: 1.6rem;
+  font-size: 0.95rem;
+}
+
+.md-questionnaire-nav__dot {
+  font-size: 0.9rem;
+  width: 0.9rem;
+  text-align: center;
+}
+
+.md-questionnaire-nav__empty {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+}
+
+.md-questionnaire-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0.15rem 0 0.15rem 0;
+}
+
+.md-questionnaire-nav__close {
+  background: none;
+  border: 1px solid var(--app-border, #d0d5dd);
+  border-radius: 8px;
+  padding: 0.25rem 0.55rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.md-questionnaire-nav__close:hover,
+.md-questionnaire-nav__close:focus-visible {
+  background: var(--app-surface-highlight, rgba(0, 0, 0, 0.04));
+}
+
+.md-questionnaire-nav__backdrop {
+  display: none;
+}
+
+.md-nav-trigger {
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid var(--app-border, #d0d5dd);
+  background: var(--app-surface, #ffffff);
+  box-shadow: 0 10px 28px var(--floating-shadow);
+  cursor: pointer;
+}
+
+.md-nav-trigger__icon {
+  font-size: 1rem;
+}
+
+.md-assessment-form .md-section-title,
+.md-assessment-form [data-question-anchor],
+.md-assessment-form [data-section-anchor] {
+  scroll-margin-top: 108px;
+}
+
+@media (max-width: 1024px) {
+  .md-questionnaire-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .md-questionnaire-nav {
+    position: fixed;
+    left: 1rem;
+    right: auto;
+    width: min(320px, calc(100% - 2rem));
+    top: calc(var(--appbar-height) + 12px);
+    transform: translateX(-110%);
+    z-index: 1300;
+    max-height: calc(100vh - var(--appbar-height) - 24px);
+  }
+
+  .md-questionnaire-layout[data-nav-open="true"] .md-questionnaire-nav {
+    transform: translateX(0);
+    box-shadow: 0 20px 45px var(--floating-shadow-strong);
+  }
+
+  .md-questionnaire-nav__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .md-questionnaire-nav__backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.45);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    z-index: 1200;
+  }
+
+  .md-questionnaire-layout[data-nav-open="true"] .md-questionnaire-nav__backdrop {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .md-nav-trigger {
+    display: inline-flex;
+  }
+}
+
+@media (min-width: 1025px) {
+  .md-questionnaire-nav__close {
+    display: none;
+  }
 }
 
 .md-assessment-form {


### PR DESCRIPTION
## Summary
- add a sticky Questionnaire Navigator sidebar with anchors for sections and questions
- enable smooth scrolling and keyboard focus for quick navigation while keeping the sidebar mobile-friendly
- style the assessment layout to keep navigation accessible without obstructing content

## Testing
- php -l submit_assessment.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b0062408c832da4acd504dcca3480)