### PR TITLE
Refresh scoring summary when single-choice/weight settings change

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1081,6 +1081,9 @@ const Builder = (() => {
       const itemRow = event.target.closest('[data-item]');
       rerenderItemRow(questionnaire, itemRow);
     }
+    if (['item-type', 'item-multi', 'item-requires-correct', 'item-weight'].includes(role)) {
+      rerenderScoringSummary(questionnaire);
+    }
   }
 
   function rerenderItemRow(questionnaire, itemRow) {
@@ -1095,6 +1098,18 @@ const Builder = (() => {
     const next = wrapper.firstElementChild;
     if (!next) return;
     itemRow.replaceWith(next);
+  }
+
+  function rerenderScoringSummary(questionnaire) {
+    const card = document.querySelector(`.qb-card[data-q="${questionnaire.clientId}"]`);
+    if (!card) return;
+    const current = card.querySelector('.qb-scoring');
+    if (!current) return;
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = renderScoringSummary(questionnaire).trim();
+    const next = wrapper.firstElementChild;
+    if (!next) return;
+    current.replaceWith(next);
   }
 
   function handleListClick(event) {


### PR DESCRIPTION
### Motivation
- The scoring summary (including the "Auto-weight single-choice with correct answer" action) could remain stale after toggling single-choice settings or editing weights, making the button appear disabled or inert.

### Description
- Add `rerenderScoringSummary(questionnaire)` which replaces the `.qb-scoring` DOM fragment with the output of `renderScoringSummary(questionnaire)`.
- Invoke `rerenderScoringSummary` from the list input handler when roles include `item-type`, `item-multi`, `item-requires-correct`, or `item-weight` so the summary and action buttons update immediately after those changes.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69895173920c832dab9597d851c3d7b7)