### PR TITLE
Improve small-screen header and top navigation behavior

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,5 +1,6 @@
 :root {
   --appbar-height: 64px;
+  --appbar-height-mobile: 52px;
   --topnav-height: 64px;
   --app-button-height: 48px;
 }
@@ -439,6 +440,51 @@ button,
   font-size: 1.05rem;
   font-weight: 600;
   color: var(--app-on-surface-strong);
+}
+
+
+.md-topnav-mobile-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  min-width: 0;
+}
+
+.md-topnav-mobile-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--app-on-primary-subtle);
+  object-fit: contain;
+  padding: 0.2rem;
+}
+
+.md-topnav-mobile-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+}
+
+.md-topnav-mobile-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  border-radius: 999px;
+  border: 1px solid var(--app-border);
+  padding: 0.3rem 0.65rem;
+  text-decoration: none;
+  color: var(--app-on-surface-strong);
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: var(--app-surface);
+}
+
+.md-topnav-mobile-link:hover,
+.md-topnav-mobile-link:focus-visible {
+  border-color: var(--app-primary);
+  color: var(--app-primary-dark);
 }
 
 .md-topnav-close {
@@ -2890,7 +2936,35 @@ body.theme-dark .md-button.md-secondary {
 
 @media (max-width: 1024px) {
   .md-shell {
-    padding: 1.1rem 1rem 2.2rem;
+    padding: 0.85rem 0.9rem 2rem;
+  }
+
+  .md-appbar {
+    min-height: var(--appbar-height-mobile);
+    padding: 0.45rem 0.85rem;
+    gap: 0.5rem;
+    flex-wrap: nowrap;
+  }
+
+  .md-appbar-title {
+    font-size: 0.98rem;
+    gap: 0.45rem;
+  }
+
+  .md-appbar-logo {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+  }
+
+  .md-appbar-actions {
+    display: none;
+  }
+
+  .md-appbar-toggle {
+    min-height: 40px;
+    width: 40px;
+    margin-right: 0.35rem;
   }
 
   .md-topnav {
@@ -2919,8 +2993,8 @@ body.theme-dark .md-button.md-secondary {
   .md-topnav-trigger {
     width: 100%;
     justify-content: space-between;
-    padding: 0.9rem 0.75rem;
-    font-size: 1.05rem;
+    padding: 0.75rem 0.7rem;
+    font-size: 0.98rem;
     align-items: flex-start;
     gap: 0.75rem;
   }
@@ -2952,8 +3026,8 @@ body.theme-dark .md-button.md-secondary {
   }
 
   .md-topnav-link {
-    padding: 0.9rem 0.85rem;
-    font-size: 1rem;
+    padding: 0.72rem 0.78rem;
+    font-size: 0.95rem;
     justify-content: flex-start;
     align-items: flex-start;
   }
@@ -2964,7 +3038,7 @@ body.theme-dark .md-button.md-secondary {
 
   html.has-js .md-topnav {
     position: fixed;
-    top: calc(var(--appbar-height) + env(safe-area-inset-top, 0px));
+    top: env(safe-area-inset-top, 0px);
     left: 0;
     right: 0;
     bottom: 0;
@@ -2979,7 +3053,7 @@ body.theme-dark .md-button.md-secondary {
     background: var(--app-surface);
     gap: 1rem;
     overflow-y: auto;
-    max-height: calc(100vh - var(--appbar-height) - env(safe-area-inset-top, 0px));
+    max-height: 100vh;
     -webkit-overflow-scrolling: touch;
     transition: transform 0.28s ease, opacity 0.28s ease;
     z-index: 1200;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -100,6 +100,13 @@
     updateBackdrop(shouldLock);
     applyTopnavA11yState(nextState);
     if (shouldLock) {
+      const activeItem = topnav.querySelector('[data-topnav-item].is-active');
+      if (activeItem instanceof HTMLElement) {
+        const activeTrigger = activeItem.querySelector('[data-topnav-trigger]');
+        if (activeTrigger instanceof HTMLElement) {
+          activeTrigger.click();
+        }
+      }
       const focusables = getTopnavFocusables();
       const firstFocusable = focusables.length ? focusables[0] : null;
       if (firstFocusable && typeof firstFocusable.focus === 'function') {
@@ -134,6 +141,19 @@
       });
     };
 
+    const openSubmenuForItem = (item) => {
+      if (!item) {
+        return;
+      }
+      const trigger = item.querySelector('[data-topnav-trigger]');
+      if (!trigger) {
+        return;
+      }
+      closeSubmenus();
+      trigger.setAttribute('aria-expanded', 'true');
+      item.classList.add('is-open');
+    };
+
     closeTopnavSubmenus = closeSubmenus;
 
     triggers.forEach((trigger) => {
@@ -145,32 +165,12 @@
         if (!item) {
           return;
         }
-        const willOpen = !item.classList.contains('is-open');
-        closeSubmenus();
-        if (willOpen) {
-          trigger.setAttribute('aria-expanded', 'true');
-          item.classList.add('is-open');
+        if (item.classList.contains('is-open')) {
+          closeSubmenus();
+          return;
         }
+        openSubmenuForItem(item);
       });
-
-      const item = trigger.closest('[data-topnav-item]');
-      if (item) {
-        item.addEventListener('click', (event) => {
-          if (!isMobileView()) {
-            return;
-          }
-          const target = event.target;
-          if (!(target instanceof Element)) {
-            return;
-          }
-          if (target.closest('[data-topnav-trigger]') || target.closest('.md-topnav-submenu')) {
-            return;
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          trigger.click();
-        });
-      }
     });
 
     document.addEventListener('click', (event) => {

--- a/templates/header.php
+++ b/templates/header.php
@@ -311,7 +311,22 @@ $currentLocaleBadge = strtoupper((string)$currentLocale);
   aria-hidden="true"
 >
   <div class="md-topnav-mobile-header" data-topnav-mobile-header>
-    <span class="md-topnav-mobile-title"><?=t($t, 'navigation_menu', 'Navigation')?></span>
+    <div class="md-topnav-mobile-brand">
+      <img src="<?=$logoPathSmall?>" alt="<?=$siteLogoAlt?>" class="md-topnav-mobile-logo" loading="lazy">
+      <span class="md-topnav-mobile-title"><?=t($t, 'navigation_menu', 'Navigation')?></span>
+    </div>
+    <div class="md-topnav-mobile-actions">
+      <a
+        href="<?=htmlspecialchars(url_for('set_lang.php?lang=' . $nextLocale), ENT_QUOTES, 'UTF-8')?>"
+        class="md-topnav-mobile-link"
+        aria-label="<?=htmlspecialchars(t($t, 'language_switch', 'Switch language'), ENT_QUOTES, 'UTF-8')?>"
+      >
+        <?=htmlspecialchars($currentLocaleBadge, ENT_QUOTES, 'UTF-8')?>
+      </a>
+      <a href="<?=htmlspecialchars(url_for('logout.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-mobile-link">
+        <?=t($t, 'logout', 'Logout')?>
+      </a>
+    </div>
     <button
       type="button"
       class="md-topnav-close"


### PR DESCRIPTION
### Motivation
- Small-screen navigation was cumbersome and inconsistent, so the mobile menu interaction needed to be standardized to a single predictable pattern.  
- The app header used considerable vertical space on phones and duplicated actions between the appbar and the nav, so compressing and unifying them improves usability and reduces clutter.  
- Auto-opening the active section when the menu is opened speeds access to common destinations on small screens.  

### Description
- Add compact mobile header content to `templates/header.php` that shows a small brand block plus language switch and logout links inside the mobile nav panel.  
- Add mobile-specific CSS in `assets/css/styles.css` including `--appbar-height-mobile`, reduced appbar paddings, smaller logo and toggle sizing, hiding desktop appbar actions on mobile, and making the topnav overlay occupy the full viewport from the top.  
- Update `assets/js/app.js` to standardize topnav interaction to an accordion-style behavior, provide an `openSubmenuForItem` helper, and auto-expand the currently active section when the mobile menu opens while preserving keyboard focus behavior.  

### Testing
- Ran `php -l templates/header.php` and it reported no syntax errors.  
- Ran `node --check assets/js/app.js` and it reported no syntax errors.  
- Attempted an automated Playwright screenshot to validate the mobile UI but the Chromium runtime crashed (SIGSEGV) in this environment so no visual artifacts were produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e38f52e24832daf2e1415cbe27e9e)