### PR TITLE
Prevent stale questionnaire builder fetches

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -303,6 +303,8 @@ function qb_questionnaire_items_to_fhir_items(array $items): array
 function send_json(array $payload, int $status = 200): void {
     http_response_code($status);
     header('Content-Type: application/json');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
     echo json_encode($payload);
     exit;
 }

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -320,6 +320,7 @@ const Builder = (() => {
 
     const params = new URLSearchParams({ action: 'fetch', csrf: state.csrf });
     fetch(withBase(`/admin/questionnaire_manage.php?${params.toString()}`), {
+      cache: 'no-store',
       headers: { 'X-CSRF-Token': state.csrf },
       credentials: 'same-origin',
     })


### PR DESCRIPTION
### Motivation
- The questionnaire builder showed saved changes only after logging out/in because the browser could be served cached JSON from the `fetch` endpoint. 
- Avoiding caching ensures the UI immediately sees server-side updates and removes the need for a manual sign-out/in cycle.

### Description
- Added cache-control headers in `send_json()` to disable storing/caching of JSON responses by intermediaries and browsers (`Cache-Control: no-store, no-cache, must-revalidate, max-age=0` and `Pragma: no-cache`) in `admin/questionnaire_manage.php`.
- Requested `no-store` cache behavior on the client fetch call by adding `cache: 'no-store'` to the `fetch()` call in `assets/js/questionnaire-builder.js` so the builder always requests fresh data.
- These combined server and client changes address stale questionnaire payloads so saved edits appear immediately in the UI.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69895a7d7be8832d913152a281ce6271)