### PR TITLE
Tighten import tile spacing

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -832,7 +832,7 @@
 .qb-import-form {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.35rem;
 }
 
 .qb-import-inline {
@@ -845,6 +845,7 @@
 
 .qb-import-inline .md-field {
   min-width: 240px;
+  margin: 0;
 }
 
 .qb-scoring-card {


### PR DESCRIPTION
### Motivation
- Reduce the large whitespace between the import tile label text and the file input which was caused by the form gap and the default `.md-field` margin inside the import row.

### Description
- Adjusted `assets/css/questionnaire-builder.css` to reduce `.qb-import-form` gap from `0.6rem` to `0.35rem` and set `.qb-import-inline .md-field { margin: 0; }` to remove extra vertical spacing.

### Testing
- No automated tests were run for this CSS tweak (visual verification expected during UI review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d868b2de4832d821f73800c4d1342)