### PR TITLE
Add scripts to purge questionnaires and seed dummy submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ while keeping at least English or French active. To add a language:
 - `init.sql` – bootstrap schema.
 - `migration.sql` – incremental changes when upgrading existing databases.
 - `dummy_data.sql` – optional demo users and responses. Remove with `dummy_data_cleanup.sql` if needed.
+- `scripts/purge_questionnaires_and_submissions.php --yes` – removes all questionnaires and linked submissions.
+- `scripts/seed_dummy_data_from_questionnaires.php` – creates dummy users/responses based on existing questionnaires.
 
 ### Data Export
 

--- a/scripts/purge_questionnaires_and_submissions.php
+++ b/scripts/purge_questionnaires_and_submissions.php
@@ -1,0 +1,64 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * Delete all questionnaires and every submission linked to them.
+ *
+ * Usage:
+ *   php scripts/purge_questionnaires_and_submissions.php [--yes]
+ */
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script can only be run from CLI." . PHP_EOL);
+    exit(1);
+}
+
+define('APP_BOOTSTRAPPED', true);
+require_once __DIR__ . '/../config.php';
+
+$confirmed = in_array('--yes', $argv, true);
+if (!$confirmed) {
+    fwrite(STDOUT, "This will permanently delete all questionnaires and related submissions." . PHP_EOL);
+    fwrite(STDOUT, "Re-run with --yes to confirm." . PHP_EOL);
+    exit(1);
+}
+
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+$counts = [
+    'questionnaire' => (int)($pdo->query('SELECT COUNT(*) FROM questionnaire')->fetchColumn() ?: 0),
+    'questionnaire_response' => (int)($pdo->query('SELECT COUNT(*) FROM questionnaire_response')->fetchColumn() ?: 0),
+    'questionnaire_response_item' => (int)($pdo->query('SELECT COUNT(*) FROM questionnaire_response_item')->fetchColumn() ?: 0),
+    'training_recommendation' => (int)($pdo->query('SELECT COUNT(*) FROM training_recommendation')->fetchColumn() ?: 0),
+    'questionnaire_assignment' => (int)($pdo->query('SELECT COUNT(*) FROM questionnaire_assignment')->fetchColumn() ?: 0),
+];
+
+$pdo->beginTransaction();
+try {
+    // Remove dependent records first so reporting and assignment tables are fully reset.
+    $pdo->exec('DELETE FROM training_recommendation');
+    $pdo->exec('DELETE FROM questionnaire_response_item');
+    $pdo->exec('DELETE FROM questionnaire_response');
+    $pdo->exec('DELETE FROM questionnaire_assignment');
+    $pdo->exec('DELETE FROM questionnaire_work_function');
+    $pdo->exec('DELETE FROM questionnaire_item_option');
+    $pdo->exec('DELETE FROM questionnaire_item');
+    $pdo->exec('DELETE FROM questionnaire_section');
+    $pdo->exec('DELETE FROM questionnaire');
+
+    // Reset schedules that were scoped to removed questionnaires.
+    $pdo->exec('UPDATE analytics_report_schedule SET questionnaire_id = NULL WHERE questionnaire_id IS NOT NULL');
+
+    $pdo->commit();
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    fwrite(STDERR, 'Failed to purge questionnaires/submissions: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}
+
+fwrite(STDOUT, 'Purge complete.' . PHP_EOL);
+foreach ($counts as $table => $count) {
+    fwrite(STDOUT, sprintf(' - %s rows before purge: %d', $table, $count) . PHP_EOL);
+}

--- a/scripts/seed_dummy_data_from_questionnaires.php
+++ b/scripts/seed_dummy_data_from_questionnaires.php
@@ -1,0 +1,236 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types=1);
+
+/**
+ * Seed dummy users, questionnaire assignments, and submissions using existing questionnaires.
+ *
+ * Usage:
+ *   php scripts/seed_dummy_data_from_questionnaires.php
+ */
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script can only be run from CLI." . PHP_EOL);
+    exit(1);
+}
+
+define('APP_BOOTSTRAPPED', true);
+require_once __DIR__ . '/../config.php';
+
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function load_questionnaires(PDO $pdo): array
+{
+    $stmt = $pdo->query(
+        "SELECT q.id, q.title, q.status, COUNT(qi.id) AS item_count\n" .
+        "FROM questionnaire q\n" .
+        "LEFT JOIN questionnaire_item qi ON qi.questionnaire_id = q.id AND qi.is_active = 1\n" .
+        "GROUP BY q.id, q.title, q.status\n" .
+        "HAVING item_count > 0\n" .
+        "ORDER BY FIELD(q.status, 'published', 'draft', 'inactive'), q.id"
+    );
+
+    return $stmt->fetchAll() ?: [];
+}
+
+/**
+ * @return array<int, int>
+ */
+function ensure_dummy_users(PDO $pdo): array
+{
+    $passwordHash = password_hash('DummyPass#2025', PASSWORD_DEFAULT);
+    $users = [
+        ['dummy_supervisor', 'supervisor', 'Dummy Supervisor', 'dummy.supervisor@example.com', 'leadership_tn'],
+        ['dummy_staff_finance', 'staff', 'Dummy Finance Staff', 'dummy.finance@example.com', 'finance'],
+        ['dummy_staff_hr', 'staff', 'Dummy HR Staff', 'dummy.hr@example.com', 'hrm'],
+        ['dummy_staff_ict', 'staff', 'Dummy ICT Staff', 'dummy.ict@example.com', 'ict'],
+        ['dummy_staff_ops', 'staff', 'Dummy Operations Staff', 'dummy.ops@example.com', 'general_service'],
+    ];
+
+    $selectStmt = $pdo->prepare('SELECT id FROM users WHERE username = ? LIMIT 1');
+    $insertStmt = $pdo->prepare(
+        'INSERT INTO users (username, password, role, full_name, email, work_function, account_status, profile_completed, must_reset_password, language) ' .
+        'VALUES (?, ?, ?, ?, ?, ?, "active", 1, 1, "en")'
+    );
+
+    $ids = [];
+    foreach ($users as [$username, $role, $fullName, $email, $workFunction]) {
+        $selectStmt->execute([$username]);
+        $existing = $selectStmt->fetchColumn();
+        if ($existing !== false) {
+            $ids[] = (int)$existing;
+            continue;
+        }
+
+        $insertStmt->execute([$username, $passwordHash, $role, $fullName, $email, $workFunction]);
+        $ids[] = (int)$pdo->lastInsertId();
+    }
+
+    return $ids;
+}
+
+function ensure_current_performance_period(PDO $pdo): int
+{
+    $year = (int)date('Y');
+    $month = (int)date('n');
+    $half = $month <= 6 ? 'H1' : 'H2';
+    $label = sprintf('%d %s', $year, $half);
+    $start = $half === 'H1' ? sprintf('%d-01-01', $year) : sprintf('%d-07-01', $year);
+    $end = $half === 'H1' ? sprintf('%d-06-30', $year) : sprintf('%d-12-31', $year);
+
+    $insert = $pdo->prepare(
+        'INSERT INTO performance_period (label, period_start, period_end) VALUES (?, ?, ?) ' .
+        'ON DUPLICATE KEY UPDATE period_start = VALUES(period_start), period_end = VALUES(period_end)'
+    );
+    $insert->execute([$label, $start, $end]);
+
+    $select = $pdo->prepare('SELECT id FROM performance_period WHERE label = ? LIMIT 1');
+    $select->execute([$label]);
+    return (int)$select->fetchColumn();
+}
+
+/**
+ * @param array<string, mixed> $item
+ * @param list<string> $options
+ * @return array<int, array<string, mixed>>
+ */
+function build_answer_payload(array $item, array $options): array
+{
+    $type = (string)($item['type'] ?? 'text');
+    if ($type === 'boolean') {
+        return [['valueBoolean' => (bool)random_int(0, 1)]];
+    }
+    if ($type === 'likert') {
+        $score = random_int(3, 5);
+        return [['valueInteger' => $score]];
+    }
+    if ($type === 'choice') {
+        if (!$options) {
+            return [['valueString' => 'N/A']];
+        }
+        shuffle($options);
+        $allowMultiple = (int)($item['allow_multiple'] ?? 0) === 1;
+        if ($allowMultiple) {
+            $take = random_int(1, min(2, count($options)));
+            $picked = array_slice($options, 0, $take);
+            return array_map(static fn(string $value): array => ['valueString' => $value], $picked);
+        }
+        return [['valueString' => $options[0]]];
+    }
+
+    $sentences = [
+        'Demonstrated consistent delivery against planned priorities.',
+        'Collaborated across teams to improve service quality outcomes.',
+        'Documented lessons learned and proposed targeted improvements.',
+        'Maintained strong compliance while meeting cycle deliverables.',
+    ];
+    return [['valueString' => $sentences[array_rand($sentences)]]];
+}
+
+$questionnaires = load_questionnaires($pdo);
+if (!$questionnaires) {
+    fwrite(STDERR, "No questionnaires with active items were found. Nothing to seed." . PHP_EOL);
+    exit(1);
+}
+
+$pdo->beginTransaction();
+try {
+    $userIds = ensure_dummy_users($pdo);
+    $staffIds = [];
+    $supervisorId = 0;
+    foreach ($userIds as $id) {
+        $roleStmt = $pdo->prepare('SELECT role FROM users WHERE id = ? LIMIT 1');
+        $roleStmt->execute([$id]);
+        $role = (string)$roleStmt->fetchColumn();
+        if ($role === 'supervisor') {
+            $supervisorId = $id;
+        }
+        if ($role === 'staff') {
+            $staffIds[] = $id;
+        }
+    }
+
+    $periodId = ensure_current_performance_period($pdo);
+
+    $cleanupResponses = $pdo->prepare(
+        'DELETE FROM questionnaire_response WHERE user_id IN (SELECT id FROM users WHERE username LIKE "dummy_%")'
+    );
+    $cleanupAssignments = $pdo->prepare(
+        'DELETE FROM questionnaire_assignment WHERE staff_id IN (SELECT id FROM users WHERE username LIKE "dummy_%")'
+    );
+    $cleanupResponses->execute();
+    $cleanupAssignments->execute();
+
+    $itemStmt = $pdo->prepare(
+        'SELECT id, linkId, type, allow_multiple FROM questionnaire_item WHERE questionnaire_id = ? AND is_active = 1 ORDER BY order_index, id'
+    );
+    $optionStmt = $pdo->prepare(
+        'SELECT value FROM questionnaire_item_option WHERE questionnaire_item_id = ? ORDER BY order_index, id'
+    );
+
+    $insertAssignment = $pdo->prepare(
+        'INSERT INTO questionnaire_assignment (staff_id, questionnaire_id, assigned_by, assigned_at) VALUES (?, ?, ?, NOW())'
+    );
+    $insertResponse = $pdo->prepare(
+        'INSERT INTO questionnaire_response (user_id, questionnaire_id, performance_period_id, status, score, reviewed_by, reviewed_at, review_comment, created_at) ' .
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())'
+    );
+    $insertResponseItem = $pdo->prepare(
+        'INSERT INTO questionnaire_response_item (response_id, linkId, answer) VALUES (?, ?, ?)'
+    );
+
+    $responsesCreated = 0;
+
+    foreach ($questionnaires as $questionnaire) {
+        $qid = (int)$questionnaire['id'];
+        $itemStmt->execute([$qid]);
+        $items = $itemStmt->fetchAll() ?: [];
+        if (!$items) {
+            continue;
+        }
+
+        foreach ($staffIds as $staffId) {
+            $insertAssignment->execute([$staffId, $qid, $supervisorId > 0 ? $supervisorId : null]);
+
+            $status = random_int(0, 10) > 2 ? 'submitted' : 'approved';
+            $score = random_int(68, 96);
+            $reviewedAt = $status === 'approved' ? date('Y-m-d H:i:s') : null;
+            $reviewComment = $status === 'approved' ? 'Reviewed dummy submission for seed data.' : null;
+
+            $insertResponse->execute([
+                $staffId,
+                $qid,
+                $periodId,
+                $status,
+                $score,
+                $status === 'approved' ? ($supervisorId > 0 ? $supervisorId : null) : null,
+                $reviewedAt,
+                $reviewComment,
+            ]);
+            $responseId = (int)$pdo->lastInsertId();
+
+            foreach ($items as $item) {
+                $optionStmt->execute([(int)$item['id']]);
+                $options = array_map(static fn(array $row): string => (string)$row['value'], $optionStmt->fetchAll() ?: []);
+                $payload = build_answer_payload($item, $options);
+                $insertResponseItem->execute([
+                    $responseId,
+                    (string)$item['linkId'],
+                    json_encode($payload),
+                ]);
+            }
+            $responsesCreated++;
+        }
+    }
+
+    $pdo->commit();
+    fwrite(STDOUT, sprintf('Seed complete. Questionnaires processed: %d, responses created: %d', count($questionnaires), $responsesCreated) . PHP_EOL);
+} catch (Throwable $e) {
+    $pdo->rollBack();
+    fwrite(STDERR, 'Failed to seed dummy data: ' . $e->getMessage() . PHP_EOL);
+    exit(1);
+}


### PR DESCRIPTION
### Motivation
- Provide safe, CLI-maintainable ways to reset questionnaire-related data and to generate realistic demo submissions for development or QA environments.

### Description
- Add `scripts/purge_questionnaires_and_submissions.php` which requires `--yes` and deletes questionnaires and dependent records (responses, response items, assignments, work-function mappings, items/options/sections) and nulls `analytics_report_schedule.questionnaire_id` while printing pre-purge row counts.
- Add `scripts/seed_dummy_data_from_questionnaires.php` which discovers existing questionnaires with active items, ensures a small set of `dummy_` users, ensures the current performance period exists, clears prior `dummy_%` responses/assignments, and creates assignments, responses and per-item answer payloads (`boolean`, `likert`, `choice`, text) to produce realistic seed data.
- Document both scripts in `README.md` under the database/migrations & data section and make the scripts executable.

### Testing
- Ran PHP linting with `php -l scripts/purge_questionnaires_and_submissions.php` which returned no syntax errors.
- Ran PHP linting with `php -l scripts/seed_dummy_data_from_questionnaires.php` which returned no syntax errors.
- Executed file permission updates to make both scripts executable and validated the README update was applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851e4858ec832dbc38cf35f23560df)