### PR TITLE
Move work function schema helper into shared work_functions library

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -96,6 +96,56 @@ function ensure_work_function_catalog(PDO $pdo): void
     }
 }
 
+function ensure_questionnaire_work_function_schema(PDO $pdo): void
+{
+    try {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS questionnaire_work_function (
+            questionnaire_id INT NOT NULL,
+            work_function VARCHAR(191) NOT NULL,
+            PRIMARY KEY (questionnaire_id, work_function)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        $columnsStmt = $pdo->query('SHOW COLUMNS FROM questionnaire_work_function');
+        $columns = [];
+        if ($columnsStmt) {
+            while ($column = $columnsStmt->fetch(PDO::FETCH_ASSOC)) {
+                $columns[$column['Field']] = $column;
+            }
+        }
+
+        if (!isset($columns['work_function'])) {
+            $pdo->exec('ALTER TABLE questionnaire_work_function ADD COLUMN work_function VARCHAR(191) NOT NULL AFTER questionnaire_id');
+        } else {
+            $type = strtolower((string)($columns['work_function']['Type'] ?? ''));
+            $needsUpdate = true;
+            if (str_contains($type, 'varchar')) {
+                $length = 0;
+                if (preg_match('/varchar\\((\\d+)\\)/i', $type, $matches)) {
+                    $length = (int)$matches[1];
+                }
+                $needsUpdate = $length < 1 || $length < 191;
+            }
+            if ($needsUpdate) {
+                $pdo->exec('ALTER TABLE questionnaire_work_function MODIFY COLUMN work_function VARCHAR(191) NOT NULL');
+            }
+        }
+
+        $primaryIndex = $pdo->query("SHOW INDEX FROM questionnaire_work_function WHERE Key_name = 'PRIMARY'");
+        $hasPrimary = $primaryIndex && $primaryIndex->fetch(PDO::FETCH_ASSOC);
+        if (!$hasPrimary) {
+            $pdo->exec('ALTER TABLE questionnaire_work_function ADD PRIMARY KEY (questionnaire_id, work_function)');
+        }
+
+        // Preserve any administrator-defined questionnaire assignments without
+        // seeding defaults on every request. The previous behaviour inserted
+        // every questionnaire/work function combination which overwrote custom
+        // selections made through the admin portal. By limiting this helper to
+        // structural concerns we ensure saved assignments remain intact.
+    } catch (PDOException $e) {
+        error_log('ensure_questionnaire_work_function_schema: ' . $e->getMessage());
+    }
+}
+
 /**
  * Fetch the active work function definitions from the catalog.
  *


### PR DESCRIPTION
### Motivation
- Fix fatal errors caused by duplicate function declarations by consolidating work-function helpers into a single library file.
- Ensure the schema helper used to create/adjust the `questionnaire_work_function` table is declared once and loaded via `config.php` so callers like `ensure_questionnaire_work_function_schema($pdo)` resolve to a single definition.

### Description
- Removed the duplicate `ensure_questionnaire_work_function_schema` implementation from `config.php` and added it to `lib/work_functions.php` so all work-function logic lives in `lib/work_functions.php`.
- The moved helper creates/adjusts the `questionnaire_work_function` table, enforces column type/length for `work_function`, and ensures the primary key exists, while preserving existing administrator data by avoiding seeding assignments.
- Kept `config.php`'s call sites unchanged; `config.php` already `require_once`s `lib/work_functions.php` so the function is available exactly once.
- Updated code formatting and comments near the helper to explain the structural-only behaviour (no automatic seeding of assignments).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972443436a4832da4df6c8257b8f000)