### PR TITLE
Restore work_function_choices helper

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -412,7 +412,6 @@ function canonical(string $value, ?array $definitions = null): string
 /**
  * @return array<string,string>
  */
-/*
 if (!function_exists('work_function_choices')) {
     function work_function_choices(PDO $pdo, bool $forceRefresh = false): array
     {
@@ -453,7 +452,6 @@ if (!function_exists('work_function_choices')) {
         return $choices;
     }
 }
-*/
 
 /**
  * @return array<string,list<int>>


### PR DESCRIPTION
### Motivation
- Staff-facing pages (e.g. `profile.php`) call `work_function_choices($pdo)` but the helper was commented out in `lib/work_functions.php`, causing an undefined function error and preventing staff pages from loading.

### Description
- Re-enabled the `work_function_choices(PDO $pdo, bool $forceRefresh = false): array` helper by restoring its implementation in `lib/work_functions.php` so profile and related pages can enumerate work functions again.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d6e556330832dbfbe3b613a343ad6)