### PR TITLE
Add standard icons for top navigation items

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -228,9 +228,32 @@ button,
   width: 18px;
   height: 18px;
   border-radius: 6px;
-  background: color-mix(in srgb, var(--app-primary) 18%, rgba(15, 23, 42, 0.1));
+  background-color: color-mix(in srgb, var(--app-primary) 45%, rgba(15, 23, 42, 0.2));
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: 18px 18px;
   flex-shrink: 0;
+}
+
+.md-topnav-trigger[data-topnav-icon="workspace"]::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='black' d='M9 4h6a2 2 0 0 1 2 2v2h3a2 2 0 0 1 2 2v7a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v-7a2 2 0 0 1 2-2h3V6a2 2 0 0 1 2-2Zm0 4h6V6H9v2Zm-5 4v5a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-5H4Z'/></svg>");
+}
+
+.md-topnav-trigger[data-topnav-icon="team"]::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='black' d='M7.5 12a4 4 0 1 1 4-4 4 4 0 0 1-4 4Zm9 0a3.5 3.5 0 1 1 3.5-3.5A3.5 3.5 0 0 1 16.5 12ZM3 20a5.5 5.5 0 0 1 11 0v1H3Zm12.5 1v-1a6.5 6.5 0 0 0-.5-2.5 5 5 0 0 1 8 3.5Z'/></svg>");
+}
+
+.md-topnav-trigger[data-topnav-icon="admin"]::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='black' d='M12 8a4 4 0 1 1-4 4 4 4 0 0 1 4-4Zm9 4a6.9 6.9 0 0 0-.1-1.3l2-1.6-2-3.4-2.5 1a7.6 7.6 0 0 0-2.2-1.3L15.7 2H8.3L7.8 5.4a7.6 7.6 0 0 0-2.2 1.3l-2.5-1-2 3.4 2 1.6A6.9 6.9 0 0 0 3 12a6.9 6.9 0 0 0 .1 1.3l-2 1.6 2 3.4 2.5-1a7.6 7.6 0 0 0 2.2 1.3L8.3 22h7.4l.5-3.4a7.6 7.6 0 0 0 2.2-1.3l2.5 1 2-3.4-2-1.6A6.9 6.9 0 0 0 21 12Z'/></svg>");
+}
+
+.md-topnav-trigger[data-topnav-icon="system"]::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='black' d='M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V5Zm0 10a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2v-4Zm3-8h4v2H7V7Zm0 10h4v2H7v-2Z'/></svg>");
+}
+
+.md-topnav-trigger[data-topnav-icon="account"]::before {
+  mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='black' d='M12 12a4 4 0 1 1 4-4 4 4 0 0 1-4 4Zm0 2c4.4 0 8 2.2 8 5v1H4v-1c0-2.8 3.6-5 8-5Z'/></svg>");
 }
 
 .md-topnav-label {

--- a/templates/header.php
+++ b/templates/header.php
@@ -326,7 +326,7 @@ $currentLocaleBadge = strtoupper((string)$currentLocale);
     $workspaceActive = $isActiveNav('workspace.my_performance', 'workspace.submit_assessment');
     ?>
     <li class="md-topnav-item<?=$workspaceActive ? ' is-active' : ''?>" data-topnav-item>
-      <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="md-topnav-trigger" data-topnav-trigger data-topnav-icon="workspace" aria-haspopup="true" aria-expanded="false">
         <span class="md-topnav-label">
           <span class="md-topnav-title"><?=t($t, 'my_workspace', 'My Workspace')?></span>
           <span class="md-topnav-desc"><?=t($t, 'my_workspace_summary', 'Stay on top of your goals and tasks.')?></span>
@@ -363,7 +363,7 @@ $currentLocaleBadge = strtoupper((string)$currentLocale);
       $teamActive = $teamNavKeys ? $isActiveNav(...$teamNavKeys) : false;
       ?>
       <li class="md-topnav-item<?=$teamActive ? ' is-active' : ''?>" data-topnav-item>
-        <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="md-topnav-trigger" data-topnav-trigger data-topnav-icon="team" aria-haspopup="true" aria-expanded="false">
           <span class="md-topnav-label">
             <span class="md-topnav-title"><?=t($t, 'team_navigation', 'Team & Reviews')?></span>
             <span class="md-topnav-desc"><?=t($t, 'team_navigation_summary', 'Support your team with reviews and approvals.')?></span>
@@ -409,7 +409,7 @@ $currentLocaleBadge = strtoupper((string)$currentLocale);
       $systemActive = $isActiveNav('admin.dashboard', 'admin.export', 'admin.settings');
       ?>
       <li class="md-topnav-item<?=$adminActive ? ' is-active' : ''?>" data-topnav-item>
-        <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="md-topnav-trigger" data-topnav-trigger data-topnav-icon="admin" aria-haspopup="true" aria-expanded="false">
           <span class="md-topnav-label">
             <span class="md-topnav-title"><?=t($t, 'admin_navigation', 'Administration')?></span>
             <span class="md-topnav-desc"><?=t($t, 'admin_navigation_summary', 'Manage users, questionnaires, and branding.')?></span>
@@ -456,7 +456,7 @@ $currentLocaleBadge = strtoupper((string)$currentLocale);
         </ul>
       </li>
       <li class="md-topnav-item<?=$systemActive ? ' is-active' : ''?>" data-topnav-item>
-        <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="md-topnav-trigger" data-topnav-trigger data-topnav-icon="system" aria-haspopup="true" aria-expanded="false">
           <span class="md-topnav-label">
             <span class="md-topnav-title"><?=t($t, 'system_navigation', 'System')?></span>
             <span class="md-topnav-desc"><?=t($t, 'system_navigation_summary', 'Configure authentication, exports, and platform upgrades.')?></span>
@@ -504,7 +504,7 @@ $currentLocaleBadge = strtoupper((string)$currentLocale);
       </li>
     <?php endif; ?>
     <li class="md-topnav-item" data-topnav-item>
-      <button type="button" class="md-topnav-trigger" data-topnav-trigger aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="md-topnav-trigger" data-topnav-trigger data-topnav-icon="account" aria-haspopup="true" aria-expanded="false">
         <span class="md-topnav-label">
           <span class="md-topnav-title"><?=t($t, 'account_tools', 'Account & Tools')?></span>
           <span class="md-topnav-desc"><?=t($t, 'account_tools_summary', 'Quick actions, profile, and preferences.')?></span>


### PR DESCRIPTION
### Motivation
- The top navigation used generic placeholder badges for each menu; replace them with meaningful icons to improve affordance and match the visual language used elsewhere.
- Provide a consistent, CSS-driven solution so icons scale and inherit the theme color while keeping markup minimal.

### Description
- Add CSS rules to `assets/css/styles.css` to use a masked SVG approach for the topnav badges, including `mask-image`, `mask-size`, and updated background color on `.md-topnav-trigger::before`.
- Add five icon masks (workspace, team, admin, system, account) as inline `data:image/svg+xml` masks in the stylesheet so no external assets are required.
- Annotate the top menu trigger buttons in `templates/header.php` by adding `data-topnav-icon` attributes for `workspace`, `team`, `admin`, `system`, and `account` so the new CSS selectors apply.

### Testing
- Started the PHP built-in server with `php -S 0.0.0.0:8000 -t /workspace/CAS2025` and it started successfully.
- Ran a Playwright script to open `http://127.0.0.1:8000/index.php`, capture a screenshot, and save it as an artifact (`artifacts/topnav-icons.png`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a3d357178832d80986558373df89d)