### PR TITLE
Load .env defaults for database configuration

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,6 +7,37 @@ require_once __DIR__ . '/lib/work_functions.php';
 if (!defined('APP_BOOTSTRAPPED')) {
     define('APP_BOOTSTRAPPED', true);
 
+    $envPath = __DIR__ . '/.env';
+    if (is_readable($envPath)) {
+        $lines = file($envPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if (is_array($lines)) {
+            foreach ($lines as $line) {
+                $trimmed = trim($line);
+                if ($trimmed === '' || $trimmed[0] === '#') {
+                    continue;
+                }
+                if (strpos($trimmed, '=') === false) {
+                    continue;
+                }
+                [$key, $value] = explode('=', $trimmed, 2);
+                $key = trim($key);
+                $value = trim($value);
+                $length = strlen($value);
+                if ($length >= 2) {
+                    $first = $value[0];
+                    $last = $value[$length - 1];
+                    if (($first === '"' && $last === '"') || ($first === "'" && $last === "'")) {
+                        $value = substr($value, 1, -1);
+                    }
+                }
+                if ($key !== '' && getenv($key) === false) {
+                    putenv($key . '=' . $value);
+                    $_ENV[$key] = $value;
+                }
+            }
+        }
+    }
+
     $appDebug = filter_var(getenv('APP_DEBUG') ?: '0', FILTER_VALIDATE_BOOLEAN);
     ini_set('display_errors', $appDebug ? '1' : '0');
     error_reporting(E_ALL);


### PR DESCRIPTION
### Motivation
- The app was falling back to the hardcoded `epss_user` DB user instead of the intended `hrassess` user when only a `.env` file was present, causing access denied errors during seeding. 
- Provide a simple, framework-free way for the application and scripts like `scripts/seed_admin.php` to pick up DB configuration stored in a `.env` file. 

### Description
- Added a lightweight `.env` loader at the top of `config.php` that reads `./.env` and exports key/value pairs via `putenv()` and `$_ENV` when the environment variable is not already set. 
- The loader skips blank lines and comments, ignores lines without `=`, trims whitespace, and strips surrounding single or double quotes from values. 
- Uses `strpos()` for `=` detection to remain compatible with older PHP versions. 
- Only `config.php` was modified to implement the behavior.

### Testing
- No automated tests were executed for this change. 
- Manual validation is implied by the change (the loader sets `DB_USER`, `DB_PASS`, etc. from `.env` before the code reads them).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966497f749c832d8fea1c230a4c57dc)