### PR TITLE
Refine secondary button interactions and centralize auth styling

### DIFF
--- a/admin/login.php
+++ b/admin/login.php
@@ -91,6 +91,7 @@ $languageLabel = htmlspecialchars(t($t, 'language_label', 'Language'), ENT_QUOTE
   <meta name="app-base-url" content="<?= $baseUrl ?>">
   <link rel="stylesheet" href="<?= asset_url('assets/css/material.css') ?>">
   <link rel="stylesheet" href="<?= asset_url('assets/css/styles.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('assets/css/auth.css') ?>">
   <?php if ($brandStyle !== ''): ?>
     <style id="md-brand-style"><?= htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8') ?></style>
   <?php endif; ?>
@@ -102,10 +103,10 @@ $languageLabel = htmlspecialchars(t($t, 'language_label', 'Language'), ENT_QUOTE
         <div class="login-visual__brand">
           <img src="<?= $logo ?>" alt="<?= $logoAlt ?>" class="login-visual__logo">
           <div>
-            <p class="md-login-simple__eyebrow" style="margin: 0; opacity: 0.9;">
+            <p class="login-visual__tagline">
               <?= htmlspecialchars(t($t, 'admin_portal_tagline', 'Secure administrator access'), ENT_QUOTES, 'UTF-8') ?>
             </p>
-            <h1 style="margin: 4px 0 0;">Admin — <?= $siteName ?></h1>
+            <h1 class="login-visual__title">Admin — <?= $siteName ?></h1>
           </div>
         </div>
         <p class="login-visual__intro">
@@ -154,7 +155,7 @@ $languageLabel = htmlspecialchars(t($t, 'language_label', 'Language'), ENT_QUOTE
             </div>
           <?php endif; ?>
 
-          <p class="md-help-note" style="text-align: center; margin-bottom: 0;">
+          <p class="md-help-note login-panel__note">
             <a class="md-login-footer-link" href="<?= htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8') ?>">
               <?= htmlspecialchars(t($t, 'back_to_user_login', 'Back to employee login'), ENT_QUOTES, 'UTF-8') ?>
             </a>

--- a/assets/css/auth.css
+++ b/assets/css/auth.css
@@ -1,0 +1,183 @@
+:root {
+  --auth-panel-border: rgba(15, 35, 74, 0.08);
+  --auth-panel-shadow: 0 12px 32px rgba(16, 40, 86, 0.08);
+  --auth-soft-text: #4f5b66;
+}
+
+.md-login-page .login-shell {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 20px;
+  background: linear-gradient(135deg, #f4f7fb 0%, #eaf0f7 100%);
+}
+
+.md-login-page .login-tile {
+  display: flex;
+  width: min(1120px, 98vw);
+  background: #fff;
+  border-radius: 28px;
+  overflow: hidden;
+  box-shadow: 0 14px 60px rgba(15, 27, 56, 0.16);
+}
+
+.md-login-page .login-visual {
+  flex: 1;
+  padding: 48px;
+  background: linear-gradient(
+    135deg,
+    var(--app-primary, #0d63d9) 0%,
+    color-mix(in srgb, var(--app-primary, #0d63d9) 70%, #2ba7ff 30%) 100%
+  );
+  color: #f7fbff;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  justify-content: center;
+}
+
+.md-login-page .login-visual__brand {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.md-login-page .login-visual__logo {
+  width: 64px;
+  height: 64px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.16);
+  padding: 10px;
+  object-fit: contain;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+}
+
+.md-login-page .login-visual__tagline {
+  margin: 0;
+  opacity: 0.9;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+}
+
+.md-login-page .login-visual__title {
+  margin: 4px 0 0;
+  font-size: clamp(1.7rem, 3vw, 2.4rem);
+}
+
+.md-login-page .login-visual__intro {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.md-login-page .login-visual__highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.md-login-page .login-visual__highlights li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.md-login-page .login-visual__bullet {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  margin-top: 6px;
+}
+
+.md-login-page .login-panel {
+  flex: 1;
+  padding: 48px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  border-left: 1px solid #edf1f5;
+}
+
+.md-login-page .login-panel__card {
+  background: #f8fafc;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.md-login-page .login-panel__header h2 {
+  margin: 0 0 6px;
+}
+
+.md-login-page .login-panel__header p {
+  margin: 0;
+  color: var(--auth-soft-text);
+}
+
+.md-login-page .login-panel__note {
+  text-align: center;
+  margin-bottom: 0;
+}
+
+.md-login-page .login-panel__footer {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  font-size: 0.95rem;
+  color: var(--auth-soft-text);
+}
+
+.md-login-page .login-panel__footer .md-login-footer-label {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: #1d2939;
+}
+
+.md-login-page .md-login-footer-hint {
+  margin: 6px 0 0;
+  color: #5f6b7a;
+}
+
+.md-login-page .md-login-footer-link {
+  color: var(--app-primary, #0d63d9);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.md-login-page .md-login-footer-link:hover,
+.md-login-page .md-login-footer-link:focus-visible {
+  text-decoration: underline;
+}
+
+.md-login-page .md-sso-buttons {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+@media (max-width: 900px) {
+  .md-login-page .login-tile {
+    flex-direction: column;
+  }
+
+  .md-login-page .login-panel {
+    border-left: none;
+    padding: 32px 24px;
+  }
+
+  .md-login-page .login-visual {
+    padding: 32px 24px;
+  }
+}

--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -79,7 +79,7 @@ body.landing-body {
 }
 
 .landing-hero__content {
-  max-width: 640px;
+  max-width: 720px;
   color: #e8edf7;
 }
 
@@ -155,8 +155,14 @@ body.landing-body {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
   margin-top: 2.5rem;
+}
+
+.landing-hero__cta-note {
+  margin: 0;
+  color: #2b3c55;
+  font-size: 0.98rem;
 }
 
 .landing-button {
@@ -225,6 +231,7 @@ body.landing-body {
 
 .landing-summary__stats {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1.25rem;
   margin: 0;
   padding: 0;

--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -283,10 +283,26 @@ body.md-bg {
   background: var(--app-primary-softer);
 }
 
+.md-button:focus-visible {
+  outline: 2px solid var(--md-primary);
+  outline-offset: 2px;
+}
+
 .md-primary {
   background: var(--md-primary);
   color: var(--md-on-primary);
   box-shadow: var(--app-shadow-soft);
+}
+
+.md-secondary {
+  background: var(--app-secondary);
+  color: var(--md-on-primary);
+  box-shadow: 0 12px 30px var(--app-secondary-soft);
+}
+
+.md-button.md-secondary:hover {
+  background: color-mix(in srgb, var(--app-secondary) 85%, #ffffff 15%);
+  box-shadow: 0 12px 30px var(--app-secondary-soft);
 }
 
 .md-danger {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2454,6 +2454,11 @@ body.theme-dark .md-button.md-primary {
   color: var(--app-on-primary);
 }
 
+body.theme-dark .md-button.md-secondary {
+  background: var(--app-secondary);
+  color: var(--app-on-primary);
+}
+
 .md-table {
   width: 100%;
   border-collapse: collapse;

--- a/index.php
+++ b/index.php
@@ -89,27 +89,6 @@ $featureItems = [
   <?php if ($brandStyle !== ''): ?>
     <style id="md-brand-style"><?= htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8') ?></style>
   <?php endif; ?>
-  <style>
-    .landing-hero__content {
-      max-width: 720px;
-    }
-
-    .landing-hero__actions {
-      gap: 0.75rem;
-      flex-wrap: wrap;
-      align-items: center;
-    }
-
-    .landing-hero__cta-note {
-      margin: 0;
-      color: #2b3c55;
-      font-size: 0.98rem;
-    }
-
-    .landing-summary__stats {
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    }
-  </style>
 </head>
 <body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>">
   <div class="landing-page">

--- a/login.php
+++ b/login.php
@@ -145,165 +145,10 @@ render_login:
   <link rel="manifest" href="<?= asset_url('manifest.php') ?>">
   <link rel="stylesheet" href="<?= asset_url('assets/css/material.css') ?>">
   <link rel="stylesheet" href="<?= asset_url('assets/css/styles.css') ?>">
+  <link rel="stylesheet" href="<?= asset_url('assets/css/auth.css') ?>">
   <?php if ($brandStyle !== ''): ?>
     <style id="md-brand-style"><?= htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8') ?></style>
   <?php endif; ?>
-  <style>
-    .login-shell {
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 32px 20px;
-      background: linear-gradient(135deg, #f4f7fb 0%, #eaf0f7 100%);
-    }
-
-    .login-tile {
-      display: flex;
-      width: min(1120px, 98vw);
-      background: #fff;
-      border-radius: 28px;
-      overflow: hidden;
-      box-shadow: 0 14px 60px rgba(15, 27, 56, 0.16);
-    }
-
-    .login-visual {
-      flex: 1;
-      padding: 48px;
-      background: linear-gradient(135deg, #0d63d9 0%, #2ba7ff 100%);
-      color: #f7fbff;
-      display: flex;
-      flex-direction: column;
-      gap: 20px;
-      justify-content: center;
-    }
-
-    .login-visual__brand {
-      display: flex;
-      align-items: center;
-      gap: 14px;
-    }
-
-    .login-visual__logo {
-      width: 64px;
-      height: 64px;
-      border-radius: 16px;
-      background: rgba(255, 255, 255, 0.16);
-      padding: 10px;
-      object-fit: contain;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-    }
-
-    .login-visual__intro {
-      margin: 0;
-      font-size: 1.05rem;
-      line-height: 1.6;
-    }
-
-    .login-visual__highlights {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      gap: 12px;
-    }
-
-    .login-visual__highlights li {
-      display: grid;
-      grid-template-columns: auto 1fr;
-      align-items: start;
-      gap: 10px;
-      font-weight: 600;
-    }
-
-    .login-visual__bullet {
-      width: 12px;
-      height: 12px;
-      border-radius: 50%;
-      background: rgba(255, 255, 255, 0.85);
-      margin-top: 6px;
-    }
-
-    .login-panel {
-      flex: 1;
-      padding: 48px;
-      background: #fff;
-      display: flex;
-      flex-direction: column;
-      gap: 24px;
-      border-left: 1px solid #edf1f5;
-    }
-
-    .login-panel__card {
-      background: #f8fafc;
-      border-radius: 20px;
-      padding: 28px;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-    }
-
-    .login-panel__header h2 {
-      margin: 0 0 6px;
-    }
-
-    .login-panel__header p {
-      margin: 0;
-      color: #4f5b66;
-    }
-
-    .login-panel__footer {
-      display: grid;
-      gap: 12px;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      font-size: 0.95rem;
-      color: #4f5b66;
-    }
-
-    .login-panel__footer .md-login-footer-label {
-      display: block;
-      font-weight: 700;
-      margin-bottom: 4px;
-      color: #1d2939;
-    }
-
-    .md-login-footer-hint {
-      margin: 6px 0 0;
-      color: #5f6b7a;
-    }
-
-    .md-login-footer-link {
-      color: #0d63d9;
-      font-weight: 600;
-      text-decoration: none;
-    }
-
-    .md-login-footer-link:hover {
-      text-decoration: underline;
-    }
-
-    .md-sso-buttons {
-      display: grid;
-      gap: 10px;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    }
-
-    @media (max-width: 900px) {
-      .login-tile {
-        flex-direction: column;
-      }
-
-      .login-panel {
-        border-left: none;
-        padding: 32px 24px;
-      }
-
-      .login-visual {
-        padding: 32px 24px;
-      }
-    }
-  </style>
 </head>
 <body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>">
   <div class="login-shell">
@@ -312,8 +157,8 @@ render_login:
         <div class="login-visual__brand">
           <img src="<?= $logo ?>" alt="<?= $logoAlt ?>" class="login-visual__logo">
           <div>
-            <p class="md-login-simple__eyebrow" style="margin: 0; opacity: 0.9;"><?= htmlspecialchars(t($t, 'login_tagline', 'Secure staff performance portal'), ENT_QUOTES, 'UTF-8') ?></p>
-            <h1 style="margin: 4px 0 0;"><?= $siteName ?></h1>
+            <p class="login-visual__tagline"><?= htmlspecialchars(t($t, 'login_tagline', 'Secure staff performance portal'), ENT_QUOTES, 'UTF-8') ?></p>
+            <h1 class="login-visual__title"><?= $siteName ?></h1>
           </div>
         </div>
         <?php if ($introText !== ''): ?>
@@ -386,7 +231,7 @@ render_login:
             </div>
           <?php endif; ?>
 
-          <p class="md-help-note" style="text-align: center; margin-bottom: 0;">
+          <p class="md-help-note login-panel__note">
             <?= htmlspecialchars(t($t, 'admin_login_hint', 'Administrators can sign in using the dedicated admin login page.'), ENT_QUOTES, 'UTF-8') ?>
             <a class="md-login-footer-link" href="<?= htmlspecialchars(url_for('admin/login.php'), ENT_QUOTES, 'UTF-8') ?>">
               <?= htmlspecialchars(t($t, 'admin_login_link', 'Go to admin login'), ENT_QUOTES, 'UTF-8') ?>


### PR DESCRIPTION
### Motivation
- Normalize secondary button interactions and improve keyboard accessibility with a visible focus state for buttons.
- Centralize login/admin presentation to remove inline styles and make auth pages easier to maintain.
- Tidy the landing hero layout so CTA spacing and stats layout are consistent with the design system.

### Description
- Added keyboard focus styling and hover refinements for the shared button component by updating `assets/css/material.css` to include `:focus-visible` rules, `.md-secondary` hover handling, and consistent elevation behavior.
- Added a dark-theme secondary button rule in `assets/css/styles.css` to ensure secondary buttons render correctly in `theme-dark` contexts.
- Introduced a new shared auth stylesheet `assets/css/auth.css` and linked it from both `login.php` and `admin/login.php` to replace inline styles and unify classes such as `login-visual__tagline`, `login-visual__title`, and `login-panel__note`.
- Consolidated landing page inline rules into `assets/css/landing.css` (increased hero width, adjusted action gap, added `.landing-hero__cta-note`, and made stats grid responsive) and removed the embedded style block from `index.php`.

### Testing
- Started the PHP development server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025`, which started successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/login.php` and produced a screenshot at `artifacts/login-buttons.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697394211e40832d879fb19ea899c135)