### PR TITLE
Fix questionnaire builder title/status persistence and normalization

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -371,6 +371,26 @@ const Builder = (() => {
     render();
   }
 
+  function normalizeStatusValue(value) {
+    const normalized = String(value || '').toLowerCase();
+    return STATUS_OPTIONS.includes(normalized) ? normalized : 'draft';
+  }
+
+  function syncActiveQuestionnaireMetaFromDom() {
+    const active = state.questionnaires.find((q) => q.clientId === state.activeKey);
+    if (!active) return;
+    const card = document.querySelector(`.qb-card[data-q="${active.clientId}"]`);
+    if (!card) return;
+
+    const titleInput = card.querySelector('[data-role="q-title"]');
+    const descriptionInput = card.querySelector('[data-role="q-description"]');
+    const statusInput = card.querySelector('[data-role="q-status"]');
+
+    if (titleInput) active.title = titleInput.value;
+    if (descriptionInput) active.description = descriptionInput.value;
+    if (statusInput) active.status = normalizeStatusValue(statusInput.value);
+  }
+
   function addQuestionnaire() {
     const next = normalizeQuestionnaire({
       title: 'Untitled Questionnaire',
@@ -750,12 +770,13 @@ const Builder = (() => {
         questionnaire.title = event.target.value;
         renderTabs();
         renderSelector();
+        renderSectionNav();
         break;
       case 'q-description':
         questionnaire.description = event.target.value;
         break;
       case 'q-status':
-        questionnaire.status = event.target.value;
+        questionnaire.status = normalizeStatusValue(event.target.value);
         renderTabs();
         renderSelector();
         break;
@@ -1241,6 +1262,7 @@ const Builder = (() => {
 
   function saveAll(publish = false) {
     if (state.saving) return;
+    syncActiveQuestionnaireMetaFromDom();
     state.saving = true;
     toggleSaveButtons();
     renderMessage(publish ? 'Publishing…' : 'Saving…');
@@ -1292,7 +1314,7 @@ const Builder = (() => {
       clientId: questionnaire.clientId,
       title: questionnaire.title,
       description: questionnaire.description,
-      status: questionnaire.status,
+      status: normalizeStatusValue(questionnaire.status),
       sections: questionnaire.sections.map((section, idx) => serializeSection(section, idx + 1)),
       items: questionnaire.items.map((item, idx) => serializeItem(item, idx + 1)),
     };


### PR DESCRIPTION
### Motivation
- The builder sometimes submitted stale or empty `Title`/`Status` values because the active card inputs were not synchronized into state before save/publish.
- Status values from the UI could be invalid or empty when serialized, leading to unexpected server-side behavior.
- The section navigation label did not update immediately when the questionnaire title changed, causing a visible mismatch.

### Description
- Synchronized the active card's metadata (`Title`, `Description`, `Status`) from the DOM into `state.questionnaires` immediately before save/publish via `syncActiveQuestionnaireMetaFromDom()` in `assets/js/questionnaire-builder.js`.
- Added `normalizeStatusValue()` and applied it when handling `q-status` changes and when serializing payloads so status is always one of `draft|published|inactive`.
- Triggered `renderSectionNav()` when the questionnaire `Title` is edited so the nav label updates immediately.
- Minor UI consistency: ensured serialized questionnaire `status` is normalized before sending to the backend.

### Testing
- Static runtime sanity check performed with `node -e "const fs=require('fs'); new Function(fs.readFileSync('assets/js/questionnaire-builder.js','utf8')); console.log('ok')"`, which printed `ok`.
- Manual verified behavior in code reading that `syncActiveQuestionnaireMetaFromDom()` is invoked prior to `saveAll()` and status normalization is applied; no automated unit tests were present for this frontend behavior.
- Additional issue observed during review: root-level items (the "Items without section" list) are rendered under `data-role="root-items"` but the sortable binding only targets containers with `data-role="items"`, so drag-and-drop reordering currently excludes root-level items. Please consider addressing this in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d082b988832dbf42a29d3b17211b)