### PR TITLE
Avoid false save errors when no DB transaction is active

### DIFF
--- a/tests/work_function_assignments_test.php
+++ b/tests/work_function_assignments_test.php
@@ -157,4 +157,20 @@ if (work_function_label($pdo, '') !== '') {
     exit(1);
 }
 
+
+$normalizedCustom = normalize_work_function_assignments(
+    [
+        'Rapid Response Team' => [1],
+    ],
+    ['rapid_response_team'],
+    [1, 2]
+);
+
+if ($normalizedCustom !== [
+    'rapid_response_team' => [1],
+]) {
+    fwrite(STDERR, "Normalization should accept catalog slugs generated from labels.\n");
+    exit(1);
+}
+
 echo "Work function assignment tests passed.\n";


### PR DESCRIPTION
### Motivation
- The UI could show a misleading "Unable to save work function defaults" error when persistence actually succeeded because transaction API calls threw in environments where a transaction was not started or unavailable. 
- The change ensures the save helper does not surface spurious failures caused by calling `commit()`/`rollBack()` when no transaction was active.

### Description
- Add a `transactionStarted` flag and wrap `beginTransaction()` in a `try/catch` to detect whether a transaction was actually initiated in `save_work_function_assignments`.
- Only call `commit()` if `transactionStarted` is true and `PDO::inTransaction()` returns true.
- Only call `rollBack()` if `transactionStarted` is true and `PDO::inTransaction()` returns true.

### Testing
- Ran `php -l lib/work_functions.php` which reported no syntax errors.
- Ran `php -l admin/work_function_defaults.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698519c024b8832dab78d9dbd1c4c50c)