### PR TITLE
Top nav: single-column mobile actions and desktop submenu collapse

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3086,6 +3086,16 @@ body.theme-dark .md-button.md-secondary {
     padding-bottom: 1rem;
     border-bottom: 1px solid var(--app-border);
   }
+
+  .md-topnav-mobile-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.35rem;
+  }
+
+  .md-topnav-mobile-link {
+    width: 100%;
+  }
 }
 
 .likert-scale {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -173,13 +173,37 @@
       });
     });
 
-    document.addEventListener('click', (event) => {
-      if (topnav.contains(event.target) || (toggle && toggle.contains(event.target)) || (backdrop && backdrop.contains(event.target))) {
+    const closeMenusIfOutside = (target) => {
+      if (topnav.contains(target) || (toggle && toggle.contains(target)) || (backdrop && backdrop.contains(target))) {
         return;
       }
       closeSubmenus();
       closeTopnav();
+    };
+
+    document.addEventListener('click', (event) => {
+      closeMenusIfOutside(event.target);
     });
+
+    topnav.addEventListener('focusout', (event) => {
+      if (isMobileView()) {
+        return;
+      }
+      const nextFocused = event.relatedTarget;
+      if (nextFocused instanceof Node && topnav.contains(nextFocused)) {
+        return;
+      }
+      closeSubmenus();
+    });
+
+    if (typeof window.matchMedia !== 'function' || window.matchMedia('(hover: hover)').matches) {
+      topnav.addEventListener('mouseleave', () => {
+        if (isMobileView()) {
+          return;
+        }
+        closeSubmenus();
+      });
+    }
 
     topnav.addEventListener('keydown', (event) => {
       if (event.key === 'Escape') {


### PR DESCRIPTION
### Motivation
- Simplify the mobile top navigation so utility action buttons stack and occupy full width for clearer touch targets and a 1-column layout.
- Standardize desktop behavior so open top-level submenus do not remain stuck when the user moves focus or the pointer away from the navigation.

### Description
- Updated mobile styling in `assets/css/styles.css` to make `.md-topnav-mobile-actions` a vertical stack and set `.md-topnav-mobile-link` to `width: 100%` so actions render as a single column.
- Introduced a small helper and expanded event handling in `assets/js/app.js` to centralize closing logic (`closeMenusIfOutside`) and to close submenus on `focusout` when focus leaves the nav and on `mouseleave` in hover-capable environments.
- Kept existing mobile drawer open/close behavior intact while ensuring submenus are collapsed consistently when appropriate.

### Testing
- Ran `node --check assets/js/app.js` to validate the modified script syntax and it passed successfully.
- Launched a local PHP dev server and attempted an HTTP request to `login.php`, which returned an HTTP 500 in this environment so full live UI verification could not be completed.
- Attempted a Playwright screenshot flow against the local server, which failed due to environment networking/response issues, so no end-to-end screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e41b357fc832db98fa7571ed2cbe1)