### PR TITLE
Fix mobile top navigation submenu tap behavior

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -152,6 +152,25 @@
           item.classList.add('is-open');
         }
       });
+
+      const item = trigger.closest('[data-topnav-item]');
+      if (item) {
+        item.addEventListener('click', (event) => {
+          if (!isMobileView()) {
+            return;
+          }
+          const target = event.target;
+          if (!(target instanceof Element)) {
+            return;
+          }
+          if (target.closest('[data-topnav-trigger]') || target.closest('.md-topnav-submenu')) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          trigger.click();
+        });
+      }
     });
 
     document.addEventListener('click', (event) => {


### PR DESCRIPTION
### Motivation
- Mobile users could only open a top-level submenu by tapping the narrow trigger area; tapping elsewhere on the menu row did nothing, which is inconsistent with common mobile menu behavior and caused a poor UX.

### Description
- Added a mobile-only row click handler that forwards valid taps on a `data-topnav-item` to the existing trigger logic so the entire menu row toggles the submenu while preserving desktop and submenu link behavior (file changed: `assets/js/app.js`).

### Testing
- Ran `node --check assets/js/app.js` which completed successfully.
- Started a local PHP dev server (`php -S 0.0.0.0:8080 -t /workspace/CAS2025`) and verified the mobile rendering via an automated Playwright run that produced a screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6909c268832db88eaffdaa9de5fc)