### PR TITLE
Auto-select performance period in submit assessment from user data

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -51,13 +51,41 @@ try {
     $fallback = $pdo->query("SELECT id, title FROM questionnaire WHERE status='published' ORDER BY title");
     $q = $fallback ? $fallback->fetchAll() : [];
 }
-$periods = $pdo->query("SELECT id, label FROM performance_period ORDER BY period_start DESC")->fetchAll();
+$periods = $pdo->query("SELECT id, label, period_start, period_end FROM performance_period ORDER BY period_start DESC")->fetchAll();
 $qid = (int)($_GET['qid'] ?? ($q[0]['id'] ?? 0));
 $availableQuestionnaireIds = array_map(static fn($row) => (int)$row['id'], $q);
 if ($qid && !in_array($qid, $availableQuestionnaireIds, true)) {
     $qid = $availableQuestionnaireIds[0] ?? 0;
 }
-$periodId = (int)($_GET['performance_period_id'] ?? ($periods[0]['id'] ?? 0));
+$findBestPeriodId = static function (array $periodRows, ?string $targetDate): int {
+    if (!$periodRows) {
+        return 0;
+    }
+    $fallbackId = (int)($periodRows[0]['id'] ?? 0);
+    if (!$targetDate) {
+        return $fallbackId;
+    }
+    $targetTs = strtotime($targetDate);
+    if ($targetTs === false) {
+        return $fallbackId;
+    }
+    foreach ($periodRows as $periodRow) {
+        $start = isset($periodRow['period_start']) ? strtotime((string)$periodRow['period_start']) : false;
+        $end = isset($periodRow['period_end']) ? strtotime((string)$periodRow['period_end']) : false;
+        if ($start === false || $end === false) {
+            continue;
+        }
+        if ($targetTs >= $start && $targetTs <= $end) {
+            return (int)$periodRow['id'];
+        }
+    }
+    return $fallbackId;
+};
+$periodTargetDate = trim((string)($user['next_assessment_date'] ?? ''));
+if ($periodTargetDate === '') {
+    $periodTargetDate = date('Y-m-d');
+}
+$periodId = (int)($_GET['performance_period_id'] ?? $findBestPeriodId($periods, $periodTargetDate));
 
 $draftSaved = $_GET['saved'] ?? '';
 if ($draftSaved === 'draft') {


### PR DESCRIPTION
### Motivation
- Improve the default performance period selected when a user opens the assessment form so it aligns with their scheduled/next assessment date rather than arbitrarily selecting the latest period.

### Description
- Loaded `period_start` and `period_end` in `submit_assessment.php` so period rows include date range boundaries for matching. 
- Added a `findBestPeriodId` helper to pick the best default performance period by checking whether a target date falls within each period's `period_start`/`period_end` range and falling back to the most recent period when no match is found. 
- Wired the helper to use the signed-in user's `next_assessment_date` (and fallback to `date('Y-m-d')` when unset), while preserving explicit `performance_period_id` values supplied via the query string. 
- Kept form POST handling unchanged so user-selected or submitted `performance_period_id` continues to be validated and used.

### Testing
- Ran `php -l submit_assessment.php` to verify there are no syntax errors and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e91faee10832d8ebf004abcd06ea0)