### PR TITLE
Tighten questionnaire import tile spacing

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -77,6 +77,10 @@
   padding: 0.75rem 0.9rem;
 }
 
+.qb-start-card > * + * {
+  margin-top: 0;
+}
+
 .qb-start-card .md-card-title {
   margin-bottom: 0.25rem;
 }


### PR DESCRIPTION
### Motivation
- Reduce unnecessary vertical whitespace in the Questionnaire builder "Import" tile which made the import card taller than intended.

### Description
- Add a CSS rule ` .qb-start-card > * + * { margin-top: 0; } ` to `assets/css/questionnaire-builder.css` to remove extra top margins between children of start cards and tighten the tile layout.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and captured a headless Playwright screenshot saved to `artifacts/questionnaire-import-tile.png`, confirming the import tile height and spacing were reduced (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7dfbad8c832da97b0d609c5cf1b8)