### PR TITLE
Keep questionnaire builder selection after save and refresh import docs

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1150,6 +1150,7 @@ if (isset($_POST['import'])) {
                                 case 'choice':
                                     return 'choice';
                                 case 'text':
+                                    return 'text';
                                 case 'textarea':
                                     return 'textarea';
                                 default:

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -74,7 +74,7 @@
   flex-direction: column;
   gap: 0.35rem;
   height: 100%;
-  justify-content: space-between;
+  justify-content: flex-start;
   padding: 0.75rem 0.9rem;
 }
 

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -358,7 +358,9 @@ const Builder = (() => {
     if (!key) return;
     state.activeKey = key;
     state.navActiveKey = 'root';
-    rememberSet(STORAGE_KEYS.active, key);
+    const selected = state.questionnaires.find((q) => q.clientId === key);
+    const rememberKey = selected?.id ? String(selected.id) : key;
+    rememberSet(STORAGE_KEYS.active, rememberKey);
     render();
   }
 
@@ -1239,6 +1241,18 @@ const Builder = (() => {
         state.csrf = data.csrf || state.csrf;
         state.dirty = false;
         renderMessage(data.message || 'Changes saved', 'success');
+        const questionnaireMap = data?.idMap?.questionnaires || {};
+        state.questionnaires.forEach((q) => {
+          if (!q.id && questionnaireMap[q.clientId]) {
+            q.id = questionnaireMap[q.clientId];
+          }
+        });
+        const active = state.questionnaires.find((q) => q.clientId === state.activeKey);
+        const activeId = active?.id || (active?.clientId ? questionnaireMap[active.clientId] : null);
+        if (activeId) {
+          initialActiveId = activeId;
+          rememberSet(STORAGE_KEYS.active, String(activeId));
+        }
         fetchData({ silent: true });
       })
       .catch((err) => renderMessage(err.message || 'Save failed', 'error'))

--- a/docs/questionnaire-import-guide.md
+++ b/docs/questionnaire-import-guide.md
@@ -1,6 +1,6 @@
 # Questionnaire Import Guide
 
-This guide explains how administrators can import questionnaires using the EPSS HR Assessment builder. The importer accepts FHIR Questionnaire resources in XML (recommended) or JSON.
+This guide explains how administrators can import questionnaires using the EPSS HR Assessment builder. The importer accepts FHIR Questionnaire resources in XML (recommended) or JSON, including single Questionnaire resources or Bundles containing Questionnaire entries.
 
 ## Prerequisites
 
@@ -10,17 +10,17 @@ This guide explains how administrators can import questionnaires using the EPSS 
 
 ## Preparing Your XML or JSON File
 
-1. Use the template as a starting point and update the `<title>` and `<description>` values.
-2. Add section-level `<item>` blocks with `type="group"`; set `<text>` for the section title and `<description>` for optional helper text.
+1. Use the template as a starting point and update the `<title>` and `<description>` values (status is imported as a draft regardless of the XML value).
+2. Add question `<item>` entries directly under the root to create items without a section, or add section-level `<item>` blocks with `type="group"`; set `<text>` for the section title and `<description>` for optional helper text.
 3. Within each section, create question `<item>` entries with:
    - A unique `<linkId>` for stable identification.
    - `<text>` containing the question prompt.
-   - `<type>` set to `likert`, `choice`, `text`, `textarea`, or `boolean` (other FHIR types import as free-text).
+   - `<type>` set to `likert`, `choice`, `text`, `textarea`, or `boolean` (other FHIR types import as free-text). `text` creates a short free-text input, while `textarea` creates a longer response field.
    - `<required value="true">` when a response is mandatory.
    - `<repeats value="true">` to allow multiple selections for `choice` items.
    - `<answerOption>` values for `likert` or `choice` items, using either `<valueString>` or `<valueCoding>` with `display` or `code`.
 4. Use `<type value="display">` for headings or instructional text you do not want stored; these entries are skipped during import.
-5. Validate that the XML or JSON is well-formed before uploading.
+5. Validate that the XML or JSON is well-formed before uploading. Work functions are applied to all available cadres by default and can be refined after import in the builder.
 
 ## Using the Excel Planning Template
 

--- a/docs/questionnaire-template.xml
+++ b/docs/questionnaire-template.xml
@@ -5,6 +5,12 @@
   <description value="Starter template for importing a questionnaire into the EPSS HR Assessment builder."/>
   <status value="draft"/>
   <item>
+    <linkId value="overall-role"/>
+    <text value="Overall role title"/>
+    <type value="text"/>
+    <required value="true"/>
+  </item>
+  <item>
     <linkId value="section-1"/>
     <text value="Team Delivery"/>
     <description value="Questions about how work is planned, executed, and shared with teammates."/>


### PR DESCRIPTION
### Motivation
- Preserve the builder context so the active questionnaire remains selected after a save or publish that triggers a refresh. 
- Reduce excessive whitespace in the three start tiles (Create, Edit, Import) to make the cards more compact. 
- Update the import template and guide to reflect current importer behavior and clarify `text` vs `textarea` handling.

### Description
- Update `assets/js/questionnaire-builder.js` to persist server-assigned `id` values returned in `idMap` after save/publish and to remember the persisted questionnaire ID so the builder stays on the same questionnaire after refresh. 
- Adjust `assets/css/questionnaire-builder.css` to use `justify-content: flex-start` for `.qb-start-card` to reduce vertical gaps in the start cards. 
- Add missing `mapType` branch for `text` in `admin/questionnaire_manage.php` to ensure `text` imports correctly. 
- Refresh the import template `docs/questionnaire-template.xml` with an example `text` item and update `docs/questionnaire-import-guide.md` to document Bundle support, that imported status is always treated as draft, root-level items (no section), `text` vs `textarea` semantics, and that work functions are applied to all cadres by default.

### Testing
- Started a local PHP dev server (`php -S ...`) and ran a headless Playwright script to render the Manage Questionnaires page and capture a screenshot, which completed successfully. 
- Verified files changed were staged and committed successfully. 
- No automated unit tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974efea6da0832dab6e56c963afd0f7)