### PR TITLE
Align landing page with login theme and simplify hero layout

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -1,7 +1,7 @@
 :root {
-  --landing-primary: var(--app-primary, #20407f);
-  --landing-primary-dark: var(--app-primary-dark, #14294e);
-  --landing-primary-darker: var(--app-primary-darker, #0c1a31);
+  --landing-primary: var(--app-primary, #0d63d9);
+  --landing-primary-dark: var(--app-primary-dark, #0c4fb0);
+  --landing-primary-darker: var(--app-primary-darker, #083575);
   --landing-accent: var(--app-secondary, #ff8a3d);
   --landing-surface: var(--app-surface, #ffffff);
   --landing-surface-muted: var(--app-surface-muted, #f3f6fb);
@@ -9,10 +9,9 @@
   --landing-background: var(
     --app-hero-gradient,
     linear-gradient(
-      120deg,
-      var(--landing-primary-darker) 0%,
-      var(--landing-primary-dark) 48%,
-      var(--landing-primary) 100%
+      135deg,
+      var(--landing-primary) 0%,
+      color-mix(in srgb, var(--landing-primary) 70%, #2ba7ff 30%) 100%
     )
   );
   --landing-radius-lg: 28px;
@@ -42,10 +41,9 @@ body.landing-body {
 
 .landing-hero {
   position: relative;
-  display: grid;
-  grid-template-columns: minmax(280px, 520px) minmax(280px, 1fr);
-  gap: clamp(2.5rem, 5vw, 4.5rem);
-  padding: clamp(3.25rem, 7vw, 6.25rem) clamp(1.75rem, 6vw, 4.5rem);
+  display: flex;
+  justify-content: center;
+  padding: clamp(3.5rem, 7vw, 6.5rem) clamp(1.75rem, 6vw, 4.5rem);
   background: var(--landing-background);
   overflow: hidden;
   align-items: center;
@@ -92,7 +90,7 @@ body.landing-body {
 }
 
 .landing-hero__content {
-  max-width: 720px;
+  max-width: 780px;
   color: #e8edf7;
 }
 
@@ -164,6 +162,28 @@ body.landing-body {
   color: rgba(226, 233, 245, 0.92);
 }
 
+.landing-hero__summary {
+  margin: 1.75rem 0 0;
+  padding: 1.5rem 1.75rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 12px 26px rgba(5, 20, 46, 0.18);
+  backdrop-filter: blur(12px);
+}
+
+.landing-hero__summary h2 {
+  margin: 0 0 0.65rem;
+  font-size: 1.25rem;
+  color: #ffffff;
+}
+
+.landing-hero__summary p {
+  margin: 0;
+  color: rgba(230, 238, 249, 0.9);
+  line-height: 1.6;
+}
+
 .landing-hero__actions {
   display: flex;
   flex-wrap: wrap;
@@ -174,7 +194,7 @@ body.landing-body {
 
 .landing-hero__cta-note {
   margin: 0;
-  color: #2b3c55;
+  color: rgba(235, 242, 252, 0.85);
   font-size: 0.98rem;
 }
 
@@ -211,63 +231,6 @@ body.landing-body {
 .landing-button--ghost:hover,
 .landing-button--ghost:focus-visible {
   background: rgba(255, 255, 255, 0.12);
-}
-
-.landing-hero__summary {
-  display: flex;
-  justify-content: center;
-}
-
-.landing-summary__card {
-  align-self: stretch;
-  background: var(--landing-surface);
-  border-radius: var(--landing-radius-lg);
-  box-shadow: var(--landing-shadow-lg);
-  padding: 2.5rem;
-  color: var(--app-text-primary, #0f1c31);
-  max-width: 440px;
-  border: 1px solid var(--app-primary-softer, rgba(16, 36, 78, 0.08));
-}
-
-.landing-summary__card h2 {
-  margin: 0 0 1rem;
-  font-size: 1.5rem;
-  line-height: 1.35;
-  color: var(--landing-primary-dark);
-}
-
-.landing-summary__card p {
-  margin: 0 0 1.75rem;
-  color: var(--app-text-secondary, #4b5a6b);
-  line-height: 1.6;
-}
-
-.landing-summary__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 1.25rem;
-  margin: 0;
-  padding: 0;
-}
-
-.landing-summary__stats div {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.landing-summary__stats dt {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--app-text-muted, #516078);
-}
-
-.landing-summary__stats dd {
-  margin: 0;
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--app-text-primary, #0f1c31);
 }
 
 .landing-main {
@@ -432,7 +395,6 @@ body.landing-body {
 
 @media (max-width: 720px) {
   .landing-hero {
-    grid-template-columns: 1fr;
     text-align: center;
   }
 
@@ -442,11 +404,6 @@ body.landing-body {
 
   .landing-hero__actions {
     justify-content: center;
-  }
-
-  .landing-hero__summary {
-    justify-content: center;
-    margin-top: 2.5rem;
   }
 
   .landing-footer {

--- a/index.php
+++ b/index.php
@@ -97,6 +97,10 @@ $featureItems = [
         </div>
         <h1 id="landing-title" class="landing-hero__title"><?= htmlspecialchars(t($t, 'landing_title', 'Performance that powers people'), ENT_QUOTES, 'UTF-8') ?></h1>
         <p class="landing-hero__subtitle"><?= $heroSubtitle ?></p>
+        <div class="landing-hero__summary" aria-label="<?= htmlspecialchars(t($t, 'landing_summary_title', 'Built for confident, modern HR teams'), ENT_QUOTES, 'UTF-8') ?>">
+          <h2><?= htmlspecialchars(t($t, 'landing_summary_title', 'Built for confident, modern HR teams'), ENT_QUOTES, 'UTF-8') ?></h2>
+          <p><?= htmlspecialchars(t($t, 'landing_summary_body', 'Use a single hub to align feedback, track completion, and surface development wins.'), ENT_QUOTES, 'UTF-8') ?></p>
+        </div>
         <div class="landing-hero__actions">
           <a class="landing-button landing-button--primary" href="<?= $loginUrl ?>"><?= $primaryCta ?></a>
           <p class="landing-hero__cta-note"><?= htmlspecialchars(t($t, 'landing_cta_note', 'One secure sign-in for managers, reviewers, and employees.'), ENT_QUOTES, 'UTF-8') ?></p>
@@ -110,12 +114,6 @@ $featureItems = [
           <?php endforeach; ?>
         </ul>
       </div>
-      <aside class="landing-hero__summary" aria-label="<?= htmlspecialchars(t($t, 'landing_summary_title', 'Built for confident, modern HR teams'), ENT_QUOTES, 'UTF-8') ?>">
-        <div class="landing-summary__card">
-          <h2><?= htmlspecialchars(t($t, 'landing_summary_title', 'Built for confident, modern HR teams'), ENT_QUOTES, 'UTF-8') ?></h2>
-          <p><?= htmlspecialchars(t($t, 'landing_summary_body', 'Use a single hub to align feedback, track completion, and surface development wins.'), ENT_QUOTES, 'UTF-8') ?></p>
-        </div>
-      </aside>
     </header>
 
     <main class="landing-main" aria-labelledby="features-heading">


### PR DESCRIPTION
### Motivation
- Make the landing (index) page use the same theme colors and visual language as the `login.php` page and simplify the hero layout for a cleaner, more focused first impression.

### Description
- Move the hero summary into the main column and simplify the hero markup in `index.php` to produce a single-column flow for title, summary, CTA and highlights.
- Update `assets/css/landing.css` color tokens to match the login theme and replace the hero gradient with a blue-themed gradient that mirrors the login styling.
- Switch the hero layout from a two-column grid to a centered flex layout, increase the content max-width, and restyle the summary as an integrated translucent card inside the hero.
- Adjust CTA and text treatments (spacing, colors, shadows) and remove the old standalone summary card styles no longer required by the simplified layout.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025`, which launched successfully and served `index.php`.
- Captured a rendered screenshot using Playwright; an initial Node-based script failed, then a Python `playwright.sync_api` script ran successfully and produced `artifacts/landing.png` showing the updated layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d78a2afe4832d9963c109e45e9c0e)