### PR TITLE
Tighten questionnaire builder start tiles

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -63,31 +63,40 @@
 
 .qb-start-grid {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
   align-items: stretch;
 }
 
 .qb-start-card {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   height: 100%;
   justify-content: space-between;
+  padding: 0.9rem 1rem;
+}
+
+.qb-start-card .md-card-title {
+  margin-bottom: 0.45rem;
+}
+
+.qb-start-card .md-hint {
+  margin-top: 0.2rem;
 }
 
 .qb-start-card-header {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
 }
 
 .qb-start-actions {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .qb-import-start {


### PR DESCRIPTION
### Motivation
- Reduce excessive whitespace in the questionnaire builder start area (Create / Edit / Import tiles) to make the UI denser and improve information density.

### Description
- Adjusted spacing in `assets/css/questionnaire-builder.css` by reducing the `.qb-start-grid` `gap` and `margin-bottom` and shrinking `.qb-start-card` `gap`. 
- Added compact `padding` for `.qb-start-card` and tightened header spacing by reducing `.qb-start-card-header` `gap` and `.qb-start-actions` `gap`.
- Tweaked title and hint spacing inside start cards with `.qb-start-card .md-card-title` and `.qb-start-card .md-hint` to further reduce vertical white space.

### Testing
- Started a local dev server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and loaded `admin/questionnaire_manage.php` using a Playwright script that captured a full-page screenshot; the page rendered and the screenshot was produced successfully.  
- No unit or integration test suites were run for this UI-only CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710451a9a8832da71aca9715260e77)