### PR TITLE
Fix questionnaire builder boolean parsing & description edit; normalize work-function assignments and safe DB transactions

### DIFF
--- a/tests/work_function_assignments_test.php
+++ b/tests/work_function_assignments_test.php
@@ -157,4 +157,20 @@ if (work_function_label($pdo, '') !== '') {
     exit(1);
 }
 
+
+$normalizedCustom = normalize_work_function_assignments(
+    [
+        'Rapid Response Team' => [1],
+    ],
+    ['rapid_response_team'],
+    [1, 2]
+);
+
+if ($normalizedCustom !== [
+    'rapid_response_team' => [1],
+]) {
+    fwrite(STDERR, "Normalization should accept catalog slugs generated from labels.\n");
+    exit(1);
+}
+
 echo "Work function assignment tests passed.\n";


### PR DESCRIPTION
### Motivation
- Restore correct builder behavior where simple edits (description) and active toggles were being mis-handled due to a switch-branch regression and unsafe boolean coercion. 
- Harden work-function assignment handling and persistence to avoid invalid input acceptance and spurious transaction errors.

### Description
- Fix `q-description` handling in `assets/js/questionnaire-builder.js` so description edits update `questionnaire.description` instead of falling through to the status branch. 
- Add a robust `toBoolean()` helper and replace unsafe `Boolean(...)` / `value !== false` checks across questionnaire/section/item/option normalization in `assets/js/questionnaire-builder.js` to correctly interpret stringified booleans like `"0"`/`"false"`. 
- Introduce `normalize_work_function_assignments()` and `save_work_function_assignments()` in `lib/work_functions.php` to validate inputs and persist assignments safely, and update `admin/work_function_defaults.php` to use these helpers. 
- Make DB writes resilient when transactions are not available by guarding `commit()`/`rollBack()` with a `transactionStarted` check and `PDO::inTransaction()` before calling them. 
- Add a test case to `tests/work_function_assignments_test.php` exercising normalization of label-derived slugs.

### Testing
- Ran `node --check assets/js/questionnaire-builder.js` to validate the modified JavaScript syntax and it succeeded. 
- Added a unit assertion in `tests/work_function_assignments_test.php` for the new normalization logic, but test suite execution was not performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698519c024b8832dab78d9dbd1c4c50c)