### PR TITLE
Fix questionnaire builder floating button overlap

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -127,7 +127,8 @@
 .qb-scroll-top {
   position: fixed;
   bottom: 1.25rem;
-  right: clamp(1rem, 2vw, 1.75rem);
+  left: clamp(1rem, 2vw, 1.75rem);
+  right: auto;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;


### PR DESCRIPTION
### Motivation
- Prevent the floating "Save" and "Back to top" buttons from overlapping in the questionnaire builder by keeping the Save button on the right and moving the go-to-top button to the left.

### Description
- Adjusted `assets/css/questionnaire-builder.css` by changing `.qb-scroll-top` to use `left: clamp(1rem, 2vw, 1.75rem)` and `right: auto` so the back-to-top button is left aligned.

### Testing
- Started a PHP development server and used Playwright to load `/admin/questionnaire_manage.php` and capture a screenshot (`artifacts/questionnaire-builder-buttons.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eaead2714832db372f4a82535d6cb)