### PR TITLE
Fix questionnaire import visibility and scoring regressions

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -308,8 +308,20 @@ const Builder = (() => {
         if (state.dirty) {
           return;
         }
+        const previousClientIdById = new Map(
+          state.questionnaires
+            .filter((q) => Number.isInteger(Number(q.id)) && Number(q.id) > 0)
+            .map((q) => [String(q.id), q.clientId])
+        );
         state.questionnaires = Array.isArray(payload.questionnaires)
-          ? payload.questionnaires.map((q) => normalizeQuestionnaire(q))
+          ? payload.questionnaires.map((q) => {
+            const normalized = normalizeQuestionnaire(q);
+            const key = normalized.id ? String(normalized.id) : null;
+            if (key && previousClientIdById.has(key)) {
+              normalized.clientId = previousClientIdById.get(key);
+            }
+            return normalized;
+          })
           : [];
         ensureActive();
         state.dirty = false;

--- a/tests/questionnaire_builder.test.js
+++ b/tests/questionnaire_builder.test.js
@@ -164,14 +164,19 @@ class FakeDocument {
   };
 
   let savedPayload = null;
+  let fetchCount = 0;
   const fetch = async (url, opts = {}) => {
     const u = String(url);
     if (u.includes('action=fetch')) {
+      fetchCount += 1;
+      const payloadQuestionnaires = fetchCount > 1
+        ? [{ ...window.QB_BOOTSTRAP[0], clientId: 'server-client-id-changed' }]
+        : window.QB_BOOTSTRAP;
       return {
         json: async () => ({
           status: 'ok',
           csrf: 'csrf-next',
-          questionnaires: window.QB_BOOTSTRAP,
+          questionnaires: payloadQuestionnaires,
         }),
       };
     }
@@ -216,6 +221,9 @@ class FakeDocument {
   if (!q) throw new Error('missing questionnaire in payload');
   if (q.title !== 'New title') throw new Error(`expected title to persist, got ${q.title}`);
   if (q.status !== 'inactive') throw new Error(`expected status to persist, got ${q.status}`);
+  if (document.card?.qid !== 'q-1') {
+    throw new Error(`expected active questionnaire client id to stay stable after refetch, got ${document.card?.qid}`);
+  }
 
   const source = fs.readFileSync('assets/js/questionnaire-builder.js', 'utf8');
   if (!source.includes("[data-role=\"items\"], [data-role=\"root-items\"]")) {


### PR DESCRIPTION
### Motivation
- Imported questionnaires were not reliably shown/selected after save/import because client-side `clientId` values could change when the server returned persisted IDs.  
- Scoring behavior regressed: single-choice items without `requires_correct` were being treated as requiring a correct option, breaking calculations and analytics.  
- Analytics and builder code needed to align on the `requires_correct` semantics and remain compatible with schemas that may lack that column.

### Description
- Preserve builder selection across server refreshes by reusing existing in-memory `clientId` when the server returns the same persisted `id` in `fetchData` in `assets/js/questionnaire-builder.js`.  
- Restore correct submission scoring in `submit_assessment.php` by fetching `requires_correct` and changing scoring: if `requires_correct` is true then only the correct option scores, otherwise any valid selection scores.  
- Update analytics section scoring in `lib/performance_sections.php` to use `requires_correct` semantics and add a DB-compatibility fallback so code still works when the `requires_correct` column is absent.  
- Add/adjust tests in `tests/questionnaire_builder.test.js` to assert clientId stability after a refetch and keep existing JS/PHP tests for scoring and analytics aligned with changes.

### Testing
- Ran linters: `php -l submit_assessment.php && php -l lib/performance_sections.php && php -l admin/questionnaire_manage.php` (no syntax errors).  
- Ran JS + unit tests: `node tests/questionnaire_builder.test.js` and `php tests/questionnaire_scoring_test.php` (both passed).  
- Ran broader test suite: `php tests/analytics_report_snapshot_test.php`, `php tests/email_templates_test.php`, and `php tests/smtp_config_test.php` (all passed).  
- One unrelated test currently fails in this environment: `php tests/work_function_assignments_test.php` fails due to a missing test helper function `work_function_label()` in the test setup and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698568df02d8832da619a835a3049e22)