### PR TITLE
Add floating Save button to questionnaire builder

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1474,6 +1474,9 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
       </div>
     </div>
   </div>
+  <button type="button" class="md-button md-outline md-floating-save-draft qb-floating-save" id="qb-save-floating" disabled>
+    <?=t($t,'save','Save Changes')?>
+  </button>
 </section>
 <?php if ($recentImportId): ?>
 <script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">window.QB_INITIAL_ACTIVE_ID = <?=json_encode($recentImportId, JSON_THROW_ON_ERROR)?>;</script>

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -23,6 +23,7 @@ const Builder = (() => {
     tabs: '#qb-tabs',
     addButton: '#qb-add-questionnaire',
     saveButton: '#qb-save',
+    floatingSaveButton: '#qb-save-floating',
     publishButton: '#qb-publish',
     exportButton: '#qb-export-questionnaire',
     openButton: '#qb-open-selected',
@@ -230,6 +231,7 @@ const Builder = (() => {
   function attachStaticListeners() {
     const addBtn = document.querySelector(selectors.addButton);
     const saveBtn = document.querySelector(selectors.saveButton);
+    const floatingSaveBtn = document.querySelector(selectors.floatingSaveButton);
     const publishBtn = document.querySelector(selectors.publishButton);
     const exportBtns = document.querySelectorAll(selectors.exportButton);
     const openBtn = document.querySelector(selectors.openButton);
@@ -243,6 +245,7 @@ const Builder = (() => {
     });
 
     saveBtn?.addEventListener('click', () => saveAll(false));
+    floatingSaveBtn?.addEventListener('click', () => saveAll(false));
     publishBtn?.addEventListener('click', () => saveAll(true));
     exportBtns.forEach((btn) => btn.addEventListener('click', handleExport));
     openBtn?.addEventListener('click', () => {
@@ -382,8 +385,10 @@ const Builder = (() => {
   function markDirty() {
     state.dirty = true;
     const saveBtn = document.querySelector(selectors.saveButton);
+    const floatingSaveBtn = document.querySelector(selectors.floatingSaveButton);
     const publishBtn = document.querySelector(selectors.publishButton);
     if (saveBtn) saveBtn.disabled = false;
+    if (floatingSaveBtn) floatingSaveBtn.disabled = false;
     if (publishBtn) publishBtn.disabled = false;
   }
 
@@ -706,9 +711,11 @@ const Builder = (() => {
 
   function toggleSaveButtons() {
     const saveBtn = document.querySelector(selectors.saveButton);
+    const floatingSaveBtn = document.querySelector(selectors.floatingSaveButton);
     const publishBtn = document.querySelector(selectors.publishButton);
     const disabled = state.questionnaires.length === 0 || state.saving;
     if (saveBtn) saveBtn.disabled = disabled || (!state.dirty && !state.loading);
+    if (floatingSaveBtn) floatingSaveBtn.disabled = disabled || (!state.dirty && !state.loading);
     if (publishBtn) publishBtn.disabled = disabled || (!state.dirty && !state.loading);
   }
 


### PR DESCRIPTION
### Motivation
- Improve save affordance in the Questionnaire Builder by adding a floating "Save Changes" button similar to the Save Draft control on the Submit page so administrators can quickly save while editing long questionnaires.

### Description
- Add a floating button markup with id `qb-save-floating` to `admin/questionnaire_manage.php` and wire it into the builder by adding `floatingSaveButton` to `assets/js/questionnaire-builder.js`, registering a click handler that calls `saveAll(false)`, and keeping its disabled state in sync via `markDirty()` and `toggleSaveButtons()`.

### Testing
- Launched a local dev server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and ran a Playwright script (`sync_playwright`) to open `/admin/questionnaire_manage.php` and capture a screenshot `artifacts/questionnaire-builder-save-floating.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e932ae33c832da46e2ac6ea80a1a2)