### PR TITLE
Improve required profile field feedback

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1545,6 +1545,72 @@ body.theme-dark .md-help-bubble::before {
   font-weight: 700;
 }
 
+.md-field--error input,
+.md-field--error select,
+.md-field--error textarea {
+  border-color: var(--app-danger);
+  background: #fff5f5;
+  box-shadow: 0 0 0 3px rgba(198, 40, 40, 0.2);
+}
+
+.md-field--error span {
+  color: var(--app-danger);
+}
+
+.md-required-popup {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.md-required-popup__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.md-required-popup__dialog {
+  position: relative;
+  z-index: 1;
+  background: #fff;
+  border-radius: 14px;
+  padding: 20px 24px;
+  max-width: 520px;
+  width: calc(100% - 32px);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.2);
+  border: 2px solid var(--app-danger);
+}
+
+.md-required-popup__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.md-required-popup__title {
+  font-weight: 600;
+  color: var(--app-danger);
+  font-size: 1.05rem;
+}
+
+.md-required-popup__close {
+  border: none;
+  background: transparent;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--app-danger);
+}
+
+.md-required-popup__body {
+  margin: 0;
+  color: var(--app-muted);
+}
+
 .md-field input:focus,
 .md-field select:focus,
 .md-field textarea:focus {


### PR DESCRIPTION
### Motivation
- Improve the new-user profile completion experience by making mandatory fields and missing input more obvious to prevent confusing failed saves. 
- Provide immediate client-side feedback (highlighting empty required fields) so users can correct errors before submission. 
- Surface a clear, accessible message explaining that required fields are missing to reduce support friction.

### Description
- Added a required-fields popup dialog and markup to `profile.php` (`.md-required-popup` with `data-required-popup`) that is shown when client validation finds missing required inputs. 
- Marked required profile fields with `md-field--required` and changed the form to include `data-profile-form`, and added an inline client-side script in `profile.php` to validate `[required]` fields, toggle `md-field--error`, and show/hide the popup before submit. 
- Added styles to `assets/css/styles.css` for `.md-field--error` visual state and the `.md-required-popup` dialog (colors, shadow, backdrop, and close button) so empty required fields are highlighted in red and the dialog matches app theming.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f5178c88832d88dbdc974b1007df)