### PR TITLE
Add semantic danger/warning/success color tokens and apply to UI

### DIFF
--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -9,7 +9,7 @@
   --md-surface: var(--app-surface);
   --md-muted: var(--app-muted);
   --md-muted-light: var(--app-muted-light);
-  --md-danger: var(--app-danger);
+  --md-danger: var(--semantic-danger);
   --md-radius: 16px;
   --md-shadow: var(--app-shadow-soft);
 }

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -553,18 +553,23 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  background: rgba(107, 114, 128, 0.15);
-  color: #374151;
+  background: var(--app-secondary-soft);
+  color: var(--app-primary-dark);
+}
+
+.qb-status-badge.qb-status-draft {
+  background: var(--semantic-warning-soft);
+  color: var(--semantic-warning-text);
 }
 
 .qb-status-badge.qb-status-published {
-  background: rgba(16, 185, 129, 0.18);
-  color: #047857;
+  background: var(--semantic-success-soft);
+  color: var(--semantic-success-text);
 }
 
 .qb-status-badge.qb-status-inactive {
-  background: rgba(148, 163, 184, 0.2);
-  color: #475569;
+  background: var(--semantic-danger-soft);
+  color: var(--semantic-danger-text);
 }
 
 .qb-response-pill {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1048,15 +1048,15 @@ body.theme-dark .md-user-card__heading h3 {
 }
 
 .md-user-chip.status-pending {
-  background: var(--status-warning-soft);
-  color: var(--status-warning-text);
-  box-shadow: inset 0 0 0 1px var(--status-warning-soft);
+  background: var(--semantic-warning-soft);
+  color: var(--semantic-warning-text);
+  box-shadow: inset 0 0 0 1px var(--semantic-warning-soft);
 }
 
 .md-user-chip.status-disabled {
-  background: var(--status-danger-soft);
-  color: var(--status-danger-text);
-  box-shadow: inset 0 0 0 1px var(--status-danger-soft);
+  background: var(--semantic-danger-soft);
+  color: var(--semantic-danger-text);
+  box-shadow: inset 0 0 0 1px var(--semantic-danger-soft);
 }
 
 body.theme-dark .md-user-chip {
@@ -1072,15 +1072,15 @@ body.theme-dark .md-user-chip.status-active {
 }
 
 body.theme-dark .md-user-chip.status-pending {
-  background: var(--status-warning-soft);
-  color: var(--status-warning-surface);
-  box-shadow: inset 0 0 0 1px var(--status-warning-soft);
+  background: var(--semantic-warning-soft);
+  color: var(--semantic-warning-text);
+  box-shadow: inset 0 0 0 1px var(--semantic-warning-soft);
 }
 
 body.theme-dark .md-user-chip.status-disabled {
-  background: var(--status-danger-soft);
-  color: var(--status-danger-surface);
-  box-shadow: inset 0 0 0 1px var(--status-danger-soft);
+  background: var(--semantic-danger-soft);
+  color: var(--semantic-danger-text);
+  box-shadow: inset 0 0 0 1px var(--semantic-danger-soft);
 }
 
 .md-user-meta {
@@ -1209,15 +1209,15 @@ body.theme-dark .md-field.md-field--compact select {
 }
 
 .md-user-delete-form .md-user-action-button.md-danger {
-  background: var(--app-danger, #dc2626);
-  box-shadow: 0 12px 30px rgba(220, 38, 38, 0.35);
-  color: var(--app-on-primary, #ffffff);
+  background: var(--semantic-danger, #dc2626);
+  box-shadow: 0 12px 30px var(--semantic-danger-soft);
+  color: var(--semantic-danger-text, #ffffff);
 }
 
 .md-user-delete-form .md-user-action-button.md-danger:hover,
 .md-user-delete-form .md-user-action-button.md-danger:focus {
-  background: #b91c1c;
-  box-shadow: 0 12px 30px rgba(185, 28, 28, 0.35);
+  background: var(--semantic-danger-strong, #b91c1c);
+  box-shadow: 0 12px 30px var(--semantic-danger-soft);
 }
 
 @media (max-width: 720px) {

--- a/config.php
+++ b/config.php
@@ -1081,6 +1081,9 @@ function site_theme_tokens(array $cfg): array
     $danger = adjust_hsl($primary, -40.0, 1.18, 0.9);
     $success = adjust_hsl($primary, 120.0, 0.95, 0.78);
     $info = adjust_hsl($primary, -20.0, 1.08, 1.02);
+    $semanticDanger = '#dc2626';
+    $semanticWarning = '#f59e0b';
+    $semanticSuccess = '#16a34a';
 
     $lightSurface = tint_color($primary, 0.9);
     $lightSurfaceAlt = tint_color($primary, 0.95);
@@ -1118,21 +1121,34 @@ function site_theme_tokens(array $cfg): array
     $warningSoft = rgba_string($warning, 0.22);
     $dangerSoft = rgba_string($danger, 0.24);
     $infoSoft = rgba_string($info, 0.2);
+    $semanticDangerSoft = rgba_string($semanticDanger, 0.24);
+    $semanticWarningSoft = rgba_string($semanticWarning, 0.22);
+    $semanticSuccessSoft = rgba_string($semanticSuccess, 0.2);
 
     $successSurface = tint_color($success, 0.85);
     $warningSurface = tint_color($warning, 0.86);
     $dangerSurface = tint_color($danger, 0.88);
     $infoSurface = tint_color($info, 0.86);
+    $semanticDangerSurface = tint_color($semanticDanger, 0.88);
+    $semanticWarningSurface = tint_color($semanticWarning, 0.86);
+    $semanticSuccessSurface = tint_color($semanticSuccess, 0.85);
 
     $successBorder = rgba_string($success, 0.28);
     $warningBorder = rgba_string($warning, 0.28);
     $dangerBorder = rgba_string($danger, 0.28);
     $infoBorder = rgba_string($info, 0.26);
+    $semanticDangerBorder = rgba_string($semanticDanger, 0.28);
+    $semanticWarningBorder = rgba_string($semanticWarning, 0.28);
+    $semanticSuccessBorder = rgba_string($semanticSuccess, 0.28);
 
     $successText = contrast_color($success);
     $warningText = contrast_color($warning);
     $dangerText = contrast_color($danger);
     $infoText = contrast_color($info);
+    $semanticDangerText = contrast_color($semanticDanger);
+    $semanticWarningText = contrast_color($semanticWarning);
+    $semanticSuccessText = contrast_color($semanticSuccess);
+    $semanticDangerStrong = shade_color($semanticDanger, 0.18);
 
     $successGradient = sprintf('linear-gradient(160deg, %s 0%%, %s 55%%, %s 100%%)', shade_color($success, 0.55), shade_color($success, 0.45), shade_color($success, 0.7));
 
@@ -1162,6 +1178,22 @@ function site_theme_tokens(array $cfg): array
     $darkWarningSoft = rgba_string($darkWarning, 0.34);
     $darkInfo = tint_color($info, 0.32);
     $darkInfoSoft = rgba_string($darkInfo, 0.32);
+    $semanticDangerDark = tint_color($semanticDanger, 0.32);
+    $semanticWarningDark = tint_color($semanticWarning, 0.32);
+    $semanticSuccessDark = tint_color($semanticSuccess, 0.32);
+    $semanticDangerDarkSoft = rgba_string($semanticDangerDark, 0.38);
+    $semanticWarningDarkSoft = rgba_string($semanticWarningDark, 0.34);
+    $semanticSuccessDarkSoft = rgba_string($semanticSuccessDark, 0.32);
+    $semanticDangerDarkSurface = tint_color($semanticDangerDark, 0.88);
+    $semanticWarningDarkSurface = tint_color($semanticWarningDark, 0.86);
+    $semanticSuccessDarkSurface = tint_color($semanticSuccessDark, 0.85);
+    $semanticDangerDarkBorder = rgba_string($semanticDangerDark, 0.28);
+    $semanticWarningDarkBorder = rgba_string($semanticWarningDark, 0.28);
+    $semanticSuccessDarkBorder = rgba_string($semanticSuccessDark, 0.28);
+    $semanticDangerDarkText = contrast_color($semanticDangerDark);
+    $semanticWarningDarkText = contrast_color($semanticWarningDark);
+    $semanticSuccessDarkText = contrast_color($semanticSuccessDark);
+    $semanticDangerDarkStrong = shade_color($semanticDangerDark, 0.18);
     $darkInputBg = rgba_string($darkSurfaceAlt, 0.92);
     $darkOnPrimary = contrast_color($primaryLight);
     $darkOnPrimarySoft = rgba_string($darkOnPrimary, 0.22);
@@ -1205,6 +1237,22 @@ function site_theme_tokens(array $cfg): array
         '--status-info-text' => $infoText,
         '--status-info-border' => $infoBorder,
         '--status-info-surface' => $infoSurface,
+        '--semantic-success' => $semanticSuccess,
+        '--semantic-success-soft' => $semanticSuccessSoft,
+        '--semantic-success-text' => $semanticSuccessText,
+        '--semantic-success-border' => $semanticSuccessBorder,
+        '--semantic-success-surface' => $semanticSuccessSurface,
+        '--semantic-warning' => $semanticWarning,
+        '--semantic-warning-soft' => $semanticWarningSoft,
+        '--semantic-warning-text' => $semanticWarningText,
+        '--semantic-warning-border' => $semanticWarningBorder,
+        '--semantic-warning-surface' => $semanticWarningSurface,
+        '--semantic-danger' => $semanticDanger,
+        '--semantic-danger-strong' => $semanticDangerStrong,
+        '--semantic-danger-soft' => $semanticDangerSoft,
+        '--semantic-danger-text' => $semanticDangerText,
+        '--semantic-danger-border' => $semanticDangerBorder,
+        '--semantic-danger-surface' => $semanticDangerSurface,
         '--app-hero-gradient' => $bgGradient,
         '--app-success-gradient' => $successGradient,
     ];
@@ -1300,6 +1348,22 @@ function site_theme_tokens(array $cfg): array
         '--app-text-secondary' => $darkTextSecondary,
         '--app-text-muted' => $darkTextMuted,
         '--app-text-inverse' => $inverseText,
+        '--semantic-success' => $semanticSuccessDark,
+        '--semantic-success-soft' => $semanticSuccessDarkSoft,
+        '--semantic-success-text' => $semanticSuccessDarkText,
+        '--semantic-success-border' => $semanticSuccessDarkBorder,
+        '--semantic-success-surface' => $semanticSuccessDarkSurface,
+        '--semantic-warning' => $semanticWarningDark,
+        '--semantic-warning-soft' => $semanticWarningDarkSoft,
+        '--semantic-warning-text' => $semanticWarningDarkText,
+        '--semantic-warning-border' => $semanticWarningDarkBorder,
+        '--semantic-warning-surface' => $semanticWarningDarkSurface,
+        '--semantic-danger' => $semanticDangerDark,
+        '--semantic-danger-strong' => $semanticDangerDarkStrong,
+        '--semantic-danger-soft' => $semanticDangerDarkSoft,
+        '--semantic-danger-text' => $semanticDangerDarkText,
+        '--semantic-danger-border' => $semanticDangerDarkBorder,
+        '--semantic-danger-surface' => $semanticDangerDarkSurface,
         '--app-table-stripe' => rgba_string($darkText, 0.08),
         '--app-table-border' => $darkDivider,
         '--app-chart-grid' => rgba_string($primaryLight, 0.18),


### PR DESCRIPTION
### Motivation
- Provide fixed "traffic light" semantic colors (danger/warning/success) with light/dark variants so status semantics are consistent across components and themes.
- Replace ad-hoc rgba/status-derived uses with explicit semantic tokens for destructive actions, status chips, and badges to improve accessibility and maintainability.

### Description
- Add fixed semantic base colors and derived values (soft, surface, border, text, strong, and dark variants) in `site_theme_tokens()` in `config.php`, and expose them as CSS variables like `--semantic-danger`, `--semantic-warning`, and `--semantic-success` (plus their soft/strong/dark variants).
- Wire the semantic tokens into the light/dark token sets so components receive appropriate colors per theme in `config.php`.
- Update `assets/css/material.css` to use `--md-danger: var(--semantic-danger)` so material components use the semantic danger token.
- Update `assets/css/styles.css` and `assets/css/questionnaire-builder.css` to use semantic tokens for user status chips, delete/destructive actions, and questionnaire status badges (map Draft→warning, Published→success, Inactive→danger).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ead313b30832d8ef15dc990e248ef)