### PR TITLE
Simplify questionnaire assignment page

### DIFF
--- a/admin/questionnaire_assignments.php
+++ b/admin/questionnaire_assignments.php
@@ -9,22 +9,6 @@ $cfg = get_site_config($pdo);
 
 $workFunctionChoices = work_function_choices($pdo);
 
-try {
-    $staffStmt = $pdo->query("SELECT id, username, full_name, work_function FROM users WHERE role='staff' AND account_status='active' ORDER BY full_name ASC, username ASC");
-    $staffMembers = $staffStmt ? $staffStmt->fetchAll(PDO::FETCH_ASSOC) : [];
-} catch (PDOException $e) {
-    error_log('questionnaire_assignments staff fetch failed: ' . $e->getMessage());
-    $staffMembers = [];
-}
-
-$staffById = [];
-foreach ($staffMembers as $member) {
-    $staffById[(int)$member['id']] = $member;
-}
-
-$selectedStaffId = (int)($_GET['staff_id'] ?? ($staffMembers[0]['id'] ?? 0));
-$selectedStaffRecord = $staffById[$selectedStaffId] ?? null;
-
 $assignmentsByWorkFunction = [];
 try {
     $assignmentStmt = $pdo->query("SELECT qwf.work_function, q.id, q.title, q.description FROM questionnaire_work_function qwf JOIN questionnaire q ON q.id = qwf.questionnaire_id WHERE q.status='published' ORDER BY qwf.work_function ASC, q.title ASC");
@@ -46,14 +30,6 @@ try {
     $assignmentsByWorkFunction = [];
 }
 
-$selectedAssignments = [];
-$selectedWorkFunction = '';
-if ($selectedStaffRecord) {
-    $selectedWorkFunction = canonical_work_function_key((string)($selectedStaffRecord['work_function'] ?? ''));
-    if ($selectedWorkFunction !== '') {
-        $selectedAssignments = $assignmentsByWorkFunction[$selectedWorkFunction] ?? [];
-    }
-}
 ?>
 <!doctype html>
 <html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
@@ -73,32 +49,6 @@ if ($selectedStaffRecord) {
       border: 1px solid rgba(37, 99, 235, 0.35);
       background: rgba(37, 99, 235, 0.08);
       color: var(--app-text-primary, #1f2937);
-    }
-    .md-assignment-summary {
-      margin: 1.5rem 0;
-      padding: 1rem;
-      border-radius: 8px;
-      border: 1px solid var(--app-border, #d0d5dd);
-      background: var(--app-surface, #ffffff);
-    }
-    .md-assignment-summary h3 {
-      margin-top: 0;
-      margin-bottom: 0.35rem;
-    }
-    .md-assignment-summary ul {
-      margin: 0.5rem 0 0;
-      padding-left: 1.1rem;
-      columns: 2;
-      column-gap: 1.25rem;
-      list-style: disc;
-    }
-    .md-assignment-summary p {
-      margin: 0.35rem 0;
-    }
-    @media (max-width: 720px) {
-      .md-assignment-summary ul {
-        columns: 1;
-      }
     }
     .md-work-function-list {
       margin-top: 2rem;
@@ -131,65 +81,13 @@ if ($selectedStaffRecord) {
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t,'assign_questionnaires','Assign Questionnaires')?></h2>
     <div class="md-assignment-intro">
-      <p><?=t($t,'assignment_work_function_only','Questionnaires are now managed at the work function level. To change which questionnaires are available to staff, update the defaults on the Work Function Defaults page.')?></p>
+      <p><?=t($t,'assignment_work_function_only','Assign questionnaires by work function. Update the defaults to control which questionnaires each team receives.')?></p>
       <p>
-        <?=t($t,'assignment_work_function_override','To override for a single staff member, update their work function in the user profile.')?>
-        <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>"><?=htmlspecialchars(t($t,'manage_users','Manage users'), ENT_QUOTES, 'UTF-8')?></a> ·
         <a href="<?=htmlspecialchars(url_for('admin/work_function_defaults.php'), ENT_QUOTES, 'UTF-8')?>"><?=htmlspecialchars(t($t,'work_function_defaults_title','Work Function Defaults'), ENT_QUOTES, 'UTF-8')?></a>
+        ·
+        <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>"><?=htmlspecialchars(t($t,'manage_users','Manage users'), ENT_QUOTES, 'UTF-8')?></a>
       </p>
     </div>
-    <?php if (!$staffMembers): ?>
-      <p><?=t($t,'no_active_staff','No active staff records available.')?></p>
-    <?php else: ?>
-      <form method="get" class="md-inline-form md-assignment-select" action="<?=htmlspecialchars(url_for('admin/questionnaire_assignments.php'), ENT_QUOTES, 'UTF-8')?>">
-        <label for="staff_id"><?=t($t,'select_staff_member','Select staff member')?>:</label>
-        <select name="staff_id" id="staff_id" onchange="this.form.submit()">
-          <?php foreach ($staffMembers as $staff): ?>
-            <?php
-              $name = trim((string)($staff['full_name'] ?? ''));
-              if ($name === '') {
-                  $name = (string)($staff['username'] ?? '');
-              }
-            ?>
-            <option value="<?=$staff['id']?>" <?=$selectedStaffId === (int)$staff['id'] ? 'selected' : ''?>><?=htmlspecialchars($name, ENT_QUOTES, 'UTF-8')?></option>
-          <?php endforeach; ?>
-        </select>
-      </form>
-      <?php if ($selectedStaffRecord): ?>
-        <?php
-          $displayName = trim((string)($selectedStaffRecord['full_name'] ?? ''));
-          if ($displayName === '') {
-              $displayName = (string)($selectedStaffRecord['username'] ?? '');
-          }
-          $workFunctionKey = $selectedWorkFunction;
-          $workFunctionLabel = $workFunctionKey !== '' ? (work_function_label($pdo, $workFunctionKey) ?: $workFunctionKey) : '';
-        ?>
-        <div class="md-assignment-summary">
-          <h3><?=htmlspecialchars($displayName, ENT_QUOTES, 'UTF-8')?></h3>
-          <?php if ($workFunctionKey === ''): ?>
-            <p><?=t($t,'assignment_missing_work_function','This staff member does not have a work function assigned yet. Assign a work function to provide questionnaires automatically.')?></p>
-          <?php else: ?>
-            <p><strong><?=t($t,'current_work_function','Current work function:')?></strong> <?=htmlspecialchars($workFunctionLabel, ENT_QUOTES, 'UTF-8')?></p>
-            <?php if ($selectedAssignments): ?>
-              <p><?=t($t,'assignment_current_defaults','The following questionnaires are currently provided based on this work function:')?></p>
-              <ul>
-                <?php foreach ($selectedAssignments as $assignment): ?>
-                  <?php
-                    $title = $assignment['title'] !== '' ? $assignment['title'] : t($t,'questionnaire','Questionnaire');
-                    $description = $assignment['description'];
-                  ?>
-                  <li>
-                    <?=htmlspecialchars($title, ENT_QUOTES, 'UTF-8')?><?php if ($description !== ''): ?> — <?=htmlspecialchars($description, ENT_QUOTES, 'UTF-8')?><?php endif; ?>
-                  </li>
-                <?php endforeach; ?>
-              </ul>
-            <?php else: ?>
-              <p><?=t($t,'assignment_no_defaults_for_function','No questionnaires are assigned to this work function yet.')?></p>
-            <?php endif; ?>
-          <?php endif; ?>
-        </div>
-      <?php endif; ?>
-    <?php endif; ?>
 
     <div class="md-work-function-list">
       <h3><?=t($t,'assignment_overview','Work function overview')?></h3>


### PR DESCRIPTION
### Motivation
- The page previously included per-staff selection and per-user summaries which added UI and code complexity unrelated to the core goal of managing questionnaire defaults by work function. 
- The intent is to make it straightforward to assign questionnaires at the work-function level and steer administrators to the work-function defaults UI. 
- Reduce surface area and styling for easier maintenance and clearer UX.

### Description
- Remove per-staff data fetch and selection logic and related variables from `admin/questionnaire_assignments.php`. 
- Remove the per-staff summary block and associated CSS rules, leaving a concise intro and two primary links. 
- Keep and render the work-function overview table driven by `work_function_choices` and `questionnaire_work_function` data, preserving the core mapping of questionnaires to work functions. 
- Update intro copy to focus on managing defaults and reorder links to `admin/work_function_defaults.php` and `admin/users.php` for clarity.

### Testing
- Started a PHP development server using `php -S` and the site served the updated page successfully. 
- Captured a screenshot of the updated page with Playwright which completed and produced `artifacts/questionnaire-assignments.png`. 
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697377edf2c8832dbe6576d874531777)