### PR TITLE
Right-align language panel on login page

### DIFF
--- a/assets/css/auth.css
+++ b/assets/css/auth.css
@@ -145,6 +145,26 @@
   color: #1d2939;
 }
 
+.md-login-page .login-panel__footer-language {
+  justify-self: end;
+  text-align: right;
+}
+
+.md-login-page .login-panel__footer-language .md-login-footer-locale {
+  justify-content: flex-end;
+}
+
+@media (max-width: 900px) {
+  .md-login-page .login-panel__footer-language {
+    justify-self: stretch;
+    text-align: left;
+  }
+
+  .md-login-page .login-panel__footer-language .md-login-footer-locale {
+    justify-content: flex-start;
+  }
+}
+
 .md-login-page .md-login-footer-hint {
   margin: 6px 0 0;
   color: #5f6b7a;

--- a/login.php
+++ b/login.php
@@ -245,7 +245,7 @@ render_login:
               <span class="md-login-footer-value"><?= $contact ?></span>
             </div>
           <?php endif; ?>
-          <div>
+          <div class="login-panel__footer-language">
             <span class="md-login-footer-label"><?= $languageLabel ?></span>
             <nav class="md-login-footer-value md-login-footer-locale lang-switch" aria-label="<?= $languageLabel ?>">
               <?php foreach ($availableLocales as $loc): ?>


### PR DESCRIPTION
### Motivation
- The language switcher in the login footer should be visually aligned to the right on desktop to match layout expectations while keeping mobile behavior unchanged.

### Description
- Wrapped the language block in the login footer with a new wrapper `<div class="login-panel__footer-language">` in `login.php` to allow independent alignment.
- Added CSS rules to `assets/css/auth.css` to right-align the language wrapper on desktop (`justify-self: end; text-align: right;` and `justify-content: flex-end` for locale links).
- Added a responsive override so the language wrapper reverts to left alignment at `@media (max-width: 900px)` to preserve mobile layout.
- Modified files: `login.php` and `assets/css/auth.css`.

### Testing
- Ran `php -l login.php` which returned no syntax errors.
- Launched a local dev server (`php -S 0.0.0.0:8000`) and captured a full-page screenshot of `/login.php` to validate the visual change (artifact produced).
- Verified diffs and committed the changes (`git diff` and commit) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e4ef943d8832d9ac5634873a78438)