### PR TITLE
Preserve questionnaire status when saving/publishing

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -747,9 +747,6 @@ if ($action === 'save' || $action === 'publish') {
             if (!in_array($status, ['draft', 'published', 'inactive'], true)) {
                 $status = 'draft';
             }
-            if ($action === 'publish' && $status !== 'inactive') {
-                $status = 'published';
-            }
 
             if ($qid && isset($questionnaireMap[$qid])) {
                 $updateQuestionnaireStmt->execute([$title, $description, $status, $qid]);

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1225,7 +1225,7 @@ const Builder = (() => {
 
     const payload = {
       csrf: state.csrf,
-      questionnaires: state.questionnaires.map((q) => serializeQuestionnaire(q, publish)),
+      questionnaires: state.questionnaires.map((q) => serializeQuestionnaire(q)),
     };
 
     fetch(withBase(`/admin/questionnaire_manage.php?action=${publish ? 'publish' : 'save'}`), {
@@ -1252,13 +1252,13 @@ const Builder = (() => {
       });
   }
 
-  function serializeQuestionnaire(questionnaire, publish) {
+  function serializeQuestionnaire(questionnaire) {
     const base = {
       id: questionnaire.id || undefined,
       clientId: questionnaire.clientId,
       title: questionnaire.title,
       description: questionnaire.description,
-      status: publish && questionnaire.status !== 'inactive' ? 'published' : questionnaire.status,
+      status: questionnaire.status,
       sections: questionnaire.sections.map((section, idx) => serializeSection(section, idx + 1)),
       items: questionnaire.items.map((item, idx) => serializeItem(item, idx + 1)),
     };


### PR DESCRIPTION
### Motivation
- The builder and server logic were overwriting administrator-chosen questionnaire statuses so items could not be set to `draft` or `inactive` reliably. 
- The intended behavior is to persist whatever status the admin selects (including `draft` and `inactive`) unless explicitly changed.

### Description
- Updated the builder client to serialize and send the questionnaire `status` exactly as selected instead of forcing `published` during a publish/save flow by removing the publish-based override in `assets/js/questionnaire-builder.js`.
- Stopped including the `publish` flag in the serialized questionnaire payload so statuses are not mutated client-side when publishing in `assets/js/questionnaire-builder.js`.
- Removed server-side logic that automatically converted non-`inactive` statuses to `published` during the save/publish handling, allowing `admin/questionnaire_manage.php` to persist the supplied `status` unchanged.
- Changes touch `assets/js/questionnaire-builder.js` and `admin/questionnaire_manage.php` to preserve administrator-selected `draft`/`inactive` values.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69728686204c832da129e3d80e758f27)