### PR TITLE
Match questionnaire headings and dividers to exact dark theme color

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2241,6 +2241,16 @@ body.theme-dark .email-template-placeholders code {
   scroll-margin-top: 108px;
 }
 
+
+.md-assessment-shell .md-card-title,
+.md-assessment-shell .md-section-title {
+  color: var(--app-primary-dark);
+}
+
+.md-assessment-shell .md-divider {
+  background: var(--app-primary-dark);
+}
+
 @media (max-width: 1024px) {
   .md-questionnaire-layout {
     grid-template-columns: 1fr;

--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -575,7 +575,7 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
 </head><body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
 <?php include __DIR__.'/templates/header.php'; ?>
 <section class="md-section">
-<div class="md-card md-elev-2">
+<div class="md-card md-elev-2 md-assessment-shell">
   <h2 class="md-card-title"><?=t($t,'submit_assessment','Submit Assessment')?></h2>
   <?php if ($flashNotice): ?><div class="md-alert success"><?=htmlspecialchars($flashNotice, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
   <?php if (!empty($err)): ?><div class="md-alert error"><?=htmlspecialchars($err, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>


### PR DESCRIPTION
### Motivation
- The questionnaire headings and divider underlines used a blended/purple tint that did not match the site dark theme and needed to use the exact dark shade for visual consistency. 
- The change scopes the style to the Submit Assessment card so only the questionnaire UI is affected.

### Description
- Updated `assets/css/styles.css` to set `.md-assessment-shell .md-divider` to `background: var(--app-primary-dark);` replacing the prior `color-mix` tint. 
- Ensured `.md-assessment-shell .md-card-title` and `.md-assessment-shell .md-section-title` are set to `color: var(--app-primary-dark);` for consistent heading color. 
- Added the `md-assessment-shell` class to the main card container in `submit_assessment.php` to scope the new styles to the Submit Assessment UI.

### Testing
- Ran `php -l submit_assessment.php` to validate PHP syntax and it succeeded. 
- Started a local PHP dev server and captured a Playwright screenshot of `http://127.0.0.1:8000/submit_assessment.php` to visually verify the divider and heading colors, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e92927678832db395f6eddf8b5260)