### PR TITLE
Fix site_config seed alignment for landing metrics

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -305,6 +305,7 @@ INSERT INTO site_config (
   'My Performance',
   NULL,
   NULL,
+  NULL,
   4280,
   '12 min',
   '94%',

--- a/migration.sql
+++ b/migration.sql
@@ -761,6 +761,7 @@ INSERT IGNORE INTO site_config (
   'My Performance',
   NULL,
   NULL,
+  NULL,
   4280,
   '12 min',
   '94%',

--- a/reset_system.sql
+++ b/reset_system.sql
@@ -69,6 +69,7 @@ REPLACE INTO site_config (
   'My Performance',
   NULL,
   NULL,
+  NULL,
   4280,
   '12 min',
   '94%',


### PR DESCRIPTION
### Motivation
- A misalignment in the `site_config` seed rows caused the numeric `landing_metric_submissions` column to receive the wrong value and produce truncation errors. 
- The init, reset, and migration seed inserts needed to be consistent to avoid failures when seeding or resetting the DB. 
- Aligning the values prevents MySQL `Data truncated` errors for the landing metric fields. 

### Description
- Inserted an explicit `NULL` for the `contact` column position and shifted `landing_metric_submissions` to the numeric value in `init.sql`. 
- Applied the same corrected ordering to `reset_system.sql` so reseeding uses the same column/value alignment. 
- Updated the `migration.sql` seed `INSERT IGNORE INTO site_config` block to match the corrected column/value order. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696642063724832d9bcbe98451526eb5)