### PR TITLE
Fix work function defaults save for custom work functions

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -513,7 +513,17 @@ function normalize_work_function_assignments(array $input, array $allowedWorkFun
     $normalized = [];
 
     foreach ($input as $workFunction => $ids) {
-        $canonical = canonical_work_function_key((string)$workFunction);
+        $rawWorkFunction = trim((string)$workFunction);
+        if ($rawWorkFunction === '') {
+            continue;
+        }
+
+        if (isset($allowedWorkFunctionSet[$rawWorkFunction])) {
+            $canonical = $rawWorkFunction;
+        } else {
+            $canonical = canonical_work_function_key($rawWorkFunction);
+        }
+
         if ($canonical === '' || !isset($allowedWorkFunctionSet[$canonical])) {
             continue;
         }

--- a/tests/work_function_assignments_test.php
+++ b/tests/work_function_assignments_test.php
@@ -157,4 +157,20 @@ if (work_function_label($pdo, '') !== '') {
     exit(1);
 }
 
+
+$normalizedCustom = normalize_work_function_assignments(
+    [
+        'Rapid Response Team' => [1],
+    ],
+    ['rapid_response_team'],
+    [1, 2]
+);
+
+if ($normalizedCustom !== [
+    'rapid_response_team' => [1],
+]) {
+    fwrite(STDERR, "Normalization should accept catalog slugs generated from labels.\n");
+    exit(1);
+}
+
 echo "Work function assignment tests passed.\n";


### PR DESCRIPTION
### Motivation
- Admin selections for newer or custom work functions could be dropped when saving because page-specific canonicalization failed to recognize explicit catalog slugs.  The change restores correct handling so selections persist for custom entries.

### Description
- Preserve explicit catalog slugs during normalization by checking the raw input against allowed slugs before falling back to canonicalization in `normalize_work_function_assignments` (`lib/work_functions.php`).
- Replace duplicated normalization and save logic in `admin/work_function_defaults.php` with shared helpers by calling `normalize_work_function_assignments` and `save_work_function_assignments` for consistent behavior.
- Add a regression check to `tests/work_function_assignments_test.php` to ensure label-style input (e.g. `Rapid Response Team`) resolves to the expected generated slug (`rapid_response_team`).
- Small refactor to reduce transaction duplication and centralize persistence logic in `save_work_function_assignments` (`lib/work_functions.php`).

### Testing
- Syntax checks: `php -l admin/work_function_defaults.php`, `php -l lib/work_functions.php`, and `php -l tests/work_function_assignments_test.php` all succeeded.
- Runtime helper check: `php -r 'require "lib/work_functions.php"; $out = normalize_work_function_assignments(["Rapid Response Team"=>[1]], ["rapid_response_team"], [1,2]); var_export($out);'` produced the expected normalized output.
- Running the full `php tests/work_function_assignments_test.php` in this environment failed due to a pre-existing undefined `work_function_label()` in the test harness; this failure is unrelated to the save/normalization fixes implemented here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698519c024b8832dab78d9dbd1c4c50c)