### PR TITLE
Auto-weight single-choice now requires 'correct answer' and updates UI label

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1028,6 +1028,7 @@ const Builder = (() => {
     const items = collectItems(questionnaire);
     const scorable = items.filter((item) => isScorable(item.type));
     const singleChoiceItems = scorable.filter((item) => item.type === 'choice' && !item.allow_multiple);
+    const singleChoiceWithCorrectItems = singleChoiceItems.filter((item) => item.requires_correct);
     const likertItems = scorable.filter((item) => item.type === 'likert');
     const manualTotal = scorable.reduce((sum, item) => sum + (Number(item.weight_percent) || 0), 0);
     let effectiveTotal = manualTotal;
@@ -1055,6 +1056,7 @@ const Builder = (() => {
       scorableCount: scorable.length,
       weightedCount,
       hasSingleChoice: singleChoiceItems.length > 0,
+      singleChoiceWithCorrectCount: singleChoiceWithCorrectItems.length,
       hasLikert: likertItems.length > 0,
       canNormalize: manualTotal > 0 && manualTotal !== 100,
       canDistribute: scorable.length > 0,
@@ -1076,7 +1078,11 @@ const Builder = (() => {
     const actions = [
       { role: 'normalize-weights', label: STRINGS.normalizeWeights, enabled: summary.canNormalize },
       { role: 'even-weights', label: STRINGS.evenWeights, enabled: summary.canDistribute },
-      { role: 'single-choice-weights', label: 'Auto-weight single-choice', enabled: summary.scorableCount > 0 },
+      {
+        role: 'single-choice-weights',
+        label: 'Auto-weight single-choice with correct answer',
+        enabled: summary.singleChoiceWithCorrectCount > 0,
+      },
       { role: 'clear-weights', label: STRINGS.clearWeights, enabled: summary.canClear },
     ]
       .map(
@@ -1128,8 +1134,7 @@ const Builder = (() => {
 
   function autoWeightSingleChoice(questionnaire) {
     const items = collectItems(questionnaire);
-    const singleChoiceItems = items.filter((item) => item.type === 'choice' && !item.allow_multiple);
-    const targetItems = singleChoiceItems.length > 0 ? singleChoiceItems : items.filter((item) => item.type === 'likert');
+    const targetItems = items.filter((item) => item.type === 'choice' && !item.allow_multiple && item.requires_correct);
     if (targetItems.length === 0) return renderMessage(STRINGS.evenNoop);
     const weight = (100 / targetItems.length).toFixed(2);
     targetItems.forEach((item) => {


### PR DESCRIPTION
### Motivation
- Make the auto-weight action only apply to single-choice questions that are configured with a correct answer requirement, and make the UI clearer by reflecting that requirement in the action label.

### Description
- Track single-choice items that have `requires_correct` enabled by adding `singleChoiceWithCorrectCount` in `computeScoring` in `assets/js/questionnaire-builder.js`.
- Change the scoring action label from `"Auto-weight single-choice"` to `"Auto-weight single-choice with correct answer"` and enable the action only when `summary.singleChoiceWithCorrectCount > 0`.
- Update `autoWeightSingleChoice` to distribute weights only across single-choice items where `item.requires_correct` is true instead of falling back to all single-choice or likert items.

### Testing
- Ran `php tests/questionnaire_scoring_test.php` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984de7abce4832dbec89d7813887a74)