### PR TITLE
Limit questionnaires to work-function defaults for non-admin users

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -16,7 +16,7 @@ $reviewEnabled = (int)($cfg['review_enabled'] ?? 1) === 1;
 
 $user = current_user();
 try {
-    if ($user['role'] === 'staff') {
+    if (($user['role'] ?? '') !== 'admin') {
         $workFunction = canonical(trim((string)($user['work_function'] ?? '')));
         $assigned = [];
 


### PR DESCRIPTION
### Motivation
- Fix a bug where all published questionnaires were shown to non-admin users regardless of work-function assignments by ensuring only admins see the full list.

### Description
- Update `submit_assessment.php` to change the availability check from `if ($user['role'] === 'staff')` to `if (($user['role'] ?? '') !== 'admin')`, so both staff and supervisors receive questionnaires filtered by their work function while admins keep access to all published questionnaires.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ecb684dcc832d97b4fee9808cca27)