### PR TITLE
Guard work function helpers in admin pages

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1,5 +1,8 @@
 <?php
 require_once __DIR__ . '/../config.php';
+if (!function_exists('available_work_functions')) {
+    require_once __DIR__ . '/../lib/work_functions.php';
+}
 require_once __DIR__ . '/../lib/analytics_report.php';
 require_once __DIR__ . '/../lib/scoring.php';
 

--- a/admin/questionnaire_assignments.php
+++ b/admin/questionnaire_assignments.php
@@ -1,5 +1,8 @@
 <?php
 require_once __DIR__ . '/../config.php';
+if (!function_exists('available_work_functions')) {
+    require_once __DIR__ . '/../lib/work_functions.php';
+}
 auth_required(['admin','supervisor']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);

--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1,5 +1,8 @@
 <?php
 require_once __DIR__.'/../config.php';
+if (!function_exists('available_work_functions')) {
+    require_once __DIR__ . '/../lib/work_functions.php';
+}
 auth_required(['admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,5 +1,8 @@
 <?php
 require_once __DIR__ . '/../config.php';
+if (!function_exists('available_work_functions')) {
+    require_once __DIR__ . '/../lib/work_functions.php';
+}
 auth_required(['admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);

--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -1,5 +1,8 @@
 <?php
 require_once __DIR__ . '/../config.php';
+if (!function_exists('available_work_functions')) {
+    require_once __DIR__ . '/../lib/work_functions.php';
+}
 
 auth_required(['admin']);
 refresh_current_user($pdo);


### PR DESCRIPTION
### Motivation
- Prevent a PHP fatal error when `work_function_defaults.php` (and other admin pages) call `available_work_functions()` while the helper file is not yet loaded.

### Description
- Add a defensive guard that conditionally includes `lib/work_functions.php` when `available_work_functions()` is undefined in `admin/work_function_defaults.php`, `admin/questionnaire_manage.php`, `admin/questionnaire_assignments.php`, `admin/users.php`, and `admin/analytics.php`.

### Testing
- Automated tests were not run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a3ca0243c832da1be5baa6401eadb)