### PR TITLE
Remove Reload App menu item

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -531,15 +531,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <span class="md-topnav-link-icon md-status-dot" aria-hidden="true"></span>
           </button>
         </li>
-        <li>
-          <button type="button" class="md-topnav-link" id="appbar-reload-btn">
-            <span class="md-topnav-link-content">
-              <span class="md-topnav-link-title"><?=htmlspecialchars(t($t, 'reload_app', 'Reload App'), ENT_QUOTES, 'UTF-8')?></span>
-              <span class="md-topnav-link-desc"><?=t($t, 'reload_app_summary', 'Refresh the app and clear cached data.')?></span>
-            </span>
-            <span class="md-topnav-link-icon" aria-hidden="true">↻</span>
-          </button>
-        </li>
         <?php foreach ($availableLocales as $loc): ?>
           <li>
             <a href="<?=htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link<?=($locale === $loc) ? ' active' : ''?>">


### PR DESCRIPTION
### Motivation
- Remove the redundant "Reload App" action from the top navigation so it no longer appears between Connectivity and language options.

### Description
- Deleted the `appbar-reload-btn` button block from `templates/header.php` to remove the Reload App entry.

### Testing
- Started a local PHP server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and ran a Playwright script that captured `artifacts/reload-app-removed.png`, confirming the menu item is no longer rendered and both steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7fad37cc832db7f90ae3f4e65774)