### PR TITLE
Move appearance settings to Branding, fix brand style injection, and compact Administration menu

### DIFF
--- a/admin/branding.php
+++ b/admin/branding.php
@@ -9,6 +9,10 @@ $t = load_lang($locale);
 $cfg = get_site_config($pdo);
 $msg = '';
 $errors = [];
+$themes = [
+    'light' => t($t, 'theme_light', 'Light'),
+    'dark' => t($t, 'theme_dark', 'Dark'),
+];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     csrf_check();
@@ -25,6 +29,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $footer_hotline_label = trim($_POST['footer_hotline_label'] ?? '');
     $footer_hotline_number = trim($_POST['footer_hotline_number'] ?? '');
     $footer_rights = trim($_POST['footer_rights'] ?? '');
+    $color_theme = strtolower(trim($_POST['color_theme'] ?? 'light'));
+    if (!array_key_exists($color_theme, $themes)) {
+        $color_theme = 'light';
+    }
+    $brand_color_reset = $_POST['brand_color_reset'] ?? '0';
+    $brand_color_input = normalize_hex_color((string)($_POST['brand_color'] ?? ''));
+    $brand_color = '';
+    if ($brand_color_reset === '1') {
+        $brand_color = '';
+    } elseif ($brand_color_input !== null) {
+        $brand_color = $brand_color_input;
+    }
     if ($footer_website_url && !preg_match('#^https?://#i', $footer_website_url)) {
         $footer_website_url = 'https://' . ltrim($footer_website_url, '/');
     }
@@ -137,6 +153,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         'footer_hotline_label' => $footer_hotline_label,
         'footer_hotline_number' => $footer_hotline_number,
         'footer_rights' => $footer_rights,
+        'color_theme' => $color_theme,
+        'brand_color' => $brand_color !== '' ? $brand_color : null,
     ];
 
     $assignments = [];
@@ -201,6 +219,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <label class="md-field"><span><?=t($t,'landing_text','Landing Text')?></span><textarea name="landing_text" rows="3"><?=htmlspecialchars($cfg['landing_text'] ?? '')?></textarea></label>
       <label class="md-field"><span><?=t($t,'address_label','Address')?></span><input name="address" value="<?=htmlspecialchars($cfg['address'] ?? '')?>"></label>
       <label class="md-field"><span><?=t($t,'contact_label','Contact')?></span><input name="contact" value="<?=htmlspecialchars($cfg['contact'] ?? '')?>"></label>
