### PR TITLE
Remove 'Help & tips' item from top navigation

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -540,15 +540,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <span class="md-topnav-link-icon" aria-hidden="true">↻</span>
           </button>
         </li>
-        <li>
-          <button type="button" class="md-topnav-link" data-help-toggle aria-haspopup="dialog" aria-expanded="false">
-            <span class="md-topnav-link-content">
-              <span class="md-topnav-link-title"><?=htmlspecialchars(t($t, 'system_help', 'Help & tips'), ENT_QUOTES, 'UTF-8')?></span>
-              <span class="md-topnav-link-desc"><?=t($t, 'system_help_summary', 'Review guidance and tips for this page.')?></span>
-            </span>
-            <span class="md-topnav-link-icon" aria-hidden="true">?</span>
-          </button>
-        </li>
         <?php foreach ($availableLocales as $loc): ?>
           <li>
             <a href="<?=htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link<?=($locale === $loc) ? ' active' : ''?>">


### PR DESCRIPTION
### Motivation
- Remove the Help & tips entry from the Account & Tools top navigation to hide the help trigger from the UI.

### Description
- Removed the `li` element that rendered the Help & tips toggle from `templates/header.php`, keeping the underlying help overlay markup intact.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a529e9814832dbb9a14c088af7696)