### PR TITLE
Style questionnaire builder dropdowns

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1234,7 +1234,7 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
       </div>
       <label class="qb-select-label" for="qb-selector"><?=t($t,'choose_questionnaire','Questionnaire')?></label>
       <div class="qb-select-wrap">
-        <select id="qb-selector" class="qb-select-input"></select>
+        <select id="qb-selector" class="qb-select qb-select-input"></select>
       </div>
       <div class="qb-start-actions">
         <button class="md-button md-elev-2" id="qb-open-selected"><?=t($t,'edit_selected','Edit selected')?></button>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -33,11 +33,26 @@
 }
 
 .qb-select-input {
+  min-height: 2.75rem;
   min-width: 240px;
-  padding: 0.4rem 0.55rem;
+  color: var(--app-on-surface, inherit);
+  background: var(--app-surface);
+  border-color: var(--app-border, rgba(0, 0, 0, 0.1));
+}
+
+.qb-select,
+.qb-select-input {
+  width: 100%;
+  min-width: 240px;
+  padding: 0.55rem 0.65rem;
   border-radius: 6px;
   border: 1px solid var(--app-border, rgba(0, 0, 0, 0.1));
+  background: var(--app-surface);
   font: inherit;
+  line-height: 1.3;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease;
+  box-sizing: border-box;
 }
 
 .qb-builder-card {
@@ -543,11 +558,40 @@
 .qb-select {
   width: 100%;
   font: inherit;
-  padding: 0.45rem;
-  border-radius: 4px;
-  border: 1px solid var(--app-border);
+  padding: 0.55rem 0.65rem;
+  border-radius: 6px;
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.1));
   background: var(--app-surface);
+  color: var(--app-on-surface, inherit);
   box-sizing: border-box;
+  line-height: 1.3;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.qb-input:hover,
+.qb-textarea:hover,
+.qb-select:hover {
+  border-color: var(--app-primary, #1d4ed8);
+  background: var(--app-primary-soft, rgba(32, 84, 147, 0.08));
+}
+
+.qb-input:focus-visible,
+.qb-textarea:focus-visible,
+.qb-select:focus-visible,
+.qb-select-input:focus-visible {
+  border-color: var(--app-primary, #1d4ed8);
+  box-shadow: 0 0 0 3px var(--app-primary-softer, rgba(32, 84, 147, 0.2));
+  outline: none;
+}
+
+.qb-input:disabled,
+.qb-textarea:disabled,
+.qb-select:disabled,
+.qb-select-input:disabled {
+  color: var(--app-muted, rgba(0, 0, 0, 0.6));
+  background: var(--app-surface-alt, rgba(0, 0, 0, 0.03));
+  cursor: not-allowed;
 }
 
 .qb-textarea {
@@ -556,7 +600,7 @@
 }
 
 .qb-select {
-  height: 2.5rem;
+  height: 2.75rem;
 }
 
 .qb-item {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -385,7 +385,7 @@ const Builder = (() => {
           </div>
           <div class="qb-field">
             <label>Status</label>
-            <select data-role="q-status">
+            <select class="qb-select" data-role="q-status">
               ${STATUS_OPTIONS
                 .map((status) => `<option value="${status}" ${status === questionnaire.status ? 'selected' : ''}>${formatStatusLabel(status)}</option>`)
                 .join('')}
@@ -467,7 +467,7 @@ const Builder = (() => {
           </div>
           <div class="qb-field">
             <label>Type</label>
-            <select data-role="item-type">
+            <select class="qb-select" data-role="item-type">
               ${QUESTION_TYPES
                 .map((type) => `<option value="${type}" ${type === item.type ? 'selected' : ''}>${type}</option>`)
                 .join('')}


### PR DESCRIPTION
## Summary
- apply shared dropdown styling that aligns with existing input variables
- add questionnaire builder select components to the styled dropdown class
- refine hover, focus, and disabled states for consistent appearance and accessibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b005ab868832dbc466acc188831ab)