### PR TITLE
Refresh landing page to align with updated EPSS navigation and UI style

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -34,6 +34,47 @@ body.landing-body {
   color: inherit;
 }
 
+.landing-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 12;
+  backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--md-surface) 90%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--app-border) 60%, transparent);
+}
+
+.landing-topbar__inner {
+  width: min(1200px, 100% - 2rem);
+  margin: 0 auto;
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.landing-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.9rem;
+}
+
+.landing-nav a {
+  text-decoration: none;
+  color: var(--app-text-primary, #10213d);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.4rem 0.65rem;
+  border-radius: 999px;
+}
+
+.landing-nav a:hover,
+.landing-nav a:focus-visible {
+  color: var(--landing-primary);
+  background: color-mix(in srgb, var(--landing-primary) 10%, transparent);
+}
+
 
 .landing-hero {
   position: relative;
@@ -145,6 +186,7 @@ body.landing-body {
   background: rgba(255, 255, 255, 0.12);
   backdrop-filter: blur(12px);
   box-shadow: var(--landing-shadow-sm);
+  text-decoration: none;
 }
 
 .landing-brand__logo {
@@ -291,6 +333,87 @@ body.landing-body {
   gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
+.landing-stats-grid,
+.landing-events-grid,
+.landing-news-grid,
+.landing-partners-grid {
+  width: var(--landing-container-width);
+  margin: 0 auto;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.landing-stats-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.landing-stat-card {
+  padding: 1.4rem;
+  border-radius: var(--landing-radius-md);
+  background: color-mix(in srgb, var(--md-surface) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--app-border) 65%, transparent);
+  box-shadow: var(--landing-shadow-sm);
+}
+
+.landing-stat-card h3 {
+  margin: 0;
+  color: var(--landing-primary-dark);
+  font-size: 1.9rem;
+}
+
+.landing-stat-card p {
+  margin: 0.45rem 0 0;
+  color: var(--app-text-secondary, #4b5a6b);
+}
+
+.landing-events-grid,
+.landing-news-grid {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.landing-event-card,
+.landing-news-card {
+  padding: 1.35rem;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--md-surface) 96%, transparent);
+  border: 1px solid color-mix(in srgb, var(--app-border) 65%, transparent);
+}
+
+.landing-event-card h3 {
+  margin: 0;
+  color: var(--landing-primary-dark);
+  font-size: 1.06rem;
+}
+
+.landing-event-card p,
+.landing-news-card p {
+  margin: 0.6rem 0 0;
+  color: var(--app-text-secondary, #4b5a6b);
+}
+
+.landing-gallery-band {
+  width: var(--landing-container-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.landing-gallery-band span,
+.landing-partners-grid span {
+  border-radius: 12px;
+  padding: 0.95rem 1rem;
+  text-align: center;
+  border: 1px dashed color-mix(in srgb, var(--landing-primary) 28%, transparent);
+  background: color-mix(in srgb, var(--landing-primary) 7%, transparent);
+  font-weight: 600;
+  color: var(--landing-primary-dark);
+}
+
+.landing-partners-grid {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
 .landing-feature-card {
   padding: 1.85rem;
   border-radius: var(--landing-radius-md);
@@ -385,6 +508,28 @@ body.landing-body {
   align-items: flex-start;
 }
 
+.landing-footer h3 {
+  margin: 0 0 0.7rem;
+  color: #1d2939;
+  font-size: 1rem;
+}
+
+.landing-footer__links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.landing-footer__links a {
+  text-decoration: none;
+  color: var(--app-text-secondary, #4f5b66);
+}
+
+.landing-footer__links a:hover,
+.landing-footer__links a:focus-visible {
+  text-decoration: underline;
+}
+
 .landing-footer__languages {
   display: flex;
   flex-wrap: wrap;
@@ -426,6 +571,12 @@ body.landing-body {
 }
 
 @media (max-width: 720px) {
+  .landing-topbar__inner {
+    flex-direction: column;
+    justify-content: center;
+    padding: 0.75rem 0;
+  }
+
   .landing-hero {
     text-align: center;
   }

--- a/index.php
+++ b/index.php
@@ -96,6 +96,46 @@ $featureItems = [
         ), ENT_QUOTES, 'UTF-8'),
     ],
 ];
+
+$navItems = [
+    ['label' => htmlspecialchars(t($t, 'nav_home', 'Home'), ENT_QUOTES, 'UTF-8'), 'href' => '#home'],
+    ['label' => htmlspecialchars(t($t, 'nav_about', 'About'), ENT_QUOTES, 'UTF-8'), 'href' => '#about'],
+    ['label' => htmlspecialchars(t($t, 'nav_procurement', 'Procurement'), ENT_QUOTES, 'UTF-8'), 'href' => '#services'],
+    ['label' => htmlspecialchars(t($t, 'nav_marketing', 'Marketing'), ENT_QUOTES, 'UTF-8'), 'href' => '#news'],
+    ['label' => htmlspecialchars(t($t, 'nav_resources', 'Resources'), ENT_QUOTES, 'UTF-8'), 'href' => '#gallery'],
+    ['label' => htmlspecialchars(t($t, 'nav_news', 'News'), ENT_QUOTES, 'UTF-8'), 'href' => '#news'],
+    ['label' => htmlspecialchars(t($t, 'nav_contact', 'Contact'), ENT_QUOTES, 'UTF-8'), 'href' => '#contact'],
+];
+
+$statTiles = [
+    ['value' => '12K+', 'label' => htmlspecialchars(t($t, 'stat_registered_users', 'Registered professionals'), ENT_QUOTES, 'UTF-8')],
+    ['value' => '97%', 'label' => htmlspecialchars(t($t, 'stat_timely_reviews', 'On-time review completion'), ENT_QUOTES, 'UTF-8')],
+    ['value' => '350+', 'label' => htmlspecialchars(t($t, 'stat_active_programs', 'Active development programmes'), ENT_QUOTES, 'UTF-8')],
+    ['value' => '24/7', 'label' => htmlspecialchars(t($t, 'stat_portal_access', 'Portal availability'), ENT_QUOTES, 'UTF-8')],
+];
+
+$eventCards = [
+    [
+        'title' => htmlspecialchars(t($t, 'event_one_title', 'Leadership coaching workshop'), ENT_QUOTES, 'UTF-8'),
+        'meta' => htmlspecialchars(t($t, 'event_one_meta', '12 May 2026 · Addis Ababa'), ENT_QUOTES, 'UTF-8'),
+    ],
+    [
+        'title' => htmlspecialchars(t($t, 'event_two_title', 'Digital appraisal rollout briefing'), ENT_QUOTES, 'UTF-8'),
+        'meta' => htmlspecialchars(t($t, 'event_two_meta', '18 May 2026 · Virtual session'), ENT_QUOTES, 'UTF-8'),
+    ],
+    [
+        'title' => htmlspecialchars(t($t, 'event_three_title', 'Performance data quality clinic'), ENT_QUOTES, 'UTF-8'),
+        'meta' => htmlspecialchars(t($t, 'event_three_meta', '26 May 2026 · Hawassa'), ENT_QUOTES, 'UTF-8'),
+    ],
+];
+
+$newsCards = [
+    htmlspecialchars(t($t, 'news_one', 'New quarterly performance framework and templates are now available.'), ENT_QUOTES, 'UTF-8'),
+    htmlspecialchars(t($t, 'news_two', 'Regional managers can now submit consolidated reports in a single workflow.'), ENT_QUOTES, 'UTF-8'),
+    htmlspecialchars(t($t, 'news_three', 'Supervisor scorecards include stronger competency benchmarking insights.'), ENT_QUOTES, 'UTF-8'),
+];
+
+$partners = ['MoPS', 'MoE', 'Civil Service Commission', 'Regional Bureaus', 'HR Council'];
 ?>
 <!doctype html>
 <html lang="<?= $langAttr ?>" data-base-url="<?= $baseUrl ?>">
@@ -157,8 +197,23 @@ $featureItems = [
 </head>
 <body class="<?= $bodyClass ?>" style="<?= $bodyStyle ?>" data-disable-dark-mode="1">
   <div class="landing-page">
-    <header class="<?= htmlspecialchars($landingHeroClass, ENT_QUOTES, 'UTF-8') ?>"<?= $landingHeroStyle !== '' ? ' style="' . $landingHeroStyle . '"' : '' ?>>
-      <div class="landing-hero__content" aria-labelledby="landing-title">
+    <header class="landing-topbar" id="home">
+      <div class="landing-topbar__inner">
+        <a class="landing-brand" href="#home">
+          <img src="<?= $logo ?>" alt="<?= $logoAlt ?>" class="landing-brand__logo">
+          <span class="landing-brand__name"><?= $siteName ?></span>
+        </a>
+        <nav class="landing-nav" aria-label="<?= htmlspecialchars(t($t, 'main_navigation', 'Main navigation'), ENT_QUOTES, 'UTF-8') ?>">
+          <?php foreach ($navItems as $item): ?>
+            <a href="<?= $item['href'] ?>"><?= $item['label'] ?></a>
+          <?php endforeach; ?>
+        </nav>
+        <a class="landing-button landing-button--primary" href="<?= $loginUrl ?>"><?= $primaryCta ?></a>
+      </div>
+    </header>
+
+    <section class="<?= htmlspecialchars($landingHeroClass, ENT_QUOTES, 'UTF-8') ?>"<?= $landingHeroStyle !== '' ? ' style="' . $landingHeroStyle . '"' : '' ?>>
+      <div class="landing-hero__content" aria-labelledby="landing-title" id="about">
         <div class="landing-brand">
           <img src="<?= $logo ?>" alt="<?= $logoAlt ?>" class="landing-brand__logo">
           <span class="landing-brand__name"><?= $siteName ?></span>
@@ -190,10 +245,21 @@ $featureItems = [
           <?php endforeach; ?>
         </ul>
       </div>
-    </header>
+    </section>
 
     <main class="landing-main" aria-labelledby="features-heading">
-      <section class="landing-section landing-section--features">
+      <section class="landing-section landing-section--stats">
+        <div class="landing-stats-grid">
+          <?php foreach ($statTiles as $tile): ?>
+            <article class="landing-stat-card">
+              <h3><?= $tile['value'] ?></h3>
+              <p><?= $tile['label'] ?></p>
+            </article>
+          <?php endforeach; ?>
+        </div>
+      </section>
+
+      <section class="landing-section landing-section--features" id="services">
         <div class="landing-section__header">
           <h2 id="features-heading"><?= htmlspecialchars(t($t, 'features_heading', 'What sets the experience apart'), ENT_QUOTES, 'UTF-8') ?></h2>
           <p><?= htmlspecialchars(t($t, 'features_subheading', 'Every element of the portal is crafted to elevate employee growth and organisational performance.'), ENT_QUOTES, 'UTF-8') ?></p>
@@ -208,10 +274,66 @@ $featureItems = [
         </div>
       </section>
 
+      <section class="landing-section landing-section--events" id="events">
+        <div class="landing-section__header">
+          <h2><?= htmlspecialchars(t($t, 'events_heading', 'Upcoming events'), ENT_QUOTES, 'UTF-8') ?></h2>
+        </div>
+        <div class="landing-events-grid">
+          <?php foreach ($eventCards as $event): ?>
+            <article class="landing-event-card">
+              <h3><?= $event['title'] ?></h3>
+              <p><?= $event['meta'] ?></p>
+            </article>
+          <?php endforeach; ?>
+        </div>
+      </section>
+
+      <section class="landing-section landing-section--news" id="news">
+        <div class="landing-section__header">
+          <h2><?= htmlspecialchars(t($t, 'latest_news', 'Latest news'), ENT_QUOTES, 'UTF-8') ?></h2>
+        </div>
+        <div class="landing-news-grid">
+          <?php foreach ($newsCards as $news): ?>
+            <article class="landing-news-card"><p><?= $news ?></p></article>
+          <?php endforeach; ?>
+        </div>
+      </section>
+
+      <section class="landing-section landing-section--gallery" id="gallery">
+        <div class="landing-section__header">
+          <h2><?= htmlspecialchars(t($t, 'gallery_heading', 'Resources and highlights'), ENT_QUOTES, 'UTF-8') ?></h2>
+        </div>
+        <div class="landing-gallery-band">
+          <span><?= htmlspecialchars(t($t, 'gallery_one', 'Policy templates'), ENT_QUOTES, 'UTF-8') ?></span>
+          <span><?= htmlspecialchars(t($t, 'gallery_two', 'Training playbooks'), ENT_QUOTES, 'UTF-8') ?></span>
+          <span><?= htmlspecialchars(t($t, 'gallery_three', 'Assessment guides'), ENT_QUOTES, 'UTF-8') ?></span>
+        </div>
+      </section>
+
+      <section class="landing-section landing-section--partners">
+        <div class="landing-section__header">
+          <h2><?= htmlspecialchars(t($t, 'partners_heading', 'Trusted partners'), ENT_QUOTES, 'UTF-8') ?></h2>
+        </div>
+        <div class="landing-partners-grid">
+          <?php foreach ($partners as $partner): ?>
+            <span><?= htmlspecialchars($partner, ENT_QUOTES, 'UTF-8') ?></span>
+          <?php endforeach; ?>
+        </div>
+      </section>
+
+      <section class="landing-section landing-section--cta">
+        <div class="landing-section__content">
+          <h2><?= htmlspecialchars(t($t, 'cta_heading', 'Start your next performance cycle with confidence'), ENT_QUOTES, 'UTF-8') ?></h2>
+          <p><?= htmlspecialchars(t($t, 'cta_description', 'Access evaluations, insights, and resources from one secure platform.'), ENT_QUOTES, 'UTF-8') ?></p>
+          <a class="landing-button landing-button--accent" href="<?= $loginUrl ?>"><?= $primaryCta ?></a>
+        </div>
+      </section>
+
     </main>
 
-    <footer class="landing-footer">
+    <footer class="landing-footer" id="contact">
       <div class="landing-footer__contact" aria-label="<?= htmlspecialchars(t($t, 'contact_details_label', 'Contact details'), ENT_QUOTES, 'UTF-8') ?>">
+        <h3><?= htmlspecialchars(t($t, 'contact_us', 'Contact us'), ENT_QUOTES, 'UTF-8') ?></h3>
         <?php if ($address !== ''): ?>
           <div><strong><?= $addressLabel ?>:</strong> <?= $address ?></div>
         <?php endif; ?>
@@ -219,7 +341,14 @@ $featureItems = [
           <div><strong><?= $contactLabel ?>:</strong> <?= $contact ?></div>
         <?php endif; ?>
       </div>
+      <div class="landing-footer__links">
+        <h3><?= htmlspecialchars(t($t, 'quick_links', 'Quick links'), ENT_QUOTES, 'UTF-8') ?></h3>
+        <a href="#services"><?= htmlspecialchars(t($t, 'services', 'Services'), ENT_QUOTES, 'UTF-8') ?></a>
+        <a href="#events"><?= htmlspecialchars(t($t, 'events', 'Events'), ENT_QUOTES, 'UTF-8') ?></a>
+        <a href="#news"><?= htmlspecialchars(t($t, 'news', 'News'), ENT_QUOTES, 'UTF-8') ?></a>
+      </div>
       <div class="landing-footer__meta">
+        <h3><?= htmlspecialchars(t($t, 'languages', 'Languages'), ENT_QUOTES, 'UTF-8') ?></h3>
         <div class="landing-footer__languages" aria-label="<?= htmlspecialchars(t($t, 'language_switch_label', 'Change language'), ENT_QUOTES, 'UTF-8') ?>">
           <?php
           $links = [];


### PR DESCRIPTION
### Motivation
- The public-facing site should match the client's updated EPSS.gov.et theme and structure, including a prominent top navigation, hero, and modern homepage bands for stats, events, news, resources and partners.
- Improve clarity of primary actions (sign-in CTA) and surface quick links/language controls in the footer to mirror the EPSS layout and UX patterns.

### Description
- Reworked the landing page template (`index.php`) to add a sticky top navigation (`$navItems`), move the hero into its own section, and introduce new content bands: stats, features/services, events, news, gallery/resources, partners, and CTA; also added example content arrays (`$statTiles`, `$eventCards`, `$newsCards`, `$partners`).
- Updated the footer to include a `Contact us` heading, a `Quick links` block and clearer language switch heading.
- Added new CSS rules in `assets/css/landing.css` for the sticky top bar, navigation styling, stat/event/news/partner grids and cards, gallery band, and responsive adjustments for mobile layouts.
- Kept existing hero, brand and feature markup but adjusted structure and IDs to support in-page navigation and the EPSS-like flow.

### Testing
- Ran PHP syntax checks with `php -l index.php` and `php -l config.php`, both returning no syntax errors.
- Launched a local PHP dev server and captured a visual verification screenshot using Playwright to confirm layout and visual hierarchy (screenshot artifact created during validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e84667c7c832db2c50af516ab8228)