### PR TITLE
Use circular flag icons for language switcher

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -559,11 +559,20 @@ button,
   border-radius: 50%;
   font-size: 1.1rem;
   background: var(--app-on-primary-subtle);
+  overflow: hidden;
 }
 
 .md-appbar-link.md-appbar-language:hover,
 .md-appbar-link.md-appbar-language:focus {
   background: var(--app-on-primary-soft);
+}
+
+.md-appbar-link.md-appbar-language .md-appbar-flag {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  display: block;
+  object-fit: cover;
 }
 
 .md-lang-switch a {

--- a/assets/images/flags/flag-am.svg
+++ b/assets/images/flags/flag-am.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Amharic">
+  <defs>
+    <clipPath id="circle">
+      <circle cx="32" cy="32" r="32" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#circle)">
+    <rect width="64" height="64" fill="#FCDD09" />
+    <rect width="64" height="21.34" y="0" fill="#078930" />
+    <rect width="64" height="21.34" y="42.66" fill="#DA121A" />
+    <circle cx="32" cy="32" r="14" fill="#0F47AF" />
+    <path d="M32 22.5 L34.6 29.2 L41.8 29.2 L36 33.4 L38.2 40.5 L32 36.6 L25.8 40.5 L28 33.4 L22.2 29.2 L29.4 29.2 Z" fill="#FCDD09" />
+  </g>
+</svg>

--- a/assets/images/flags/flag-en.svg
+++ b/assets/images/flags/flag-en.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="English">
+  <defs>
+    <clipPath id="circle">
+      <circle cx="32" cy="32" r="32" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#circle)">
+    <rect width="64" height="64" fill="#012169" />
+    <path d="M0 0 L0 8 L56 64 L64 64 L64 56 L8 0 Z" fill="#FFFFFF" />
+    <path d="M64 0 L56 0 L0 56 L0 64 L8 64 L64 8 Z" fill="#FFFFFF" />
+    <path d="M0 0 L0 5 L59 64 L64 64 L64 59 L5 0 Z" fill="#C8102E" />
+    <path d="M64 0 L59 0 L0 59 L0 64 L5 64 L64 5 Z" fill="#C8102E" />
+    <rect x="0" y="26" width="64" height="12" fill="#FFFFFF" />
+    <rect x="26" y="0" width="12" height="64" fill="#FFFFFF" />
+    <rect x="0" y="29" width="64" height="6" fill="#C8102E" />
+    <rect x="29" y="0" width="6" height="64" fill="#C8102E" />
+  </g>
+</svg>

--- a/assets/images/flags/flag-fr.svg
+++ b/assets/images/flags/flag-fr.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="French">
+  <defs>
+    <clipPath id="circle">
+      <circle cx="32" cy="32" r="32" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#circle)">
+    <rect width="64" height="64" fill="#FFFFFF" />
+    <rect width="21.4" height="64" x="0" y="0" fill="#0055A4" />
+    <rect width="21.4" height="64" x="42.6" y="0" fill="#EF4135" />
+  </g>
+</svg>

--- a/templates/header.php
+++ b/templates/header.php
@@ -67,6 +67,11 @@ $localeFlags = [
     'fr' => '🇫🇷',
     'am' => '🇪🇹',
 ];
+$localeFlagIcons = [
+    'en' => 'assets/images/flags/flag-en.svg',
+    'fr' => 'assets/images/flags/flag-fr.svg',
+    'am' => 'assets/images/flags/flag-am.svg',
+];
 $currentLocale = $locale ?? $defaultLocale;
 $localeCount = count($availableLocales);
 $localeIndex = $localeCount > 0 ? array_search($currentLocale, $availableLocales, true) : false;
@@ -74,6 +79,7 @@ $nextLocale = $localeCount > 0
     ? $availableLocales[(($localeIndex === false ? 0 : $localeIndex) + 1) % $localeCount]
     : $currentLocale;
 $currentLocaleFlag = $localeFlags[$currentLocale] ?? '🌐';
+$currentLocaleFlagIcon = $localeFlagIcons[$currentLocale] ?? null;
 ?>
 <?php if ($brandStyle !== ''): ?>
 <style id="md-brand-style"><?=htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8')?></style>
@@ -105,7 +111,16 @@ $currentLocaleFlag = $localeFlags[$currentLocale] ?? '🌐';
       aria-label="<?=htmlspecialchars(t($t, 'language_switch', 'Switch language'), ENT_QUOTES, 'UTF-8')?>"
       title="<?=htmlspecialchars(t($t, 'language_switch', 'Switch language'), ENT_QUOTES, 'UTF-8')?>"
     >
-      <span aria-hidden="true"><?=$currentLocaleFlag?></span>
+      <?php if ($currentLocaleFlagIcon): ?>
+        <img
+          src="<?=htmlspecialchars(url_for($currentLocaleFlagIcon), ENT_QUOTES, 'UTF-8')?>"
+          alt=""
+          class="md-appbar-flag"
+          aria-hidden="true"
+        >
+      <?php else: ?>
+        <span aria-hidden="true"><?=$currentLocaleFlag?></span>
+      <?php endif; ?>
     </a>
     <a href="<?=htmlspecialchars(url_for('logout.php'), ENT_QUOTES, 'UTF-8')?>" class="md-appbar-link">
       <?=t($t, 'logout', 'Logout')?>


### PR DESCRIPTION
### Motivation
- The language button is circular but the flag inside was small and not filling the control, so replace the emoji-only display with circular flag icons that fully occupy the round button.

### Description
- Add SVG flag assets for supported locales at `assets/images/flags/flag-en.svg`, `flag-fr.svg`, and `flag-am.svg`.
- Update `templates/header.php` to use a locale-to-icon map and render an `<img>` for the current locale with an emoji fallback when no icon is available.
- Update `assets/css/styles.css` to ensure the flag image fills and is cropped to the circular button using `overflow: hidden` and `object-fit: cover`.

### Testing
- Started the PHP built-in server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and it launched successfully.
- Rendered the site and captured a visual verification screenshot using a Playwright script (Python) which produced `artifacts/language-flag-button.png` successfully.
- Committed the changes to the repository (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eaef0a97c832db5169f1f8f009b7a)