### PR TITLE
Show only flag icon in top-right language switcher

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -614,7 +614,7 @@ button,
 }
 
 .md-appbar-link.md-appbar-language {
-  padding: 0 0.55rem;
+  padding: 0;
   flex: 0 0 var(--app-button-height);
   width: auto;
   height: var(--app-button-height);
@@ -622,7 +622,6 @@ button,
   border-radius: 999px;
   font-size: 0.85rem;
   line-height: 1;
-  gap: 0.35rem;
   background: var(--app-on-primary-subtle);
 }
 
@@ -640,11 +639,6 @@ button,
   flex: 0 0 auto;
 }
 
-.md-appbar-link.md-appbar-language .md-appbar-language-text {
-  display: inline-block;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-}
 
 .md-lang-switch a {
   margin: 0 0.15rem;

--- a/templates/header.php
+++ b/templates/header.php
@@ -110,7 +110,6 @@ $currentLocaleFlag = asset_url('assets/images/flags/flag-' . $currentLocale . '.
         loading="lazy"
         decoding="async"
       >
-      <span class="md-appbar-language-text"><?=htmlspecialchars($currentLocaleBadge, ENT_QUOTES, 'UTF-8')?></span>
     </a>
     <a href="<?=htmlspecialchars(url_for('logout.php'), ENT_QUOTES, 'UTF-8')?>" class="md-appbar-link">
       <?=t($t, 'logout', 'Logout')?>


### PR DESCRIPTION
### Motivation
- Make the app header language switch consistent with the login page by removing the textual locale badge (e.g. `EN`, `FR`, `AM`) and leaving only the flag to reduce visual clutter.

### Description
- Removed the locale badge span from `templates/header.php` so the appbar language link renders only the flag image. 
- Tightened the language button styling in `assets/css/styles.css` by removing extra horizontal padding and the gap to keep the control compact. 
- Removed the now-unused `.md-appbar-link.md-appbar-language .md-appbar-language-text` CSS block from `assets/css/styles.css`. 
- Made small related spacing cleanups in the stylesheet to reflect the flag-only control.

### Testing
- Linted PHP templates with `php -l templates/header.php` which succeeded. 
- Linted the login page with `php -l login.php` which succeeded. 
- Launched the dev server (`make run` / `php -S`) and attempted an automated Playwright screenshot for visual verification, but the UI check failed because the environment could not connect to the database (`SQLSTATE[HY000] [2002] Connection refused`), so interactive verification of the authenticated header could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5798d3c0832daa11d3dc864638fa)