### PR TITLE
Preserve inactive questionnaires when publishing

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -747,6 +747,9 @@ if ($action === 'save' || $action === 'publish') {
             if (!in_array($status, ['draft', 'published', 'inactive'], true)) {
                 $status = 'draft';
             }
+            if ($action === 'publish' && $status === 'draft') {
+                $status = 'published';
+            }
 
             if ($qid && isset($questionnaireMap[$qid])) {
                 $updateQuestionnaireStmt->execute([$title, $description, $status, $qid]);


### PR DESCRIPTION
### Motivation
- Prevent the publish flow from overwriting questionnaires explicitly marked `inactive` while still treating publish requests as an upgrade for drafts.

### Description
- Added a check in `admin/questionnaire_manage.php` so that when the request `action` is `publish` only questionnaires with status `draft` are promoted to `published`, leaving `inactive` entries unchanged.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697521835380832dba7c1c0b93378f57)