### PR TITLE
Guard work function definitions from redefinition errors

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -1,6 +1,5 @@
 <?php
 require_once __DIR__ . '/../config.php';
-require_once __DIR__ . '/../lib/work_functions.php';
 auth_required(['admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);

--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -1,6 +1,11 @@
 <?php
 declare(strict_types=1);
 
+if (defined('WORK_FUNCTIONS_LOADED')) {
+    return;
+}
+define('WORK_FUNCTIONS_LOADED', true);
+
 /**
  * Retrieve the built-in (code-level) work function definition list.
  *


### PR DESCRIPTION
### Motivation
- Prevent PHP `redeclare` errors that break pages when `lib/work_functions.php` is included more than once by making the module safe to include multiple times and removing a redundant include.

### Description
- Add a one-time load guard to the top of `lib/work_functions.php` using `WORK_FUNCTIONS_LOADED` so the file returns immediately if already loaded.
- Remove the redundant `require_once __DIR__ . '/../lib/work_functions.php'` from `admin/work_function_defaults.php` because `config.php` already includes it.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69725d1140f8832d8500edfc0575fbd0)