### PR TITLE
Load canonical helper and normalize staff work function in submit_assessment

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -1,6 +1,9 @@
 <?php
 require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/lib/scoring.php';
+if (!function_exists('canonical')) {
+    require_once __DIR__ . '/lib/work_functions.php';
+}
 auth_required(['staff','supervisor','admin']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);
@@ -14,7 +17,7 @@ $reviewEnabled = (int)($cfg['review_enabled'] ?? 1) === 1;
 $user = current_user();
 try {
     if ($user['role'] === 'staff') {
-        $workFunction = canonical_work_function_key(trim((string)($user['work_function'] ?? '')));
+        $workFunction = canonical(trim((string)($user['work_function'] ?? '')));
         $assigned = [];
 
         if ($workFunction !== '') {


### PR DESCRIPTION
### Motivation
- Staff submissions failed due to an undefined `canonical` function when resolving work function keys, blocking staff from submitting assessments.

### Description
- Add a conditional `require_once __DIR__ . '/lib/work_functions.php'` when `canonical` is not defined and use `canonical(trim(...))` to normalize the staff `work_function` value in `submit_assessment.php`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebeda283c832d9bc7c3710b7ede4f)