### PR TITLE
Revert footer to dark shaded styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2879,8 +2879,8 @@ body.theme-dark .md-button.md-secondary {
 
 .md-footer {
   padding: 2.8rem 1.35rem 2.5rem;
-  background: linear-gradient(160deg, var(--footer-bg-start) 0%, var(--footer-bg-mid) 55%, var(--footer-bg-end) 100%);
-  color: var(--footer-text);
+  background: linear-gradient(160deg, var(--app-on-surface-strong) 0%, var(--app-on-surface-strong) 55%, var(--app-on-surface-muted) 100%);
+  color: var(--app-surface-alt);
   position: relative;
   overflow: hidden;
 }
@@ -2907,14 +2907,14 @@ body.theme-dark .md-button.md-secondary {
 }
 
 .md-footer a {
-  color: var(--footer-link);
+  color: var(--app-surface-highlight);
   text-decoration: none;
   font-weight: 500;
 }
 
 .md-footer a:hover,
 .md-footer a:focus {
-  color: var(--footer-link-hover);
+  color: var(--app-text-inverse);
   text-decoration: underline;
 }
 

--- a/config.php
+++ b/config.php
@@ -1380,12 +1380,6 @@ function site_theme_tokens(array $cfg): array
         '--app-chart-surface' => $lightSurface,
         '--app-chip-bg' => rgba_string($primary, 0.08),
         '--app-chip-border' => $lightBorder,
-        '--footer-bg-start' => $onSurfaceStrong,
-        '--footer-bg-mid' => $onSurfaceStrong,
-        '--footer-bg-end' => $onSurfaceMuted,
-        '--footer-text' => $lightSurfaceAlt,
-        '--footer-link' => $lightSurfaceHighlight,
-        '--footer-link-hover' => $inverseText,
         'color' => $lightText,
     ];
 


### PR DESCRIPTION
### Motivation

- Restore the page footer to the previous dark-shaded appearance after a recent change that froze a separate footer palette. 
- Ensure footer uses the app theme tokens so dark theme contrast and site-wide theming remain consistent.

### Description

- Updated `assets/css/styles.css` to restore the footer background and text colors to the app-level dark tokens (`--app-on-surface-strong`, `--app-on-surface-muted`, `--app-surface-alt`) and to revert link color bindings to `--app-surface-highlight` and `--app-text-inverse` for hover state. 
- Removed the footer-specific light-theme token overrides from `config.php` so the footer is no longer frozen to a separate set of `--footer-*` variables. 
- No changes were required to `templates/footer.php`; the visual behavior is driven by the restored CSS and token configuration.

### Testing

- Ran `php -l config.php` and it reported no syntax errors (passed). 
- Ran `php -l templates/footer.php` and it reported no syntax errors (passed). 
- Performed an automated visual check by launching a local PHP server and capturing a full-page screenshot via Playwright, with the screenshot saved to `artifacts/footer-revert.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea0eea380832d8c37460610e571d4)