### PR TITLE
Define str_contains polyfill before schema initialization

### DIFF
--- a/config.php
+++ b/config.php
@@ -4,6 +4,28 @@ declare(strict_types=1);
 require_once __DIR__ . '/lib/email_templates.php';
 require_once __DIR__ . '/lib/work_functions.php';
 
+if (!function_exists('str_starts_with')) {
+    function str_starts_with(string $haystack, string $needle): bool
+    {
+        if ($needle === '') {
+            return true;
+        }
+
+        return strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
+if (!function_exists('str_contains')) {
+    function str_contains(string $haystack, string $needle): bool
+    {
+        if ($needle === '') {
+            return true;
+        }
+
+        return strpos($haystack, $needle) !== false;
+    }
+}
+
 if (!defined('APP_BOOTSTRAPPED')) {
     define('APP_BOOTSTRAPPED', true);
 
@@ -94,28 +116,6 @@ if (!defined('APP_BOOTSTRAPPED')) {
 }
 
 require_once __DIR__ . '/lib/email_templates.php';
-
-if (!function_exists('str_starts_with')) {
-    function str_starts_with(string $haystack, string $needle): bool
-    {
-        if ($needle === '') {
-            return true;
-        }
-
-        return strncmp($haystack, $needle, strlen($needle)) === 0;
-    }
-}
-
-if (!function_exists('str_contains')) {
-    function str_contains(string $haystack, string $needle): bool
-    {
-        if ($needle === '') {
-            return true;
-        }
-
-        return strpos($haystack, $needle) !== false;
-    }
-}
 
 function site_default_brand_color(array $cfg): string
 {


### PR DESCRIPTION
### Motivation
- On PHP < 8 the schema bootstrap can call helpers that use `str_contains`, so the polyfill must be available before any schema initialization to avoid fatal errors and skipped migrations.

### Description
- Move the `str_starts_with` and `str_contains` polyfill definitions to the top of `config.php` so they are defined before `initialize_database_schema($pdo)` is invoked during bootstrap.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972648916fc832da3fe961dd5ef9918)