### PR TITLE
Fix questionnaire navigation sections

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -311,6 +311,40 @@ if ($qid) {
     $i = $pdo->prepare("SELECT * FROM questionnaire_item WHERE questionnaire_id=? AND is_active=1 ORDER BY order_index ASC");
     $i->execute([$qid]);
     $items = $i->fetchAll();
+    $sectionIds = [];
+    foreach ($sections as $sectionRow) {
+        $sectionId = (int)($sectionRow['id'] ?? 0);
+        if ($sectionId > 0) {
+            $sectionIds[$sectionId] = true;
+        }
+    }
+    $missingSectionIds = [];
+    foreach ($items as $itemRow) {
+        if ($itemRow['section_id'] === null) {
+            continue;
+        }
+        $sectionId = (int)$itemRow['section_id'];
+        if ($sectionId > 0 && !isset($sectionIds[$sectionId])) {
+            $missingSectionIds[$sectionId] = true;
+        }
+    }
+    if ($missingSectionIds) {
+        $placeholders = implode(',', array_fill(0, count($missingSectionIds), '?'));
+        $missingStmt = $pdo->prepare(
+            "SELECT * FROM questionnaire_section WHERE questionnaire_id=? AND id IN ($placeholders) " .
+            "ORDER BY order_index ASC, id ASC"
+        );
+        $missingStmt->execute(array_merge([$qid], array_keys($missingSectionIds)));
+        $sections = array_merge($sections, $missingStmt->fetchAll());
+        usort($sections, static function (array $a, array $b): int {
+            $orderA = (int)($a['order_index'] ?? 0);
+            $orderB = (int)($b['order_index'] ?? 0);
+            if ($orderA === $orderB) {
+                return (int)($a['id'] ?? 0) <=> (int)($b['id'] ?? 0);
+            }
+            return $orderA <=> $orderB;
+        });
+    }
     $itemOptions = [];
     if ($items) {
         $itemIds = array_column($items, 'id');


### PR DESCRIPTION
### Motivation
- The questionnaire navigator could show only the first section because some items referenced section rows that were not returned by the initial `questionnaire_section` query.
- Ensure the navigator lists all sections that have active items so users can access every section during submission.

### Description
- Collect existing section IDs from the initial `SELECT * FROM questionnaire_section ... is_active=1` result and compute any `section_id` values referenced by items that are missing from that set.
- Query the missing section rows with `SELECT * FROM questionnaire_section WHERE questionnaire_id=? AND id IN (...)` and merge them into the `$sections` array when needed.
- Re-sort `$sections` by `order_index` and `id` after merging so ordering remains stable.
- No other behavior changes; anchors and item rendering use the merged `$sections` as before.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec6c8b430832da8dce8b3e1854f36)