### PR TITLE
Align draft notification UI to yellow warning semantics

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2372,9 +2372,9 @@ body.theme-dark .md-floating-save-draft {
   padding: 0.85rem 1rem;
   border-radius: 12px;
   background: transparent;
-  color: var(--status-warning);
-  border: 1px solid var(--status-warning-border);
-  border-left: 5px solid var(--status-warning);
+  color: var(--status-warning, #f59e0b);
+  border: 1px solid var(--status-warning-border, rgba(245, 158, 11, 0.35));
+  border-left: 5px solid var(--status-warning, #f59e0b);
   margin-bottom: 1.1rem;
 }
 
@@ -2391,9 +2391,9 @@ body.theme-dark .md-floating-save-draft {
 }
 
 .md-alert.warning {
-  color: var(--status-warning);
-  border-color: var(--status-warning-border);
-  border-left-color: var(--status-warning);
+  color: var(--status-warning, #f59e0b);
+  border-color: var(--status-warning-border, rgba(245, 158, 11, 0.35));
+  border-left-color: var(--status-warning, #f59e0b);
 }
 
 .md-offline-banner {
@@ -2484,9 +2484,9 @@ body.theme-dark .md-offline-banner__dismiss:focus {
 
 .md-offline-draft[data-state="queued"],
 .md-offline-draft[data-state="reminder"] {
-  border-color: var(--status-warning-border);
-  border-left-color: var(--status-warning);
-  color: var(--status-warning);
+  border-color: var(--status-warning-border, rgba(245, 158, 11, 0.35));
+  border-left-color: var(--status-warning, #f59e0b);
+  color: var(--status-warning, #f59e0b);
 }
 
 .md-offline-draft[data-state="error"] {
@@ -2497,9 +2497,10 @@ body.theme-dark .md-offline-banner__dismiss:focus {
 
 .md-draft-alert {
   margin-top: 1rem;
-  border-color: var(--status-warning-border);
-  border-left-color: var(--status-warning);
-  color: var(--status-warning);
+  background: var(--status-warning-surface, #fef3c7);
+  border-color: var(--status-warning-border, rgba(245, 158, 11, 0.35));
+  border-left-color: var(--status-warning, #f59e0b);
+  color: var(--status-warning, #f59e0b);
 }
 
 .md-draft-list {
@@ -2512,17 +2513,17 @@ body.theme-dark .md-offline-banner__dismiss:focus {
 }
 
 .md-draft-list a {
-  color: var(--status-warning);
+  color: var(--status-warning, #f59e0b);
   font-weight: 600;
   text-decoration: none;
 }
 
 .md-draft-list a:visited {
-  color: var(--status-warning);
+  color: var(--status-warning, #f59e0b);
 }
 
 .md-draft-alert strong {
-  color: var(--status-warning);
+  color: var(--status-warning, #f59e0b);
 }
 
 .md-draft-list a:hover,
@@ -3784,7 +3785,7 @@ body.theme-dark .md-upgrade-progress__message {
 
 body.theme-dark .md-work-function-card {
   background: color-mix(in srgb, var(--md-surface) 90%, transparent);
-  border-color: color-mix(in srgb, var(--app-text-secondary, #d1d5f9) 18%, transparent);
+  border-color: color-mix(in srgb, var(--app-text-secondary, #94a3b8) 18%, transparent);
 }
 
 .md-work-function-heading h3 {


### PR DESCRIPTION
### Motivation
- The draft/notification UI was using a browner/purple fallback when theme variables were missing, which made notification states read incorrectly instead of a mid-spectrum yellow between success (green) and danger (red).
- The intent is to ensure a strict green/yellow/red semantic mapping for success/warning/error states so notifications consistently read as yellow.

### Description
- Updated warning fallbacks from `#b45309` to a true yellow fallback `#f59e0b` and adjusted border alpha to `rgba(245, 158, 11, 0.35)` across alert and draft-related selectors in `assets/css/styles.css` (including `.md-alert`, `.md-alert.warning`, `.md-draft-alert`, `.md-draft-list a`, and queued/reminder `.md-offline-draft`).
- Added an explicit notification surface background `background: var(--status-warning-surface, #fef3c7)` to `.md-draft-alert` so the "Saved drafts awaiting submission" tile reads as a notification card rather than plain text with a border.
- Kept existing semantic tokens in `config.php` aligned (`--semantic-warning` / `--status-warning` set to `#f59e0b`) and preserved prior dark-mode border fallback adjustments.

### Testing
- Ran `git diff --check` which completed with no issues.
- Linted PHP files with `php -l config.php` and `php -l my_performance.php`, both returned no syntax errors.
- Started a local PHP dev server and executed a Playwright screenshot script which produced an artifact, but the page returned HTTP 500 due to a DB connection refusal in this environment so full visual validation was incomplete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7415ae30832d91975d4c8b54f3be)