### PR TITLE
Align user tile action buttons to the left

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1215,11 +1215,11 @@ body.theme-dark .md-field.md-field--compact select {
 
 .md-user-form-actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
 }
 
 .md-user-delete-form {
-  align-self: flex-end;
+  align-self: flex-start;
 }
 
 .md-user-delete-form .md-user-action-button {


### PR DESCRIPTION
### Motivation
- User card action buttons (Apply / Deactivate) were right-aligned in the user tile footer and should be left-aligned to match the requested layout change.

### Description
- Update CSS in `assets/css/styles.css` to left-align actions by changing `.md-user-form-actions { justify-content: flex-start; }` and making the delete form align with `.md-user-delete-form { align-self: flex-start; }`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0de4aaa8832d9c996eae58c1d535)