### PR TITLE
Guard work function helpers against double load

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -1,10 +1,9 @@
 <?php
 declare(strict_types=1);
 
-if (defined('WORK_FUNCTIONS_LOADED')) {
+if (function_exists('available_work_functions')) {
     return;
 }
-define('WORK_FUNCTIONS_LOADED', true);
 
 /**
  * Retrieve the built-in (code-level) work function definition list.


### PR DESCRIPTION
### Motivation
- Prevent `available_work_functions()` from being undefined and avoid duplicate function declarations when `lib/work_functions.php` is included multiple times by replacing the stale constant guard with a safer runtime check.

### Description
- Replace the `WORK_FUNCTIONS_LOADED` constant guard with `if (function_exists('available_work_functions')) { return; }` so the file only returns early when the functions are already defined.

### Testing
- Ran `php -l lib/work_functions.php` which reported `No syntax errors detected` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979135c3d0c832d8bf3b345a35ea884)