### PR TITLE
Tighten questionnaire start card layout

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -66,14 +66,13 @@
   gap: 0.55rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   margin-bottom: 0.6rem;
-  align-items: stretch;
+  align-items: start;
 }
 
 .qb-start-card {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  height: 100%;
   justify-content: flex-start;
   padding: 0.75rem 0.9rem;
 }


### PR DESCRIPTION
### Motivation
- Reduce wasted vertical space in the questionnaire start tiles by preventing the grid from stretching cards to the height of the tallest tile.

### Description
- Update `assets/css/questionnaire-builder.css` to change `.qb-start-grid` from `align-items: stretch` to `align-items: start` and remove the forced `height: 100%` from `.qb-start-card` so cards size to their content.

### Testing
- Launched a local PHP dev server and captured a layout screenshot with Playwright (`artifacts/qb-start-cards.png`), which completed successfully; no unit tests were required for this layout-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751dbfe678832d8b2591de98a1fd4d)