### PR TITLE
Align form grid buttons to prevent stretched height

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1242,6 +1242,7 @@ body.theme-dark .md-field.md-field--compact select {
 
 .md-form-grid > .md-button {
   justify-self: start;
+  align-self: start;
 }
 
 .md-form-grid > .md-form-actions {


### PR DESCRIPTION
### Motivation
- The Users "Create" button was taller than other system buttons because form-grid buttons were stretching to fill the grid row height.

### Description
- Add `align-self: start` to `.md-form-grid > .md-button` in `assets/css/styles.css` to prevent vertical stretching of buttons.

### Testing
- Started a local dev server and captured a Playwright screenshot of `/admin/users.php` which shows the Create button aligned with other system buttons (artifact: `artifacts/users-create-button.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8edaa400832d9a88852e966c26f0)