### PR TITLE
Tighten questionnaire builder layout, make single-choice correct optional, and align landing theme

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -1,10 +1,15 @@
 :root {
-  --landing-primary: #20407f;
-  --landing-primary-dark: #14294e;
-  --landing-accent: #ff8a3d;
-  --landing-surface: #ffffff;
+  --landing-primary: var(--app-primary, #20407f);
+  --landing-primary-dark: var(--app-primary-dark, #14294e);
+  --landing-accent: var(--app-secondary, #ff8a3d);
+  --landing-surface: var(--app-surface, #ffffff);
   --landing-muted: #4b5a6b;
-  --landing-background: linear-gradient(120deg, #102447 0%, #0c1a31 45%, #112644 100%);
+  --landing-background: linear-gradient(
+    120deg,
+    var(--landing-primary-dark) 0%,
+    color-mix(in srgb, var(--landing-primary-dark) 70%, #0c1a31 30%) 45%,
+    var(--landing-primary) 100%
+  );
   --landing-radius-lg: 28px;
   --landing-radius-md: 18px;
   --landing-shadow-lg: 0 24px 58px rgba(9, 24, 54, 0.3);

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -63,40 +63,40 @@
 
 .qb-start-grid {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  margin-bottom: 0.75rem;
+  gap: 0.55rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-bottom: 0.6rem;
   align-items: stretch;
 }
 
 .qb-start-card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
   height: 100%;
   justify-content: space-between;
-  padding: 0.9rem 1rem;
+  padding: 0.75rem 0.9rem;
 }
 
 .qb-start-card .md-card-title {
-  margin-bottom: 0.45rem;
+  margin-bottom: 0.25rem;
 }
 
 .qb-start-card .md-hint {
-  margin-top: 0.2rem;
+  margin-top: 0.15rem;
 }
 
 .qb-start-card-header {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.15rem;
 }
 
 .qb-start-actions {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.4rem;
+  gap: 0.3rem;
 }
 
 .qb-import-start {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -153,9 +153,7 @@ const Builder = (() => {
       : 'choice';
     const allowMultiple = type === 'choice' && Boolean(item.allow_multiple);
     const requiresCorrect =
-      type === 'choice' && !allowMultiple
-        ? Boolean(item.requires_correct ?? options.some((opt) => opt.is_correct))
-        : false;
+      type === 'choice' && !allowMultiple ? Boolean(item.requires_correct) : false;
     const normalized = {
       id: item.id ?? null,
       clientId: item.clientId || uuid('i'),
@@ -851,8 +849,8 @@ const Builder = (() => {
         if (item.type !== 'choice') {
           item.allow_multiple = false;
           item.requires_correct = false;
-        } else if (!item.allow_multiple) {
-          item.requires_correct = true;
+        } else if (item.allow_multiple) {
+          item.requires_correct = false;
         }
         if (['choice', 'likert'].includes(item.type) && item.options.length === 0) {
           item.options = item.type === 'likert'
@@ -869,8 +867,6 @@ const Builder = (() => {
           item.allow_multiple = input.checked;
           if (item.allow_multiple) {
             item.requires_correct = false;
-          } else if (item.requires_correct !== true) {
-            item.requires_correct = true;
           }
           ensureSingleChoiceCorrect(item);
         }
@@ -938,11 +934,11 @@ const Builder = (() => {
         text: '',
         type: 'choice',
         options: [
-          { value: '', is_correct: true },
+          { value: '' },
           { value: '' },
         ],
         weight_percent: 0,
-        requires_correct: true,
+        requires_correct: false,
       })
     );
   }


### PR DESCRIPTION
### Motivation
- Reduce wasted space in the questionnaire builder start tiles and make the create/edit/import cards more compact for denser screens.
- Stop forcing single-choice items to require a correct answer by default so questions can be informational without a correct option (`requires_correct` should be optional).
- Make the landing page use the configured theme colors so the public landing matches the selected application palette instead of a hard-coded palette.

### Description
- Tightened spacing and sizing of the start tiles and related layout rules by updating `assets/css/questionnaire-builder.css` and adjusting `qb-start-grid`, `.qb-start-card`, and related paddings/gaps.
- Changed single-choice defaulting and option handling in `assets/js/questionnaire-builder.js` so `requires_correct` defaults to `false`, new items/options are created without an auto-selected correct option, and the code only enforces correct-option rules when `requires_correct` is explicitly true.
- Updated `assets/css/landing.css` to map landing variables to app theme variables (e.g. `--landing-primary: var(--app-primary, ...)`) and rebuilt the landing background using the theme variables and `color-mix` so the landing page palette follows the configured app colors.

### Testing
- Started a local PHP development server (`php -S 0.0.0.0:8000 -t /workspace/CAS2025`) and executed an automated Playwright script to render the landing page and capture a screenshot (`artifacts/landing-page.png`), which completed successfully.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697289284b7c832d8443f0556d80b952)