+      <h3 class="md-subhead"><?=t($t,'appearance_settings','Appearance')?></h3>
+      <label class="md-field">
+        <span><?=t($t,'color_theme','Color Theme')?></span>
+        <select name="color_theme">
+          <?php foreach ($themes as $themeValue => $themeLabel): ?>
+            <option value="<?=htmlspecialchars($themeValue, ENT_QUOTES, 'UTF-8')?>" <?=site_color_theme($cfg) === $themeValue ? 'selected' : ''?>><?=htmlspecialchars($themeLabel, ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-field md-field-inline">
+        <span>
+          <?=t($t,'brand_color','Brand Color')?>
+          <?=render_help_icon(t($t,'brand_color_hint','Pick any brand color to personalize buttons, highlights, and gradients.'))?>
+        </span>
+        <div class="md-color-picker" data-brand-color-picker data-default-color="<?=htmlspecialchars(site_default_brand_color($cfg), ENT_QUOTES, 'UTF-8')?>">
+          <input type="color" name="brand_color" value="<?=htmlspecialchars(site_brand_color($cfg), ENT_QUOTES, 'UTF-8')?>" aria-label="<?=t($t,'brand_color_picker','Choose a brand color')?>">
+          <span class="md-color-value"><?=htmlspecialchars(strtoupper(site_brand_color($cfg)), ENT_QUOTES, 'UTF-8')?></span>
+          <button type="button" class="md-button md-outline md-compact" data-brand-color-reset><?=t($t,'brand_color_reset','Use default brand color')?></button>
+          <input type="hidden" name="brand_color_reset" value="0" data-brand-color-reset-field>
+        </div>
+      </label>
       <h3 class="md-subhead"><?=t($t,'footer_settings','Footer Details')?></h3>
       <label class="md-field"><span><?=t($t,'footer_org_name_label','Organization Name')?></span><input name="footer_org_name" value="<?=htmlspecialchars($cfg['footer_org_name'] ?? '')?>"></label>
       <label class="md-field"><span><?=t($t,'footer_org_short_label','Organization Short Name')?></span><input name="footer_org_short" value="<?=htmlspecialchars($cfg['footer_org_short'] ?? '')?>"></label>

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -15,11 +15,6 @@ try {
     }
     $previousReviewEnabled = (int)($cfg['review_enabled'] ?? 1) === 1;
 
-    $themes = [
-        'light' => t($t, 'theme_light', 'Light'),
-        'dark' => t($t, 'theme_dark', 'Dark'),
-    ];
-
     $msg = '';
     $errors = [];
     $enabledLocales = site_enabled_locales($cfg);
@@ -72,20 +67,6 @@ try {
             $smtp_timeout = 20;
         }
 
-        $color_theme = strtolower(trim($_POST['color_theme'] ?? 'light'));
-        if (!array_key_exists($color_theme, $themes)) {
-            $color_theme = 'light';
-        }
-
-        $brand_color_reset = $_POST['brand_color_reset'] ?? '0';
-        $brand_color_input = normalize_hex_color((string)($_POST['brand_color'] ?? ''));
-        $brand_color = '';
-        if ($brand_color_reset === '1') {
-            $brand_color = '';
-        } elseif ($brand_color_input !== null) {
-            $brand_color = $brand_color_input;
-        }
-
         $enabledLocalesInput = $_POST['enabled_locales'] ?? [];
         if (!is_array($enabledLocalesInput)) {
             $enabledLocalesInput = [];
@@ -122,8 +103,6 @@ try {
             'microsoft_oauth_client_id' => $microsoft_oauth_client_id,
             'microsoft_oauth_client_secret' => $microsoft_oauth_client_secret,
             'microsoft_oauth_tenant' => $microsoft_oauth_tenant,
-            'color_theme' => $color_theme,
-            'brand_color' => $brand_color !== '' ? $brand_color : null,
             'local_login_enabled' => $local_login_enabled,
             'smtp_enabled' => $smtp_enabled,
             'smtp_host' => $smtp_host !== '' ? $smtp_host : null,
@@ -213,12 +192,6 @@ try {
     if (!isset($cfg) || !is_array($cfg)) {
         $cfg = site_config_defaults();
     }
-    if (!isset($themes) || !is_array($themes)) {
-        $themes = [
-            'light' => t($t, 'theme_light', 'Light'),
-            'dark' => t($t, 'theme_dark', 'Dark'),
-        ];
-    }
     if (!isset($enabledLocales) || !is_array($enabledLocales)) {
         $enabledLocales = site_enabled_locales($cfg);
     }
@@ -267,27 +240,6 @@ $pageHelpKey = 'admin.settings';
     <?php endif; ?>
     <form method="post" action="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>">
       <input type="hidden" name="csrf" value="<?=htmlspecialchars(csrf_token(), ENT_QUOTES, 'UTF-8')?>">
-      <h3 class="md-subhead"><?=t($t,'appearance_settings','Appearance')?></h3>
-      <label class="md-field">
-        <span><?=t($t,'color_theme','Color Theme')?></span>
-        <select name="color_theme">
-          <?php foreach ($themes as $themeValue => $themeLabel): ?>
-            <option value="<?=htmlspecialchars($themeValue, ENT_QUOTES, 'UTF-8')?>" <?=site_color_theme($cfg) === $themeValue ? 'selected' : ''?>><?=htmlspecialchars($themeLabel, ENT_QUOTES, 'UTF-8')?></option>
-          <?php endforeach; ?>
-        </select>
-      </label>
-      <label class="md-field md-field-inline">
-        <span>
-          <?=t($t,'brand_color','Brand Color')?>
-          <?=render_help_icon(t($t,'brand_color_hint','Pick any brand color to personalize buttons, highlights, and gradients.'))?>
-        </span>
-        <div class="md-color-picker" data-brand-color-picker data-default-color="<?=htmlspecialchars(site_default_brand_color($cfg), ENT_QUOTES, 'UTF-8')?>">
-          <input type="color" name="brand_color" value="<?=htmlspecialchars(site_brand_color($cfg), ENT_QUOTES, 'UTF-8')?>" aria-label="<?=t($t,'brand_color_picker','Choose a brand color')?>">
-          <span class="md-color-value"><?=htmlspecialchars(strtoupper(site_brand_color($cfg)), ENT_QUOTES, 'UTF-8')?></span>
-          <button type="button" class="md-button md-outline md-compact" data-brand-color-reset><?=t($t,'brand_color_reset','Use default brand color')?></button>
-          <input type="hidden" name="brand_color_reset" value="0" data-brand-color-reset-field>
-        </div>
-      </label>
       <h3 class="md-subhead">
         <?=t($t,'language_settings','Languages')?>
         <?=render_help_icon(t($t,'language_settings_hint','Choose which interface languages are available to users.'))?>

--- a/templates/header.php
+++ b/templates/header.php
@@ -64,7 +64,7 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
 };
 ?>
 <?php if ($brandStyle !== ''): ?>
-<style id="md-brand-style">:root { <?=htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8')?>; }</style>
+<style id="md-brand-style"><?=htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8')?></style>
 <?php endif; ?>
 <script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
   window.APP_DEFAULT_LOCALE = <?=json_encode($defaultLocale, JSON_THROW_ON_ERROR)?>;
@@ -410,7 +410,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
         <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
           <span class="md-topnav-label">
             <span class="md-topnav-title"><?=t($t, 'admin_navigation', 'Administration')?></span>
-            <span class="md-topnav-desc"><?=t($t, 'admin_navigation_summary', 'Configure the system and manage advanced tools.')?></span>
           </span>
           <span class="md-topnav-chevron" aria-hidden="true"></span>
         </button>
@@ -419,7 +418,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/dashboard.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.dashboard')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'admin_dashboard', 'System Information')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'admin_dashboard_summary', 'Check system health, updates, and alerts.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -428,7 +426,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.users')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'manage_users', 'Manage Users')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'manage_users_summary', 'Create, update, or deactivate user accounts.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -437,7 +434,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.manage_questionnaires')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'manage_questionnaires', 'Manage Questionnaires')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'manage_questionnaires_summary', 'Build and organize available questionnaires.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -446,7 +442,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/work_function_defaults.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.work_function_defaults')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'work_function_defaults_title', 'Work Function Defaults')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'work_function_defaults_summary', 'Choose default forms for each work function.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -455,7 +450,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/export.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.export')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'export_data', 'Export Data')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'export_data_summary', 'Download responses for record keeping or analysis.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -464,7 +458,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/branding.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.branding')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'branding', 'Branding & Landing')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'branding_summary', 'Update colors, logos, and landing content.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -473,7 +466,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('admin/settings.php'), ENT_QUOTES, 'UTF-8')?>" <?=$topNavLinkAttributes('admin.settings')?>>
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t, 'settings', 'Settings')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'settings_summary', 'Adjust global preferences and integrations.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
             </a>
@@ -482,7 +474,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <a href="<?=htmlspecialchars(url_for('swagger.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link md-topnav-link--external" target="_blank" rel="noopener">
               <span class="md-topnav-link-content">
                 <span class="md-topnav-link-title"><?=t($t,'api_documentation','API Documentation')?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'api_documentation_summary', 'Open the developer reference in a new tab.')?></span>
               </span>
               <span class="md-topnav-link-icon" aria-hidden="true">↗</span>
             </a>


### PR DESCRIPTION
### Motivation

- Consolidate appearance controls so changing the brand color/theme updates the full UI from a single place and keep branding-related items together. 
- Ensure the computed CSS variables output by `site_brand_style()` are injected correctly so all header-included pages pick up the theme. 
- Reduce horizontal space used by the Administration menu so more items remain visible on small screens.

### Description

- Moved `brand_color` and `color_theme` form inputs and processing out of `admin/settings.php` and into `admin/branding.php`, including persisting the values from the Branding page (`admin/branding.php`).
- Removed appearance handling and the color picker UI from `admin/settings.php` so branding is edited under `admin/branding.php` only. 
- Fixed the brand style injection in `templates/header.php` by rendering the `site_brand_style($cfg)` string directly in the `<style id="md-brand-style">` tag (removed the extra `:root { ... }` wrapper), so theme CSS variables apply across header-included pages. 
- Removed descriptive subtitle elements (`md-topnav-desc` / `md-topnav-link-desc`) from the Administration topnav submenu items in `templates/header.php` to save space on smaller screens.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776f711ccc832d8290954b0933e83d)