### PR TITLE
Fix form grid button height

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1252,6 +1252,8 @@ body.theme-dark .md-field.md-field--compact select {
 .md-form-grid > .md-button {
   justify-self: start;
   align-self: start;
+  height: fit-content;
+  min-height: var(--app-button-height, 48px);
 }
 
 .md-form-grid > .md-form-actions {


### PR DESCRIPTION
### Motivation
- Prevent buttons inside `.md-form-grid` (e.g. the Create button) from stretching vertically and ensure a consistent minimum button height.

### Description
- Add `height: fit-content;` and `min-height: var(--app-button-height, 48px);` to `.md-form-grid > .md-button` in `assets/css/styles.css` to stop vertical stretching while preserving the configured minimum button height.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec844cfec832da4ea232c051f78c6)