### PR TITLE
Increase dark mode contrast for stronger readability

### DIFF
--- a/config.php
+++ b/config.php
@@ -1228,16 +1228,16 @@ function site_theme_tokens(array $cfg): array
 
     $bgGradient = sprintf('linear-gradient(140deg, %s 0%%, %s 45%%, %s 100%%)', $palette['bgStart'], $palette['bgMid'], $palette['bgEnd']);
 
-    $darkBackground = shade_color($primary, 0.88);
-    $darkSurface = shade_color($primary, 0.82);
-    $darkSurfaceAlt = shade_color($primary, 0.76);
-    $darkSurfaceMuted = shade_color($primary, 0.72);
-    $darkText = tint_color($primary, 0.68);
-    $darkTextSecondary = tint_color($primary, 0.58);
-    $darkTextMuted = tint_color($primary, 0.5);
-    $darkBorder = rgba_string($darkText, 0.24);
-    $darkBorderStrong = rgba_string($darkText, 0.32);
-    $darkDivider = rgba_string($darkText, 0.18);
+    $darkBackground = shade_color($primary, 0.94);
+    $darkSurface = shade_color($primary, 0.9);
+    $darkSurfaceAlt = shade_color($primary, 0.86);
+    $darkSurfaceMuted = shade_color($primary, 0.82);
+    $darkText = tint_color($primary, 0.88);
+    $darkTextSecondary = tint_color($primary, 0.78);
+    $darkTextMuted = tint_color($primary, 0.68);
+    $darkBorder = rgba_string($darkText, 0.38);
+    $darkBorderStrong = rgba_string($darkText, 0.5);
+    $darkDivider = rgba_string($darkText, 0.28);
     $darkShadow = '0 18px 46px ' . rgba_string(shade_color($primary, 0.74), 0.7);
     $darkShadowStrong = '0 22px 60px ' . rgba_string(shade_color($primary, 0.7), 0.78);
     $darkPrimarySoft = rgba_string($primaryLight, 0.22);
@@ -1272,8 +1272,8 @@ function site_theme_tokens(array $cfg): array
     $darkOnPrimary = contrast_color($primaryLight);
     $darkOnPrimarySoft = rgba_string($darkOnPrimary, 0.22);
     $darkOnPrimarySubtle = rgba_string($darkOnPrimary, 0.16);
-    $darkOnSurfaceMuted = tint_color($primary, 0.55);
-    $darkBgGradient = sprintf('radial-gradient(circle at top, %s 0%%, %s 45%%, %s 100%%)', shade_color($primary, 0.78), shade_color($primary, 0.82), shade_color($primary, 0.92));
+    $darkOnSurfaceMuted = tint_color($primary, 0.72);
+    $darkBgGradient = sprintf('radial-gradient(circle at top, %s 0%%, %s 45%%, %s 100%%)', shade_color($primary, 0.86), shade_color($primary, 0.9), shade_color($primary, 0.96));
 
     $root = [
         '--brand-primary' => $primary,


### PR DESCRIPTION
### Motivation

- Users requested a much stronger contrast between text and background in dark mode to improve legibility across the app.
- The change aims to make primary and secondary copy stand out more clearly against dark surfaces and to strengthen structural affordances like borders and dividers.

### Description

- Increased darkness of dark-mode background and surface tokens by adjusting `--app-bg`, `--app-surface`, `--app-surface-alt`, and related source values inside `site_theme_tokens` in `config.php`.
- Brightened dark-mode text tokens by raising the tint values used for `--app-text-primary`, `--app-text-secondary`, and `--app-text-muted` so foreground copy contrasts more with dark surfaces.
- Strengthened border/divider opacity by increasing RGBA alpha values for dark borders and dividers, and updated the dark radial background gradient stops to preserve contrast across the page.

### Testing

- Ran `php -l config.php` and it returned no syntax errors.
- Launched the built-in PHP server with `php -S` to validate runtime, but page rendering returned HTTP 500 due to an unavailable DB connection in the environment.
- Attempted a Playwright Chromium screenshot which crashed in this environment (browser process SIGSEGV), so it failed to complete.
- Successfully ran a Playwright Firefox screenshot script against the local server which produced a dark-mode screenshot for visual validation (DB errors did not prevent the capture in that run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea138b3cc832da867cce61f81a283)