### PR TITLE
Add compact round flag language switcher to app bar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -552,6 +552,20 @@ button,
   background: var(--app-on-primary-soft);
 }
 
+.md-appbar-link.md-appbar-language {
+  padding: 0;
+  width: var(--app-button-height);
+  height: var(--app-button-height);
+  border-radius: 50%;
+  font-size: 1.1rem;
+  background: var(--app-on-primary-subtle);
+}
+
+.md-appbar-link.md-appbar-language:hover,
+.md-appbar-link.md-appbar-language:focus {
+  background: var(--app-on-primary-soft);
+}
+
 .md-lang-switch a {
   margin: 0 0.15rem;
   padding: 0.25rem 0.55rem;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -505,7 +505,7 @@
     }
   };
 
-  const langLinkSelector = '.md-lang-switch a, .lang-switch a';
+  const langLinkSelector = '.md-lang-switch a, .lang-switch a, .md-appbar-language';
   document.querySelectorAll(langLinkSelector).forEach((link) => {
     link.addEventListener('click', () => {
       let targetLocale = '';

--- a/templates/header.php
+++ b/templates/header.php
@@ -62,6 +62,18 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
     $aria = $isActiveNav(...$keys) ? ' aria-current="page"' : '';
     return sprintf('class="%s"%s', $class, $aria);
 };
+$localeFlags = [
+    'en' => '🇬🇧',
+    'fr' => '🇫🇷',
+    'am' => '🇪🇹',
+];
+$currentLocale = $locale ?? $defaultLocale;
+$localeCount = count($availableLocales);
+$localeIndex = $localeCount > 0 ? array_search($currentLocale, $availableLocales, true) : false;
+$nextLocale = $localeCount > 0
+    ? $availableLocales[(($localeIndex === false ? 0 : $localeIndex) + 1) % $localeCount]
+    : $currentLocale;
+$currentLocaleFlag = $localeFlags[$currentLocale] ?? '🌐';
 ?>
 <?php if ($brandStyle !== ''): ?>
 <style id="md-brand-style"><?=htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8')?></style>
@@ -87,6 +99,14 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
     <span><?=$siteTitle?></span>
   </div>
   <div class="md-appbar-actions">
+    <a
+      href="<?=htmlspecialchars(url_for('set_lang.php?lang=' . $nextLocale), ENT_QUOTES, 'UTF-8')?>"
+      class="md-appbar-link md-appbar-language"
+      aria-label="<?=htmlspecialchars(t($t, 'language_switch', 'Switch language'), ENT_QUOTES, 'UTF-8')?>"
+      title="<?=htmlspecialchars(t($t, 'language_switch', 'Switch language'), ENT_QUOTES, 'UTF-8')?>"
+    >
+      <span aria-hidden="true"><?=$currentLocaleFlag?></span>
+    </a>
     <a href="<?=htmlspecialchars(url_for('logout.php'), ENT_QUOTES, 'UTF-8')?>" class="md-appbar-link">
       <?=t($t, 'logout', 'Logout')?>
     </a>
@@ -510,17 +530,6 @@ $topNavLinkAttributes = static function (string ...$keys) use ($isActiveNav): st
             <span class="md-topnav-link-icon md-status-dot" aria-hidden="true"></span>
           </button>
         </li>
-        <?php foreach ($availableLocales as $loc): ?>
-          <li>
-            <a href="<?=htmlspecialchars(url_for('set_lang.php?lang=' . $loc), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link<?=($locale === $loc) ? ' active' : ''?>">
-              <span class="md-topnav-link-content">
-                <span class="md-topnav-link-title"><?=t($t, 'language_label', 'Language')?>: <?=strtoupper($loc)?></span>
-                <span class="md-topnav-link-desc"><?=t($t, 'language_switch', 'Switch language')?></span>
-              </span>
-              <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
-            </a>
-          </li>
-        <?php endforeach; ?>
         <li>
           <a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link">
             <span class="md-topnav-link-content">


### PR DESCRIPTION
### Motivation
- Simplify and surface the language selector by moving it next to the `Logout` action and make switching as minimal as possible (a single round flag that advances to the next locale on click).

### Description
- Compute the current and next locale and map locales to flag glyphs in `templates/header.php`, inject a compact anchor into the app bar that links to `set_lang.php?lang=<next>` and remove the language list from the account menu.
- Add styling for the new round flag button in `assets/css/styles.css` under the class `.md-appbar-language` so it appears as a circular control in the app bar.
- Include the new language control in the existing locale click handling by expanding the selector in `assets/js/app.js` to include `.md-appbar-language`, preserving session-based pending-locale behavior and Google Translate integration.

### Testing
- Launched the PHP built-in server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and the server started successfully on port 8000.
- Ran a Playwright smoke test that navigated to `login.php` and captured a screenshot at `artifacts/appbar-language.png`, confirming the new round flag control renders in the app bar.
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d82f58aa0832dbd464c77af6c71f2)