### PR TITLE
Render language switcher flags as full circular icons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -558,6 +558,7 @@ button,
   height: var(--app-button-height);
   border-radius: 50%;
   font-size: 1.1rem;
+  line-height: 0;
   background: var(--app-on-primary-subtle);
   overflow: hidden;
 }
@@ -570,9 +571,12 @@ button,
 .md-appbar-link.md-appbar-language .md-appbar-flag {
   width: 100%;
   height: 100%;
+  min-width: 100%;
+  min-height: 100%;
   border-radius: 50%;
   display: block;
   object-fit: cover;
+  transform: scale(1.04);
 }
 
 .md-lang-switch a {

--- a/assets/images/flags/flag-am.svg
+++ b/assets/images/flags/flag-am.svg
@@ -1,14 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Amharic">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Ethiopian flag">
   <defs>
-    <clipPath id="circle">
+    <clipPath id="am-circle-clip">
       <circle cx="32" cy="32" r="32" />
     </clipPath>
   </defs>
-  <g clip-path="url(#circle)">
+  <g clip-path="url(#am-circle-clip)">
     <rect width="64" height="64" fill="#FCDD09" />
-    <rect width="64" height="21.34" y="0" fill="#078930" />
-    <rect width="64" height="21.34" y="42.66" fill="#DA121A" />
+    <rect width="64" height="21.33" y="0" fill="#078930" />
+    <rect width="64" height="21.33" y="42.67" fill="#DA121A" />
     <circle cx="32" cy="32" r="14" fill="#0F47AF" />
-    <path d="M32 22.5 L34.6 29.2 L41.8 29.2 L36 33.4 L38.2 40.5 L32 36.6 L25.8 40.5 L28 33.4 L22.2 29.2 L29.4 29.2 Z" fill="#FCDD09" />
+    <path d="M32 22.5L34.6 29.2H41.8L36 33.4L38.2 40.5L32 36.6L25.8 40.5L28 33.4L22.2 29.2H29.4Z" fill="#FCDD09" />
   </g>
 </svg>

--- a/assets/images/flags/flag-en.svg
+++ b/assets/images/flags/flag-en.svg
@@ -1,15 +1,15 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="English">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="United Kingdom flag">
   <defs>
-    <clipPath id="circle">
+    <clipPath id="en-circle-clip">
       <circle cx="32" cy="32" r="32" />
     </clipPath>
   </defs>
-  <g clip-path="url(#circle)">
+  <g clip-path="url(#en-circle-clip)">
     <rect width="64" height="64" fill="#012169" />
-    <path d="M0 0 L0 8 L56 64 L64 64 L64 56 L8 0 Z" fill="#FFFFFF" />
-    <path d="M64 0 L56 0 L0 56 L0 64 L8 64 L64 8 Z" fill="#FFFFFF" />
-    <path d="M0 0 L0 5 L59 64 L64 64 L64 59 L5 0 Z" fill="#C8102E" />
-    <path d="M64 0 L59 0 L0 59 L0 64 L5 64 L64 5 Z" fill="#C8102E" />
+    <path d="M0 0V8L56 64H64V56L8 0Z" fill="#FFFFFF" />
+    <path d="M64 0H56L0 56V64H8L64 8Z" fill="#FFFFFF" />
+    <path d="M0 0V5L59 64H64V59L5 0Z" fill="#C8102E" />
+    <path d="M64 0H59L0 59V64H5L64 5Z" fill="#C8102E" />
     <rect x="0" y="26" width="64" height="12" fill="#FFFFFF" />
     <rect x="26" y="0" width="12" height="64" fill="#FFFFFF" />
     <rect x="0" y="29" width="64" height="6" fill="#C8102E" />

--- a/assets/images/flags/flag-fr.svg
+++ b/assets/images/flags/flag-fr.svg
@@ -1,12 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="French">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="French flag">
   <defs>
-    <clipPath id="circle">
+    <clipPath id="fr-circle-clip">
       <circle cx="32" cy="32" r="32" />
     </clipPath>
   </defs>
-  <g clip-path="url(#circle)">
+  <g clip-path="url(#fr-circle-clip)">
     <rect width="64" height="64" fill="#FFFFFF" />
-    <rect width="21.4" height="64" x="0" y="0" fill="#0055A4" />
-    <rect width="21.4" height="64" x="42.6" y="0" fill="#EF4135" />
+    <rect width="21.33" height="64" x="0" y="0" fill="#0055A4" />
+    <rect width="21.33" height="64" x="42.67" y="0" fill="#EF4135" />
   </g>
 </svg>


### PR DESCRIPTION
### Motivation
- The language button's flag artwork was not perfectly round and left visible gaps inside the circular button, producing a visual glitch in the app header.
- No external skill was required; changes are direct edits to the CSS and SVG assets to ensure the flags render as properly clipped circular icons.

### Description
- Tightened language button CSS by adding `line-height: 0`, `min-width: 100%`, `min-height: 100%`, and `transform: scale(1.04)` so flag images fully cover the circular container without gaps.
- Updated the three locale SVGs to use locale-specific `clipPath` IDs, adjusted slice dimensions and `aria-label`s, and ensured each SVG is clipped to a full circle for consistent rendering.
- Preserved `object-fit: cover` and `border-radius: 50%` so the fix is robust across button sizes and device pixel ratios.

### Testing
- Started the built-in PHP server with `php -S 0.0.0.0:8080`, which launched successfully but application requests returned HTTP 500 due to missing database connectivity in this environment.
- Ran a Playwright screenshot script against `/login.php`, which completed and produced a screenshot artifact, however the page rendered an HTTP 500 error because the test environment lacked DB access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698535c254f8832d8528e27b3db2e4eb)