### PR TITLE
Disable dark mode for login and landing pages

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,6 +20,7 @@
     : {};
   const themeToggleButton = document.querySelector('[data-theme-toggle]');
   const themeOverrideStorageKey = 'hrassess:theme:override';
+  const darkModeDisabled = body && body.getAttribute('data-disable-dark-mode') === '1';
 
   const applyTheme = (theme) => {
     const next = theme === 'dark' ? 'dark' : 'light';
@@ -116,24 +117,31 @@
   };
 
   let manualThemeOverride = getStoredThemeOverride();
-  applyThemeMode(manualThemeOverride);
+  if (darkModeDisabled) {
+    applyTheme('light');
+    if (themeToggleButton) {
+      themeToggleButton.hidden = true;
+    }
+  } else {
+    applyThemeMode(manualThemeOverride);
 
-  if (!manualThemeOverride && navigator.geolocation && typeof navigator.geolocation.getCurrentPosition === 'function') {
-    navigator.geolocation.getCurrentPosition((position) => {
-      applyThemeMode(null, position && position.coords ? position.coords : null);
-    }, () => {
-      // Ignore geolocation errors and keep time-based fallback.
-    }, { maximumAge: 30 * 60 * 1000, timeout: 3000, enableHighAccuracy: false });
-  }
+    if (!manualThemeOverride && navigator.geolocation && typeof navigator.geolocation.getCurrentPosition === 'function') {
+      navigator.geolocation.getCurrentPosition((position) => {
+        applyThemeMode(null, position && position.coords ? position.coords : null);
+      }, () => {
+        // Ignore geolocation errors and keep time-based fallback.
+      }, { maximumAge: 30 * 60 * 1000, timeout: 3000, enableHighAccuracy: false });
+    }
 
-  if (themeToggleButton) {
-    themeToggleButton.addEventListener('click', () => {
-      const currentTheme = document.body.classList.contains('theme-dark') ? 'dark' : 'light';
-      const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      manualThemeOverride = nextTheme;
-      saveThemeOverride(nextTheme);
-      applyThemeMode(manualThemeOverride);
-    });
+    if (themeToggleButton) {
+      themeToggleButton.addEventListener('click', () => {
+        const currentTheme = document.body.classList.contains('theme-dark') ? 'dark' : 'light';
+        const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        manualThemeOverride = nextTheme;
+        saveThemeOverride(nextTheme);
+        applyThemeMode(manualThemeOverride);
+      });
+    }
   }
 
   const isMobileView = () => (mobileMedia ? mobileMedia.matches : window.innerWidth <= 900);

--- a/index.php
+++ b/index.php
@@ -97,7 +97,7 @@ $featureItems = [
     <style id="md-brand-style"><?= htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8') ?></style>
   <?php endif; ?>
 </head>
-<body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>">
+<body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>" data-disable-dark-mode="1">
   <div class="landing-page">
     <header class="<?= htmlspecialchars($landingHeroClass, ENT_QUOTES, 'UTF-8') ?>"<?= $landingHeroStyle !== '' ? ' style="' . $landingHeroStyle . '"' : '' ?>>
       <div class="landing-hero__content" aria-labelledby="landing-title">

--- a/login.php
+++ b/login.php
@@ -150,7 +150,7 @@ render_login:
     <style id="md-brand-style"><?= htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8') ?></style>
   <?php endif; ?>
 </head>
-<body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>">
+<body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>" data-disable-dark-mode="1">
   <div class="login-shell">
     <div class="login-tile">
       <div class="login-visual">


### PR DESCRIPTION
### Motivation
- The login and landing pages should always render in light mode because a site-wide dark theme was affecting their visual appearance and usability.

### Description
- Add a page-level opt-out attribute `data-disable-dark-mode="1"` to the `<body>` tag in `login.php` and `index.php` to mark these pages as light-only.
- Update `assets/js/app.js` to detect the `data-disable-dark-mode` flag and, when present, force the light theme and hide the theme toggle control.
- Preserve existing auto/manual theme detection and geolocation-based behavior for pages that do not opt out.

### Testing
- Ran `php -l login.php` and `php -l index.php`, both reported no syntax errors and succeeded.
- Verified the code changes via `git diff` for `login.php`, `index.php`, and `assets/js/app.js` to ensure intended edits were applied.
- Attempted automated UI validation with Playwright to capture screenshots of `login.php` and `index.php`, but browser execution failed in this environment (Chromium crashed and Firefox returned `NS_ERROR_NET_RESET`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6dbea9b0832da572adf7cb7665aa)