### PR TITLE
Align index page color styling with login theme

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -2,17 +2,14 @@
   --landing-primary: var(--app-primary, #0d63d9);
   --landing-primary-dark: var(--app-primary-dark, #0c4fb0);
   --landing-primary-darker: var(--app-primary-darker, #083575);
-  --landing-accent: var(--app-secondary, #ff8a3d);
+  --landing-accent: #2ba7ff;
   --landing-surface: var(--app-surface, #ffffff);
-  --landing-surface-muted: var(--app-surface-muted, #f3f6fb);
+  --landing-surface-muted: #f8fafc;
   --landing-muted: var(--app-text-muted, #4b5a6b);
-  --landing-background: var(
-    --app-hero-gradient,
-    linear-gradient(
-      135deg,
-      var(--landing-primary) 0%,
-      color-mix(in srgb, var(--landing-primary) 70%, #2ba7ff 30%) 100%
-    )
+  --landing-background: linear-gradient(
+    135deg,
+    var(--landing-primary) 0%,
+    color-mix(in srgb, var(--landing-primary) 70%, #2ba7ff 30%) 100%
   );
   --landing-radius-lg: 28px;
   --landing-radius-md: 18px;
@@ -27,7 +24,7 @@ body.landing-body {
   min-height: 100vh;
   font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--app-text-primary, #0f1c31);
-  background: var(--app-bg, #f3f6fb);
+  background: linear-gradient(135deg, #f4f7fb 0%, #eaf0f7 100%);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -45,6 +42,8 @@ body.landing-body {
   justify-content: center;
   padding: clamp(3.5rem, 7vw, 6.5rem) clamp(1.75rem, 6vw, 4.5rem);
   background: var(--landing-background);
+  border-radius: 0 0 28px 28px;
+  box-shadow: 0 14px 60px rgba(15, 27, 56, 0.16);
   overflow: hidden;
   align-items: center;
 }
@@ -91,7 +90,7 @@ body.landing-body {
 
 .landing-hero__content {
   max-width: 780px;
-  color: #e8edf7;
+  color: #f7fbff;
 }
 
 .landing-hero__highlights {
@@ -108,15 +107,15 @@ body.landing-body {
   gap: 0.85rem;
   font-size: 1rem;
   line-height: 1.6;
-  color: rgba(233, 238, 250, 0.95);
+  color: rgba(247, 251, 255, 0.95);
 }
 
 .landing-hero__bullet {
   width: 0.9rem;
   height: 0.9rem;
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--landing-accent) 70%, #ffffff 30%);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--landing-accent) 30%, transparent);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.18);
   flex-shrink: 0;
   margin-top: 0.35rem;
 }
@@ -128,7 +127,7 @@ body.landing-body {
   padding: 0.4rem 0.85rem;
   margin-bottom: 1.75rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.12);
   backdrop-filter: blur(12px);
   box-shadow: var(--landing-shadow-sm);
 }
@@ -159,7 +158,7 @@ body.landing-body {
   margin: 0;
   font-size: 1.125rem;
   line-height: 1.7;
-  color: rgba(226, 233, 245, 0.92);
+  color: rgba(247, 251, 255, 0.92);
 }
 
 .landing-hero__summary {
@@ -235,7 +234,7 @@ body.landing-body {
 
 .landing-main {
   flex: 1;
-  background: var(--landing-surface-muted);
+  background: transparent;
   padding: clamp(3.25rem, 6vw, 5.25rem) 0;
 }
 
@@ -350,8 +349,8 @@ body.landing-body {
 
 .landing-footer {
   padding: clamp(2.5rem, 5vw, 3.5rem);
-  background: #0c162b;
-  color: rgba(255, 255, 255, 0.86);
+  background: #ffffff;
+  color: #4f5b66;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 1.75rem;
@@ -360,7 +359,7 @@ body.landing-body {
 .landing-footer__contact strong {
   display: inline-block;
   min-width: 5.5rem;
-  color: #ffffff;
+  color: #1d2939;
 }
 
 .landing-footer__meta {
@@ -371,7 +370,7 @@ body.landing-body {
 }
 
 .landing-footer__languages a {
-  color: #ffffff;
+  color: var(--landing-primary);
   text-decoration: none;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -383,7 +382,7 @@ body.landing-body {
 }
 
 .landing-footer__secondary-link a {
-  color: rgba(255, 255, 255, 0.82);
+  color: #4f5b66;
   text-decoration: none;
   font-weight: 500;
 }


### PR DESCRIPTION
### Motivation
- Make the landing/index page visually consistent with the login experience by reusing the same blue-forward color direction and light background treatment. 
- Improve contrast and cohesion for hero text, accents and glass surfaces so the site has a single cohesive brand presentation. 
- Replace the previous dark footer with a light panel style to match the login page aesthetic and improve readability.

### Description
- Updated `assets/css/landing.css` variables to align with the login palette (`--landing-accent`, `--landing-surface-muted`, and `--landing-background`) and simplified the hero gradient behavior. 
- Restyled hero visuals including hero container depth, hero text color, hero bullet shape/appearance, brand chip background, and added rounded hero edges/box-shadow to match the login tile. 
- Adjusted page and main backgrounds and switched the footer from a dark theme to a light surface with updated text and link colors for consistent contrast.

### Testing
- Ran `php -l index.php` which reported no syntax errors. 
- Ran `php -l login.php` which reported no syntax errors. 
- Launched a local dev server and captured an automated Playwright screenshot to validate the updated landing styling at `browser:/tmp/codex_browser_invocations/a0f1ad5c4807bc2e/artifacts/artifacts/index-landing-style.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698527f73898832d92e9a986f43d5554)