### PR TITLE
Standardize status colors: map info/notification to warning (yellow)

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -218,7 +218,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             t($t, 'upgrade_available', 'Version %s is available for installation.'),
                             $availableVersionDisplay
                         );
-                        $flashType = 'success';
+                        $flashType = 'info';
                     } else {
                         $upgradeState['available_version'] = null;
                         $upgradeState['available_version_label'] = $availableLabel;
@@ -308,7 +308,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         error_log('Installed release metadata save failed: ' . $versionStoreError->getMessage());
                     }
                     $flashMessage = t($t, 'upgrade_command_success', 'Upgrade command completed successfully. Review the logs for details.');
-                    $flashType = 'success';
+                    $flashType = 'info';
                 } else {
                     $flashMessage = t($t, 'upgrade_command_failed', 'The upgrade command returned a non-zero exit code. Review the log for details.');
                     $flashType = 'error';

--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -70,7 +70,7 @@ body.md-bg {
 }
 
 .md-status-indicator:focus-visible {
-  outline: 2px solid var(--status-info, #2563eb);
+  outline: 2px solid var(--status-info, #f59e0b);
   outline-offset: 2px;
 }
 
@@ -354,6 +354,12 @@ body.md-bg {
   padding: 12px 16px;
   border-radius: 12px;
   margin: 12px 0;
+}
+
+.md-alert.info {
+  color: var(--status-info);
+  border-color: var(--status-info-border);
+  border-left-color: var(--status-info);
 }
 
 .md-table {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -517,7 +517,7 @@ button,
 }
 
 .md-status-indicator:focus-visible {
-  outline: 2px solid var(--status-info, #2563eb);
+  outline: 2px solid var(--status-info, #f59e0b);
   outline-offset: 2px;
 }
 
@@ -1134,8 +1134,8 @@ body.theme-dark .md-user-card__heading h3 {
 
 .md-user-chip.status-active {
   background: var(--semantic-success-soft);
-  color: var(--semantic-success-text);
-  box-shadow: inset 0 0 0 1px var(--semantic-success-soft);
+  color: var(--semantic-success);
+  box-shadow: inset 0 0 0 1px var(--semantic-success-border);
 }
 
 .md-user-chip.status-pending {
@@ -1158,8 +1158,8 @@ body.theme-dark .md-user-chip {
 
 body.theme-dark .md-user-chip.status-active {
   background: var(--semantic-success-soft);
-  color: var(--semantic-success-text);
-  box-shadow: inset 0 0 0 1px var(--semantic-success-soft);
+  color: var(--semantic-success);
+  box-shadow: inset 0 0 0 1px var(--semantic-success-border);
 }
 
 body.theme-dark .md-user-chip.status-pending {
@@ -2396,6 +2396,12 @@ body.theme-dark .md-floating-save-draft {
   border-left-color: var(--status-warning);
 }
 
+.md-alert.info {
+  color: var(--status-info);
+  border-color: var(--status-info-border);
+  border-left-color: var(--status-info);
+}
+
 .md-offline-banner {
   position: fixed;
   left: 50%;
@@ -2665,6 +2671,12 @@ body.theme-dark .md-alert.success {
   color: var(--status-success);
   border-color: var(--status-success-border);
   border-left-color: var(--status-success);
+}
+
+body.theme-dark .md-alert.info {
+  color: var(--status-info);
+  border-color: var(--status-info-border);
+  border-left-color: var(--status-info);
 }
 
 body.theme-dark .md-logo {

--- a/config.php
+++ b/config.php
@@ -1155,7 +1155,7 @@ function site_theme_tokens(array $cfg): array
     $warning = $semanticWarning;
     $danger = $semanticDanger;
     $success = $semanticSuccess;
-    $info = adjust_hsl($primary, -20.0, 1.08, 1.02);
+    $info = $semanticWarning;
 
     $lightSurface = tint_color($primary, 0.9);
     $lightSurfaceAlt = tint_color($primary, 0.95);


### PR DESCRIPTION
### Motivation
- Align notification/"info" tokens with the system semantic warning color so all notification/warning UI elements use the same yellow palette.
- Ensure focus outlines and alert fallbacks consistently show the agreed yellow instead of a brand blue fallback.

### Description
- Mapped `info` token to the semantic warning color by setting `$info = $semanticWarning` in `config.php`.
- Updated CSS fallbacks from `#2563eb` to `#f59e0b` for `--status-info` in `assets/css/styles.css` and `assets/css/material.css` so focus outlines follow the yellow convention.
- Added `.md-alert.info` rules in both CSS files to support info-style alerts using `--status-info` tokens.
- Adjusted `.md-user-chip.status-active` to use `var(--semantic-success)` for text and `var(--semantic-success-border)` for the inset border, and changed two admin flash message types from `'success'` to `'info'` in `admin/dashboard.php` where an available upgrade/upgrade command completion is informational.

### Testing
- Ran `php -l config.php` and the file passed with no syntax errors. 
- Ran `php -l admin/dashboard.php` and the file passed with no syntax errors. 
- Attempted a Playwright screenshot of `/admin/dashboard.php`, but the local web server returned `ERR_EMPTY_RESPONSE` so no runtime screenshot could be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e6beee7b0832d8d7573d34a332f50)