### PR TITLE
Preserve inactive questionnaire status when publishing

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1258,7 +1258,7 @@ const Builder = (() => {
       clientId: questionnaire.clientId,
       title: questionnaire.title,
       description: questionnaire.description,
-      status: publish ? 'published' : questionnaire.status,
+      status: publish && questionnaire.status !== 'inactive' ? 'published' : questionnaire.status,
       sections: questionnaire.sections.map((section, idx) => serializeSection(section, idx + 1)),
       items: questionnaire.items.map((item, idx) => serializeItem(item, idx + 1)),
     };


### PR DESCRIPTION
### Motivation
- Fix a bug where publishing from the builder would set questionnaires with `status: 'inactive'` to `published`, preventing administrators from keeping a questionnaire inactive.

### Description
- Update `serializeQuestionnaire` so the status is only forced to `'published'` on a publish action when the questionnaire is not already `'inactive'`, i.e. `status: publish && questionnaire.status !== 'inactive' ? 'published' : questionnaire.status` in `assets/js/questionnaire-builder.js`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697264748f70832d9857fb469c301f0e)