### PR TITLE
Use single-choice as primary question type and add correct-answer scoring

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -756,6 +756,26 @@
   padding: 0.3rem 0.45rem;
 }
 
+.qb-option-correct {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: var(--app-muted);
+  margin-right: 0.35rem;
+}
+
+.qb-option-correct input[type="radio"] {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.qb-hint {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  color: var(--app-muted);
+}
+
 .qb-option-readonly {
   background: var(--app-primary-softer);
   cursor: default;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2857,6 +2857,13 @@ body.theme-dark .md-button.md-primary {
   margin-top: 0.5rem;
 }
 
+.choice-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
 .likert-scale__option {
   display: flex;
   flex-direction: column;
@@ -2868,7 +2875,21 @@ body.theme-dark .md-button.md-primary {
   min-width: 110px;
 }
 
+.choice-options__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: var(--app-secondary-soft);
+}
+
 .likert-scale__option input[type="radio"] {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.choice-options__option input[type="radio"] {
   width: 1.25rem;
   height: 1.25rem;
 }
@@ -2879,10 +2900,19 @@ body.theme-dark .md-button.md-primary {
   color: var(--app-muted);
 }
 
+.choice-options__option span {
+  font-size: 0.9rem;
+  color: var(--app-muted);
+}
+
 @media (max-width: 640px) {
   .likert-scale {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.65rem;
+  }
+
+  .choice-options {
     gap: 0.65rem;
   }
 
@@ -2893,6 +2923,11 @@ body.theme-dark .md-button.md-primary {
     gap: 0.75rem;
     width: 100%;
     min-width: 0;
+    padding: 0.75rem 0.85rem;
+  }
+
+  .choice-options__option {
+    justify-content: flex-start;
     padding: 0.75rem 0.85rem;
   }
 

--- a/init.sql
+++ b/init.sql
@@ -127,7 +127,7 @@ CREATE TABLE questionnaire_item (
   section_id INT NULL,
   linkId VARCHAR(64) NOT NULL,
   text VARCHAR(500) NOT NULL,
-  type ENUM('likert','text','textarea','boolean','choice') NOT NULL DEFAULT 'likert',
+  type ENUM('likert','text','textarea','boolean','choice') NOT NULL DEFAULT 'choice',
   order_index INT NOT NULL DEFAULT 0,
   weight_percent INT NOT NULL DEFAULT 0,
   allow_multiple TINYINT(1) NOT NULL DEFAULT 0,
@@ -141,6 +141,7 @@ CREATE TABLE questionnaire_item_option (
   id INT AUTO_INCREMENT PRIMARY KEY,
   questionnaire_item_id INT NOT NULL,
   value VARCHAR(500) NOT NULL,
+  is_correct TINYINT(1) NOT NULL DEFAULT 0,
   order_index INT NOT NULL DEFAULT 0,
   FOREIGN KEY (questionnaire_item_id) REFERENCES questionnaire_item(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -101,11 +101,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $items = $itemsStmt->fetchAll();
 
             $nonScorableTypes = ['display', 'group', 'section'];
+            $singleChoiceWeightMap = questionnaire_even_single_choice_weights($items);
             $likertWeightMap = questionnaire_even_likert_weights($items);
             foreach ($items as &$itemRow) {
                 $type = (string)($itemRow['type'] ?? '');
                 $isScorable = !in_array($type, $nonScorableTypes, true);
-                $itemRow['computed_weight'] = questionnaire_resolve_effective_weight($itemRow, $likertWeightMap, $isScorable);
+                $itemRow['computed_weight'] = questionnaire_resolve_effective_weight($itemRow, $singleChoiceWeightMap, $likertWeightMap, $isScorable);
             }
             unset($itemRow);
 
@@ -113,11 +114,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($items) {
                 $itemIds = array_column($items, 'id');
                 $placeholders = implode(',', array_fill(0, count($itemIds), '?'));
-                $optStmt = $pdo->prepare("SELECT questionnaire_item_id, value FROM questionnaire_item_option WHERE questionnaire_item_id IN ($placeholders) ORDER BY questionnaire_item_id, order_index, id");
+                $optStmt = $pdo->prepare("SELECT questionnaire_item_id, value, is_correct FROM questionnaire_item_option WHERE questionnaire_item_id IN ($placeholders) ORDER BY questionnaire_item_id, order_index, id");
                 $optStmt->execute($itemIds);
                 foreach ($optStmt->fetchAll() as $opt) {
                     $itemId = (int)$opt['questionnaire_item_id'];
-                    $optionMap[$itemId][] = $opt['value'];
+                    $value = (string)($opt['value'] ?? '');
+                    if ($value === '') {
+                        continue;
+                    }
+                    $optionMap[$itemId]['values'][] = $value;
+                    if (!empty($opt['is_correct']) && empty($optionMap[$itemId]['correct'])) {
+                        $optionMap[$itemId]['correct'] = $value;
+                    }
                 }
             }
 
@@ -131,7 +139,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $isScorable = !in_array($type, $nonScorableTypes, true);
                 $effectiveWeight = isset($it['computed_weight'])
                     ? (float)$it['computed_weight']
-                    : questionnaire_resolve_effective_weight($it, $likertWeightMap, $isScorable);
+                    : questionnaire_resolve_effective_weight($it, $singleChoiceWeightMap, $likertWeightMap, $isScorable);
                 $achievedPoints = 0.0;
                 $a = json_encode([]);
                 $isRequired = !empty($it['is_required']);
@@ -155,7 +163,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $raw = reset($raw);
                     }
                     $selected = is_string($raw) ? trim($raw) : '';
-                    $validOptions = array_map('trim', $optionMap[(int)$it['id']] ?? []);
+                    $validOptions = array_map('trim', $optionMap[(int)$it['id']]['values'] ?? []);
                     if ($selected !== '' && $validOptions && !in_array($selected, $validOptions, true)) {
                         $selected = '';
                     }
@@ -199,7 +207,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         }
                         return '';
                     }, $selected), static fn($val) => $val !== ''));
-                    $validOptions = array_map('trim', $optionMap[(int)$it['id']] ?? []);
+                    $validOptions = array_map('trim', $optionMap[(int)$it['id']]['values'] ?? []);
                     if ($validOptions) {
                         $values = array_values(array_filter($values, static function ($val) use ($validOptions) {
                             return in_array($val, $validOptions, true);
@@ -208,8 +216,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     if ($values) {
                         $hasResponse = true;
                     }
-                    if ($values) {
+                    if ($values && $allowMultiple) {
                         $achievedPoints = $effectiveWeight;
+                    }
+                    if (!$allowMultiple && $values) {
+                        $correctValue = $optionMap[(int)$it['id']]['correct'] ?? null;
+                        $selectedValue = (string)($values[0] ?? '');
+                        if ($correctValue !== null && $selectedValue !== '' && $selectedValue === $correctValue) {
+                            $achievedPoints = $effectiveWeight;
+                        }
                     }
                     $a = json_encode(array_map(static fn($val) => ['valueString' => $val], $values));
                 } else {
@@ -307,7 +322,7 @@ if ($qid) {
     if ($items) {
         $itemIds = array_column($items, 'id');
         $placeholders = implode(',', array_fill(0, count($itemIds), '?'));
-        $optStmt = $pdo->prepare("SELECT questionnaire_item_id, value, order_index FROM questionnaire_item_option WHERE questionnaire_item_id IN ($placeholders) ORDER BY questionnaire_item_id, order_index, id");
+        $optStmt = $pdo->prepare("SELECT questionnaire_item_id, value, order_index, is_correct FROM questionnaire_item_option WHERE questionnaire_item_id IN ($placeholders) ORDER BY questionnaire_item_id, order_index, id");
         $optStmt->execute($itemIds);
         foreach ($optStmt->fetchAll() as $row) {
             $itemOptions[(int)$row['questionnaire_item_id']][] = $row;
@@ -461,15 +476,20 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
         </select>
           <small class="md-hint"><?=htmlspecialchars(t($t,'multiple_choice_hint','Select all that apply'), ENT_QUOTES, 'UTF-8')?></small>
       <?php else: ?>
-        <select name="item_<?=htmlspecialchars($it['linkId'] ?? '', ENT_QUOTES, 'UTF-8')?>"<?=$requiredAttr?>>
-            <option value=""><?=htmlspecialchars(t($t,'select_single_option','Select an option'), ENT_QUOTES, 'UTF-8')?></option>
-          <?php foreach ($options as $opt): ?>
-            <?php $optValue = (string)($opt['value'] ?? '');
-            $isSelected = (string)$optValue !== '' && ((string)$optValue === (string)$firstValue);
-            ?>
-            <option value="<?=htmlspecialchars($optValue, ENT_QUOTES, 'UTF-8')?>" <?=$isSelected ? 'selected' : ''?>><?=htmlspecialchars($opt['value'] ?? '', ENT_QUOTES, 'UTF-8')?></option>
+        <div class="choice-options" role="radiogroup" aria-label="<?=htmlspecialchars($it['text'] ?? '', ENT_QUOTES, 'UTF-8')?>"<?=$ariaRequired?>>
+          <?php foreach ($options as $idx => $opt):
+            $optValue = (string)($opt['value'] ?? '');
+            $label = $opt['value'] ?? ('Option ' . ($idx + 1));
+            $inputId = ($it['linkId'] ?? 'choice') . '_' . ($idx + 1);
+            $selected = is_string($firstValue) ? $firstValue : ((string)$firstValue);
+            $isSelected = $optValue !== '' && $selected !== '' && (string)$optValue === $selected;
+          ?>
+          <label class="choice-options__option" for="<?=htmlspecialchars($inputId, ENT_QUOTES, 'UTF-8')?>">
+            <input type="radio" id="<?=htmlspecialchars($inputId, ENT_QUOTES, 'UTF-8')?>" name="item_<?=htmlspecialchars($it['linkId'] ?? '', ENT_QUOTES, 'UTF-8')?>" value="<?=htmlspecialchars($optValue, ENT_QUOTES, 'UTF-8')?>" <?=$isSelected ? 'checked' : ''?><?=($required && $idx === 0) ? ' required' : ''?>>
+            <span><?=htmlspecialchars($label, ENT_QUOTES, 'UTF-8')?></span>
+          </label>
           <?php endforeach; ?>
-        </select>
+        </div>
       <?php endif; ?>
       <?php else: ?>
         <?php

--- a/tests/analytics_report_snapshot_test.php
+++ b/tests/analytics_report_snapshot_test.php
@@ -14,7 +14,7 @@ $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $pdo->exec('CREATE TABLE questionnaire (id INTEGER PRIMARY KEY, title TEXT, status TEXT)');
 $pdo->exec('CREATE TABLE questionnaire_section (id INTEGER PRIMARY KEY, questionnaire_id INT, title TEXT, order_index INT, is_active INT DEFAULT 1)');
 $pdo->exec('CREATE TABLE questionnaire_item (id INTEGER PRIMARY KEY, questionnaire_id INT, section_id INT, linkId TEXT, type TEXT, allow_multiple INT, weight_percent REAL, order_index INT, is_active INT)');
-$pdo->exec('CREATE TABLE questionnaire_item_option (id INTEGER PRIMARY KEY, questionnaire_item_id INT, value TEXT, order_index INT)');
+$pdo->exec('CREATE TABLE questionnaire_item_option (id INTEGER PRIMARY KEY, questionnaire_item_id INT, value TEXT, is_correct INT DEFAULT 0, order_index INT)');
 $pdo->exec('CREATE TABLE questionnaire_response (id INTEGER PRIMARY KEY, user_id INT, questionnaire_id INT, performance_period_id INT, status TEXT, score REAL, created_at TEXT, reviewed_at TEXT)');
 $pdo->exec('CREATE TABLE questionnaire_response_item (id INTEGER PRIMARY KEY, response_id INT, linkId TEXT, answer TEXT)');
 $pdo->exec('CREATE TABLE performance_period (id INTEGER PRIMARY KEY, label TEXT, period_start TEXT)');

--- a/tests/questionnaire_scoring_test.php
+++ b/tests/questionnaire_scoring_test.php
@@ -4,45 +4,46 @@ declare(strict_types=1);
 require_once __DIR__ . '/../lib/scoring.php';
 
 $items = [
-    ['id' => 1, 'linkId' => 'likert_a', 'type' => 'likert'],
-    ['id' => 2, 'linkId' => 'likert_b', 'type' => 'likert', 'weight_percent' => 25],
+    ['id' => 1, 'linkId' => 'single_a', 'type' => 'choice', 'allow_multiple' => 0],
+    ['id' => 2, 'linkId' => 'single_b', 'type' => 'choice', 'allow_multiple' => 0, 'weight_percent' => 25],
     ['id' => 3, 'linkId' => 'bool_a', 'type' => 'boolean', 'weight_percent' => 15],
     ['id' => 4, 'linkId' => 'text_a', 'type' => 'text'],
 ];
 
+$singleChoiceWeights = questionnaire_even_single_choice_weights($items);
 $likertWeights = questionnaire_even_likert_weights($items);
-if (count($likertWeights) !== 2) {
-    fwrite(STDERR, "Expected two likert weights.\n");
+if (count($singleChoiceWeights) !== 2) {
+    fwrite(STDERR, "Expected two single-choice weights.\n");
     exit(1);
 }
 
-$weightA = questionnaire_resolve_effective_weight($items[0], $likertWeights, true);
-$weightB = questionnaire_resolve_effective_weight($items[1], $likertWeights, true);
-$weightBoolean = questionnaire_resolve_effective_weight($items[2], $likertWeights, true);
-$weightText = questionnaire_resolve_effective_weight($items[3], $likertWeights, true);
+$weightA = questionnaire_resolve_effective_weight($items[0], $singleChoiceWeights, $likertWeights, true);
+$weightB = questionnaire_resolve_effective_weight($items[1], $singleChoiceWeights, $likertWeights, true);
+$weightBoolean = questionnaire_resolve_effective_weight($items[2], $singleChoiceWeights, $likertWeights, true);
+$weightText = questionnaire_resolve_effective_weight($items[3], $singleChoiceWeights, $likertWeights, true);
 
 if (abs($weightA - 50.0) > 0.001) {
-    fwrite(STDERR, "Likert auto weight calculation failed.\n");
+    fwrite(STDERR, "Single-choice auto weight calculation failed.\n");
     exit(1);
 }
 
 if (abs($weightB - 25.0) > 0.001) {
-    fwrite(STDERR, "Explicit likert weight should override auto distribution.\n");
+    fwrite(STDERR, "Explicit single-choice weight should override auto distribution.\n");
     exit(1);
 }
 
 if (abs($weightBoolean - 15.0) > 0.001) {
-    fwrite(STDERR, "Boolean weight was lost when likert auto weights were present.\n");
+    fwrite(STDERR, "Boolean weight was lost when single-choice auto weights were present.\n");
     exit(1);
 }
 
 if ($weightText !== 0.0) {
-    fwrite(STDERR, "Unweighted non-likert item should not receive implicit weight.\n");
+    fwrite(STDERR, "Unweighted non-single-choice item should not receive implicit weight.\n");
     exit(1);
 }
 
 $nonScorable = ['id' => 5, 'linkId' => 'section_1', 'type' => 'section', 'weight_percent' => 10];
-if (questionnaire_resolve_effective_weight($nonScorable, $likertWeights, false) !== 0.0) {
+if (questionnaire_resolve_effective_weight($nonScorable, $singleChoiceWeights, $likertWeights, false) !== 0.0) {
     fwrite(STDERR, "Non-scorable items must yield zero weight.\n");
     exit(1);
 }

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -151,6 +151,9 @@ ALTER TABLE questionnaire_item
 ALTER TABLE questionnaire_item
   ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER is_required;
 
+ALTER TABLE questionnaire_item_option
+  ADD COLUMN IF NOT EXISTS is_correct TINYINT(1) NOT NULL DEFAULT 0 AFTER value;
+
 UPDATE questionnaire
 SET status = 'draft'
 WHERE status IS NULL OR status NOT IN ('draft','published','inactive');


### PR DESCRIPTION
### Motivation
- The questionnaire model has changed to use single-choice (single-select) as the primary question type with a single correct answer per item, and scoring must reflect this new behaviour.
- Analytics, submission scoring, builder UI and FHIR import/export must respect single-choice auto-weighting and correct-answer scoring so dashboards and exports remain accurate.

### Description
- Scoring: added `questionnaire_even_single_choice_weights`, extended `questionnaire_resolve_effective_weight` to accept single-choice and likert weight maps, and updated scoring consumers to prefer single-choice auto-weights and correct-answer scoring where applicable (files: `lib/scoring.php`, `lib/performance_sections.php`, `admin/analytics.php`).
- Submission and FHIR: submission handling now reads `is_correct` option flags and awards points only for a matching single-choice answer (files: `submit_assessment.php`, `fhir/QuestionnaireResponse.php`).
- Builder and admin: questionnaire builder defaults new items to `choice`, provides UI to mark one correct option for single-choice questions, serializes `is_correct` for options, and admin save/import logic enforces and persists a single correct option (files: `assets/js/questionnaire-builder.js`, `admin/questionnaire_manage.php`).
- Schema & styling: added `is_correct` to `questionnaire_item_option`, changed default item type to `choice` in schema/migrations and updated CSS for choice radio groups and builder controls (files: `init.sql`, `migration.sql`, `upgrade_to_v3.sql`, `assets/css/*`).
- Tests & exports: updated unit tests and analytics export code to include correct-answer handling and single-choice auto-weighting (files: `tests/*`, `admin/questionnaire_manage.php`, `fhir/QuestionnaireResponse.php`).

### Testing
- Dev server and UI check: started the PHP dev server (`php -S 0.0.0.0:8000 -t /workspace/CAS2025`) and captured a page screenshot using a Playwright script, which ran and produced an artifact; the server started successfully and a screenshot was saved.
- Unit tests: existing PHP test scripts were updated to reflect single-choice behaviour but the test suite was not executed as part of this change, so no unit test results are available. 
- Note: database migrations were updated to include `is_correct` and default item type changes; apply and verify migrations in a staging environment before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697114d654dc832da295755822d26530)