### PR TITLE
Only show back-online banner on state changes; deactivate users instead of deleting and style button red

### DIFF
--- a/admin/users.php
+++ b/admin/users.php
@@ -229,9 +229,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_POST['delete'])) {
         $id = (int)($_POST['id'] ?? 0);
         if ($id > 0) {
-            $stm = $pdo->prepare('DELETE FROM users WHERE id=?');
+            $stm = $pdo->prepare("UPDATE users SET account_status = 'disabled' WHERE id=?");
             $stm->execute([$id]);
-            $_SESSION['admin_users_flash'] = t($t, 'user_deleted', 'User deleted successfully.');
+            $_SESSION['admin_users_flash'] = t($t, 'user_deactivated', 'User deactivated successfully.');
             header('Location: ' . url_for('admin/users.php'));
             exit;
         }
@@ -553,10 +553,10 @@ foreach ($rows as $r) {
                 <button name="reset" class="md-button md-elev-1 md-user-action-button"><?=t($t,'apply','Apply')?></button>
               </div>
             </form>
-            <form method="post" action="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" class="md-user-delete-form" data-verify-user="<?=htmlspecialchars($r['username'], ENT_QUOTES, 'UTF-8')?>" data-verify-prompt="<?=htmlspecialchars(t($t,'confirm_delete_prompt','Type the username to confirm deletion.'), ENT_QUOTES, 'UTF-8')?>" data-verify-mismatch="<?=htmlspecialchars(t($t,'delete_verification_failed','The entered username did not match. No changes were made.'), ENT_QUOTES, 'UTF-8')?>">
+            <form method="post" action="<?=htmlspecialchars(url_for('admin/users.php'), ENT_QUOTES, 'UTF-8')?>" class="md-user-delete-form" data-verify-user="<?=htmlspecialchars($r['username'], ENT_QUOTES, 'UTF-8')?>" data-verify-prompt="<?=htmlspecialchars(t($t,'confirm_deactivate_prompt','Type the username to confirm deactivation.'), ENT_QUOTES, 'UTF-8')?>" data-verify-mismatch="<?=htmlspecialchars(t($t,'deactivate_verification_failed','The entered username did not match. No changes were made.'), ENT_QUOTES, 'UTF-8')?>">
               <input type="hidden" name="csrf" value="<?=csrf_token()?>">
               <input type="hidden" name="id" value="<?=$record['id']?>">
-              <button name="delete" class="md-button md-danger md-elev-1 md-user-action-button" type="submit"><?=t($t,'delete','Delete')?></button>
+              <button name="delete" class="md-button md-danger md-elev-1 md-user-action-button" type="submit"><?=t($t,'deactivate','Deactivate')?></button>
             </form>
           </div>
         </article>
@@ -612,7 +612,7 @@ foreach ($rows as $r) {
   forms.forEach((form) => {
     form.addEventListener('submit', (event) => {
       const expected = form.dataset.verifyUser || '';
-      const promptMessage = form.dataset.verifyPrompt || 'Type the username to confirm deletion.';
+      const promptMessage = form.dataset.verifyPrompt || 'Type the username to confirm deactivation.';
       const mismatch = form.dataset.verifyMismatch || 'The entered username did not match. No changes were made.';
       const response = window.prompt(promptMessage, '');
       if (response === null) {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1208,6 +1208,18 @@ body.theme-dark .md-field.md-field--compact select {
   min-width: clamp(8rem, 18vw, 10.5rem);
 }
 
+.md-user-delete-form .md-user-action-button.md-danger {
+  background: var(--app-danger, #dc2626);
+  box-shadow: 0 12px 30px rgba(220, 38, 38, 0.35);
+  color: var(--app-on-primary, #ffffff);
+}
+
+.md-user-delete-form .md-user-action-button.md-danger:hover,
+.md-user-delete-form .md-user-action-button.md-danger:focus {
+  background: #b91c1c;
+  box-shadow: 0 12px 30px rgba(185, 28, 28, 0.35);
+}
+
 @media (max-width: 720px) {
   .md-user-card__footer {
     flex-direction: column;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -933,14 +933,21 @@
   syncOfflineCredentials();
   window.addEventListener('pageshow', syncOfflineCredentials);
 
+  let lastConnectivityState = isAppOnline() ? 'online' : 'offline';
+
   const handleConnectivityUpdate = (state) => {
     const online = state && typeof state.online === 'boolean' ? state.online : isAppOnline();
+    const nextState = online ? 'online' : 'offline';
+    if (lastConnectivityState === nextState) {
+      return;
+    }
     if (online) {
       showOfflineBanner('online');
     } else {
       offlineDismissedWhileOffline = false;
       showOfflineBanner('offline');
     }
+    lastConnectivityState = nextState;
   };
 
   if (connectivity) {


### PR DESCRIPTION
### Motivation
- Prevent the "Back online" popup from appearing repeatedly when connectivity state hasn't changed. 
- Replace destructive user deletion with a safer deactivate flow and make the action visually red to indicate danger.

### Description
- Updated connectivity handling in `assets/js/app.js` to track `lastConnectivityState` and call `showOfflineBanner` only when the state actually changes. 
- Replaced the DELETE SQL in `admin/users.php` with an `UPDATE users SET account_status = 'disabled'` to deactivate users instead of removing rows. 
- Adjusted admin UI strings and verification prompt keys in `admin/users.php` and the in-page confirmation prompt to reference deactivation rather than deletion, and changed the button label from `Delete` to `Deactivate`. 
- Added explicit red styling for the deactivate button in `assets/css/styles.css` to remove the previous green shadow and present a clear danger appearance.

### Testing
- Started a local PHP dev server with `php -S ...` to load the admin users page, which started successfully. 
- Ran a Playwright script that loaded `/admin/users.php` and produced a screenshot (`artifacts/admin-users.png`) to validate the UI changes, which completed successfully. 
- Committed changes to the repository successfully; no automated unit tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d88e0b70c832d81e2ea97736e36f7)