### PR TITLE
Follow-up: restore success/error alert theming after warning style fix

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2230,15 +2230,15 @@ body.theme-dark .md-floating-save-draft {
 }
 
 .md-alert.success {
-  background: var(--app-secondary-soft));
+  background: var(--app-secondary-soft);
   color: var(--app-primary-dark);
   border-left-color: var(--app-secondary);
 }
 
 .md-alert.error {
-  background: var(--app-danger-soft));
+  background: var(--app-danger-soft);
   color: var(--status-danger-text);
-  border-left-color: var(--app-danger));
+  border-left-color: var(--app-danger);
 }
 
 .md-alert.warning {
@@ -2459,19 +2459,19 @@ body.theme-dark .md-field textarea:focus {
 }
 
 body.theme-dark .md-alert {
-  background: var(--app-secondary-soft));
+  background: var(--app-secondary-soft);
   color: var(--app-surface-highlight);
   border-left-color: var(--app-secondary);
 }
 
 body.theme-dark .md-alert.error {
-  background: var(--app-danger-soft));
+  background: var(--app-danger-soft);
   color: var(--status-danger-surface);
-  border-left-color: var(--app-danger));
+  border-left-color: var(--app-danger);
 }
 
 body.theme-dark .md-alert.success {
-  background: var(--app-secondary-soft));
+  background: var(--app-secondary-soft);
   color: var(--app-surface-highlight);
 }
 


### PR DESCRIPTION
### Motivation
- Correct a high-priority regression where `.md-alert.success` and `.md-alert.error` fell back to the base warning styling because their CSS variable declarations were malformed.
- Ensure alert variants continue to follow the selected theme and render correct success/error colors rather than inheriting the warning color.

### Description
- Fixed malformed CSS variable syntax (extra `)`) in `assets/css/styles.css` for `.md-alert.success`, `.md-alert.error`, and the `body.theme-dark` alert overrides so their `background` and `border-left-color` declarations parse correctly.
- Restored intended cascade behavior so variant rules properly override the base `.md-alert` warning styles and preserve theme-aware tokens like `var(--app-secondary-soft)` and `var(--app-danger-soft)`.

### Testing
- Ran `git diff --check` to confirm there are no whitespace or diff errors and it completed successfully.
- Launched a local PHP dev server (`php -S`) and used a Playwright script to inject `warning`, `success`, and `error` alert samples and capture a screenshot to visually verify the colors rendered as expected.
- Verified the CSS file changes parse and the visual verification confirmed success/error alerts no longer inherit the warning styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984d360d110832d8a5ff78232497078)