### PR TITLE
Consolidate questionnaire import controls in builder start tile

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1247,12 +1247,21 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
         <h2 class="md-card-title"><?=t($t,'qb_start_import_title','Import or align a questionnaire')?></h2>
         <p class="md-hint"><?=t($t,'qb_start_import_hint','Upload a questionnaire XML file or download our template to mirror other survey tools.')?></p>
       </div>
-      <div class="qb-start-actions">
-        <a class="md-button md-elev-2" href="#qb-import-anchor"><?=t($t,'go_to_import','Go to import tools')?></a>
-        <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
-          <?=t($t,'download_import_guide','Download Import Guide')?>
-        </a>
-      </div>
+      <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
+        <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+        <div class="qb-import-inline">
+          <label class="md-field"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
+          <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
+        </div>
+        <div class="qb-start-actions">
+          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
+            <?=t($t,'download_xml_template','Download XML template')?>
+          </a>
+          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
+            <?=t($t,'download_import_guide','Download Import Guide')?>
+          </a>
+        </div>
+      </form>
     </div>
   </div>
   <div class="qb-manager-layout">
@@ -1288,27 +1297,6 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
         <div id="qb-list" class="qb-list" aria-live="polite"></div>
       </div>
     </div>
-  </div>
-</section>
-<section class="qb-import-banner" id="qb-import-anchor">
-  <div class="md-card md-elev-1 qb-import-card">
-    <div class="qb-import-card-header">
-      <h3 class="md-card-title"><?=t($t,'fhir_import','Questionnaire import')?></h3>
-      <p class="md-hint"><?=t($t,'qb_import_hint','Update or add questionnaires from an XML file.')?></p>
-    </div>
-    <form method="post" enctype="multipart/form-data" class="qb-import-form qb-import-inline" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
-      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-      <label class="md-field"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
-      <div class="qb-import-actions">
-        <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
-        <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
-          <?=t($t,'download_xml_template','Download XML template')?>
-        </a>
-        <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
-          <?=t($t,'download_import_guide','Download Import Guide')?>
-        </a>
-      </div>
-    </form>
   </div>
 </section>
 <?php if ($recentImportId): ?>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -708,22 +708,6 @@
   gap: 0.6rem;
 }
 
-.qb-import-banner {
-  margin-top: 1rem;
-}
-
-.qb-import-card {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem 1rem;
-}
-
-.qb-import-card-header {
-  max-width: 420px;
-}
-
 .qb-import-inline {
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
## Summary
- move questionnaire import form into the start tile and remove the duplicate bottom import banner
- keep the import submission, template download, and guide links together within the tile
- clean up unused styles related to the removed import banner

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b00648180832db9ce31055094f91d)