### PR TITLE
Improve questionnaire import feedback and focus

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -832,20 +832,27 @@
 .qb-import-form {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .qb-import-inline {
   display: flex;
-  align-items: flex-end;
-  gap: 0.75rem;
-  flex: 1 1 360px;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 1 auto;
   flex-wrap: wrap;
 }
 
 .qb-import-inline .md-field {
   min-width: 240px;
   margin: 0;
+}
+
+.md-import-popup__list {
+  margin: 0.4rem 0 0;
+  padding-left: 1.2rem;
+  color: var(--app-muted);
+  font-size: 0.9rem;
 }
 
 .qb-scoring-card {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -95,6 +95,7 @@ const Builder = (() => {
   };
 
   let initialActiveId = window.QB_INITIAL_ACTIVE_ID || null;
+  let pendingImportFocus = false;
 
   const baseMeta = document.querySelector('meta[name="app-base-url"]');
   let appBase = window.APP_BASE_URL || (baseMeta ? baseMeta.content : '/');
@@ -317,6 +318,9 @@ const Builder = (() => {
       if (match) {
         state.activeKey = match.clientId;
         state.navActiveKey = 'root';
+        const rememberKey = match.id ? String(match.id) : match.clientId;
+        rememberSet(STORAGE_KEYS.active, rememberKey);
+        pendingImportFocus = true;
         initialActiveId = null;
         return;
       }
@@ -393,6 +397,10 @@ const Builder = (() => {
     renderQuestionnaires();
     renderSectionNav();
     toggleSaveButtons();
+    if (pendingImportFocus) {
+      pendingImportFocus = false;
+      focusActiveQuestionnaire();
+    }
   }
 
   function renderSelector() {
@@ -428,6 +436,15 @@ const Builder = (() => {
     const html = buildQuestionnaireCard(active);
     list.innerHTML = html;
     bindSortables();
+  }
+
+  function focusActiveQuestionnaire() {
+    const card = document.querySelector(`[data-q="${state.activeKey}"]`);
+    if (!card) return;
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    card.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+    const titleInput = card.querySelector('[data-role="q-title"]');
+    titleInput?.focus({ preventScroll: true });
   }
 
   function buildQuestionnaireCard(questionnaire) {


### PR DESCRIPTION
### Motivation
- Users need immediate visual confirmation when an import succeeds or fails and the ability to see a concise import log.  
- Newly imported questionnaires must be shown and focused in the builder so they are visible right after import.  
- The Import tile layout wastes vertical space and should be tightened for a more compact UI.

### Description
- Record detailed import metadata (file name, parse errors, import counts, DB errors) into `$_SESSION['questionnaire_import_popup']` and render it as a dismissible popup in `admin/questionnaire_manage.php`.  
- Add popup HTML and a small client-side dismiss handler so the user can read the import log after the page redirect.  
- Compact the import form and file input by adding `md-field--compact` markup and tightening spacing in `assets/css/questionnaire-builder.css`, and add styles for the popup details list.  
- Ensure imported questionnaires are focused after load by setting a `pendingImportFocus` flag and implementing `focusActiveQuestionnaire()` in `assets/js/questionnaire-builder.js` that scrolls the newly imported questionnaire into view and focuses its title input.

### Testing
- Launched a PHP dev server and ran a Playwright script to load `/admin/questionnaire_manage.php` and capture a screenshot (`artifacts/import-popup.png`), which ran successfully and shows the new import popup UI.  
- No automated unit tests were added; visual/browser validation via Playwright completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e92f23564832d9710a46c44aa22d3)