### PR TITLE
Allow deletion of questionnaires without submissions in v1 builder

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -69,6 +69,22 @@ $qbStrings = [
     'evenNoop' => t($t, 'qb_scoring_even_noop', 'Add scorable questions before splitting weights.'),
     'clearSuccess' => t($t, 'qb_scoring_clear_success', 'Cleared all question weights.'),
     'clearNoop' => t($t, 'qb_scoring_clear_noop', 'No weights to clear.'),
+    'deleteQuestionnaireLabel' => t($t, 'qb_delete_questionnaire', 'Delete questionnaire'),
+    'deleteQuestionnaireConfirm' => t(
+        $t,
+        'qb_delete_questionnaire_confirm',
+        'Delete "%s"? This cannot be undone.'
+    ),
+    'deleteQuestionnaireBlocked' => t(
+        $t,
+        'qb_delete_questionnaire_blocked',
+        'Questionnaires with submissions cannot be deleted.'
+    ),
+    'deleteQuestionnaireSuccess' => t(
+        $t,
+        'qb_delete_questionnaire_success',
+        'Questionnaire removed. Save to apply the changes.'
+    ),
 ];
 
 const LIKERT_DEFAULT_OPTIONS = [


### PR DESCRIPTION
### Motivation
- Enable administrators to remove questionnaires that have no submissions so they can be re-imported and edited as drafts (e.g. to set correct answers) before publishing again.

### Description
- Added localized strings for deletion UI and messages in `admin/questionnaire_manage.php` (`deleteQuestionnaireLabel`, `deleteQuestionnaireConfirm`, `deleteQuestionnaireBlocked`, `deleteQuestionnaireSuccess`).
- Added a delete action to the v1 builder UI in `assets/js/questionnaire-builder.js`, including a `removeQuestionnaire` function that confirms deletion, blocks deletion when `hasResponses` is true, removes the questionnaire from the client state, updates the active selection, marks the state dirty, and renders feedback.
- The delete button is disabled for questionnaires with submissions and shows a helpful tooltip; deletions are client-side and require saving to persist (message surfaces that saving will apply changes).
- Bound the delete button handler when rendering questionnaire cards so the button works for the active questionnaire.

### Testing
- Automated tests: none were run.
- (No automated test failures reported because no tests were executed.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698902c30dc4832d9d837e06dd0e62a4)