### PR TITLE
Fix site_config seed insert column alignment

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -766,7 +766,6 @@ INSERT IGNORE INTO site_config (
   '12 min',
   '94%',
   NULL,
-  NULL,
   'Ethiopian Pharmaceutical Supply Service',
   'EPSS / EPS',
   'epss.gov.et',


### PR DESCRIPTION
### Motivation
- Fix the failing upgrade caused by a mismatched column/value list in the `INSERT IGNORE INTO site_config` seed which produced the error `Column count doesn't match value count` during migration.

### Description
- Remove the extra stray `NULL` in `migration.sql` so the number of values aligns with the column list for the `site_config` seed insert.

### Testing
- Ran a small validation script that parses the `INSERT` statement and confirms the column and value counts now both equal 39, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697128c4ae8c832db68befdee4e023bf)