### PR TITLE
Update questionnaire saved message to use theme color

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -359,7 +359,7 @@
 }
 
 .qb-message[data-state="success"] {
-  color: var(--status-success-text);
+  color: var(--app-primary-dark, var(--app-primary));
 }
 
 .qb-scoring-note {


### PR DESCRIPTION
### Motivation
- The questionnaire "saved" success label was using the generic success text color rather than the configured theme primary shade, so it needed to follow the current theme selected under Settings.

### Description
- Replace `.qb-message[data-state="success"]` color from `var(--status-success-text)` to `var(--app-primary-dark, var(--app-primary))` in `assets/css/questionnaire-builder.css` so the success label uses the theme primary shade.

### Testing
- Started a local dev server with `php -S` and ran a headless Playwright script to load `/admin/questionnaire_manage.php` and capture `artifacts/questionnaire-manage.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8f9087d4832d8ea093d844f664d1)