### PR TITLE
Fix pink warning/draft label colors to follow selected theme

### DIFF
--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -347,9 +347,9 @@ body.md-bg {
 }
 
 .md-alert {
-  background: var(--app-warning-soft));
-  border-left: 4px solid var(--app-warning));
-  color: var(--md-muted);
+  background: var(--status-warning-soft);
+  border-left: 4px solid var(--app-primary-dark);
+  color: var(--app-primary-dark);
   padding: 12px 16px;
   border-radius: 12px;
   margin: 12px 0;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2223,9 +2223,9 @@ body.theme-dark .md-floating-save-draft {
 .md-alert {
   padding: 0.85rem 1rem;
   border-radius: 12px;
-  background: var(--app-warning-soft));
-  color: var(--status-warning-text);
-  border-left: 5px solid var(--app-warning));
+  background: var(--status-warning-soft);
+  color: var(--app-primary-dark);
+  border-left: 5px solid var(--app-primary-dark);
   margin-bottom: 1.1rem;
 }
 
@@ -2242,9 +2242,9 @@ body.theme-dark .md-floating-save-draft {
 }
 
 .md-alert.warning {
-  background: var(--app-warning-soft));
-  color: var(--status-warning-text);
-  border-left-color: var(--app-warning));
+  background: var(--status-warning-soft);
+  color: var(--app-primary-dark);
+  border-left-color: var(--app-primary-dark);
 }
 
 .md-offline-banner {
@@ -2378,9 +2378,17 @@ body.theme-dark .md-offline-draft[data-state="error"] {
 }
 
 .md-draft-list a {
-  color: var(--app-primary);
+  color: var(--app-primary-dark);
   font-weight: 600;
   text-decoration: none;
+}
+
+.md-draft-list a:visited {
+  color: var(--app-primary-dark);
+}
+
+.md-draft-alert strong {
+  color: var(--app-primary-dark);
 }
 
 .md-draft-list a:hover,


### PR DESCRIPTION
### Motivation
- The "Saved drafts awaiting submission:" label and related warning/draft labels displayed a pinkish color because alert styles used the warning color path and malformed CSS variables, which didn't follow the currently selected theme primary dark shade.
- Other draft-related labels and links used the default primary link color that could drift to pink in some theme configurations, so they needed to be aligned to the theme's dark primary shade.

### Description
- Updated shared alert styles to use the semantic token and theme-aware primary dark shade by changing alert backgrounds to `var(--status-warning-soft)` and text/border accents to `var(--app-primary-dark)` in `assets/css/styles.css` and `assets/css/material.css`.
- Fixed malformed CSS variable usages (extra closing parentheses) found in alert rules.
- Made draft list links and visited link states use `var(--app-primary-dark)` and set the draft alert heading (`.md-draft-alert strong`) to `var(--app-primary-dark)` for consistent non-pink labeling.
- Changes applied to `assets/css/styles.css` and `assets/css/material.css` to keep alert/draft styles consistent across pages.

### Testing
- Ran `git diff --check` to verify there are no whitespace or conflict marker issues and it succeeded.
- Launched the PHP development server (`php -S`) and performed a visual check by injecting a sample draft warning on the login page using Playwright, capturing a screenshot to validate the color change successfully.
- Committed the fixes and verified the diff; no automated unit tests were present or run for these styling changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c8f30730832d81da096214519fdd)