### PR TITLE
Set submit_assessment.php as the default user landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ delivery workflow with ISO/IEC 12207 (software life cycle), ISO/IEC 25010
 ## Default navigation
 
 - `/index.php` – login
-- `/my_performance.php` – personal performance hub (default landing page after login)
+- `/my_performance.php` – personal performance hub for reviewing historical results
 - `/submit_assessment.php` – assessment submission
 - `/admin/*` – administration
 

--- a/dashboard.php
+++ b/dashboard.php
@@ -4,6 +4,6 @@ auth_required();
 refresh_current_user($pdo);
 require_profile_completion($pdo);
 
-$redirectTarget = url_for('my_performance.php');
+$redirectTarget = url_for('submit_assessment.php');
 header('Location: ' . $redirectTarget);
 exit;

--- a/login.php
+++ b/login.php
@@ -74,7 +74,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $_SESSION['pending_notice'] = true;
                 header('Location: ' . url_for('profile.php?pending=1'));
             } else {
-                header('Location: ' . url_for('my_performance.php'));
+                header('Location: ' . url_for('submit_assessment.php'));
             }
             exit;
         }
@@ -117,10 +117,10 @@ $signInSubheading = t(
     'Use your credentials to continue to your personalized workspace.'
 );
 $formAction = htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8');
-$offlineRedirect = htmlspecialchars(url_for('my_performance.php'), ENT_QUOTES, 'UTF-8');
+$offlineRedirect = htmlspecialchars(url_for('submit_assessment.php'), ENT_QUOTES, 'UTF-8');
 $offlineWarmRoutes = htmlspecialchars(implode(',', [
-    url_for('my_performance.php'),
     url_for('submit_assessment.php'),
+    url_for('my_performance.php'),
     url_for('profile.php'),
     url_for('dashboard.php'),
 ]), ENT_QUOTES, 'UTF-8');

--- a/oauth.php
+++ b/oauth.php
@@ -140,7 +140,7 @@ if ($status === 'pending') {
     exit;
 }
 
-header('Location: ' . url_for('my_performance.php'));
+header('Location: ' . url_for('submit_assessment.php'));
 exit;
 
 function oauth_fail(string $message, string $provider): void

--- a/set_lang.php
+++ b/set_lang.php
@@ -9,7 +9,7 @@ if (!empty($_SESSION['user']['id'])) {
     $stmt->execute([$lang, $_SESSION['user']['id']]);
     refresh_current_user($pdo);
 }
-$redirect = cleanRedirect($_SERVER['HTTP_REFERER'] ?? '', url_for('my_performance.php'));
+$redirect = cleanRedirect($_SERVER['HTTP_REFERER'] ?? '', url_for('submit_assessment.php'));
 header('Location: ' . $redirect);
 exit;
 ?>


### PR DESCRIPTION
### Motivation
- Users should land on the assessment submission workflow by default instead of the personal performance hub to streamline the primary task flow.
- Update application redirects and PWA/offline routing so all login paths (local, SSO, dashboard entry, and language switch fallback) are consistent with the new default.

### Description
- Changed the post-login redirect in `login.php` to `submit_assessment.php` for active users and adjusted the offline redirect/warm routes to prioritize the submit page.
- Updated OAuth success flow in `oauth.php` to redirect to `submit_assessment.php` for active SSO users.
- Updated `dashboard.php` so the dashboard entry redirect target is `submit_assessment.php`.
- Updated `set_lang.php` to use `submit_assessment.php` as the safe fallback referrer and updated `README.md` to reflect that `my_performance.php` is for reviewing historical results.

### Testing
- Ran `php -l login.php` which reported no syntax errors.
- Ran `php -l oauth.php` which reported no syntax errors.
- Ran `php -l dashboard.php` which reported no syntax errors.
- Ran `php -l set_lang.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e9db019c8832d89ff51e461e84ede)