### PR TITLE
Fix work function defaults payload fallback

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -366,21 +366,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         csrf_check();
         $input = $_POST['assignments'] ?? [];
         $payloadJson = $_POST['assignments_payload'] ?? '';
+        $payloadInvalid = false;
         if (is_string($payloadJson) && $payloadJson !== '') {
             $decoded = json_decode($payloadJson, true);
             if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
                 $input = $decoded;
             } else {
-                $errors[] = t(
-                    $t,
-                    'work_function_defaults_invalid_payload',
-                    'The work function selections could not be processed. Please try again.'
-                );
-                $input = [];
+                $payloadInvalid = true;
             }
         }
         if (!is_array($input)) {
             $input = [];
+        }
+        if ($payloadInvalid && $input === []) {
+            $errors[] = t(
+                $t,
+                'work_function_defaults_invalid_payload',
+                'The work function selections could not be processed. Please try again.'
+            );
         }
         $validWorkFunctions = array_flip($workFunctionKeys);
         $validQuestionnaires = array_flip(array_keys($questionnaireMap));


### PR DESCRIPTION
### Motivation
- Prevent an invalid JSON `assignments_payload` from blocking saving when regular form `assignments` data is available.
- Provide a clearer error condition that only surfaces when both the JSON payload is invalid and there is no usable form data.

### Description
- Update `admin/work_function_defaults.php` to parse `assignments_payload` into `$input` but record invalid JSON with a boolean `payloadInvalid` flag instead of immediately adding an error and clearing form data.
- Preserve normal form `assignments` when JSON parsing fails, and only append the `work_function_defaults_invalid_payload` error when `payloadInvalid` is `true` and `$input` is empty.
- Keep existing normalization and validation of work function and questionnaire IDs unchanged.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d633f2108832da5323d38449e0b20)