### PR TITLE
Fix unresolved BuildConfig usage and modernize Android Gradle scripts

### DIFF
--- a/Android App/app/build.gradle
+++ b/Android App/app/build.gradle
@@ -4,29 +4,32 @@ plugins {
 }
 
 android {
-    namespace 'org.cas2025.prototype'
-    compileSdk 34
+    namespace = 'org.cas2025.prototype'
+    compileSdk = 34
 
     defaultConfig {
-        applicationId "org.cas2025.prototype"
-        minSdk 24
-        targetSdk 34
-        versionCode 1
-        versionName "0.1.0"
+        applicationId = "org.cas2025.prototype"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "0.1.0"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            minifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile('proguard-android-optimize.txt'),
+                'proguard-rules.pro'
+            )
         }
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
@@ -34,7 +37,7 @@ android {
     }
 
     buildFeatures {
-        viewBinding true
+        viewBinding = true
     }
 }
 

--- a/Android App/build.gradle
+++ b/Android App/build.gradle
@@ -1,10 +1,4 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
-        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21'
-    }
+plugins {
+    id 'com.android.application' version '8.5.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.0.21' apply false
 }


### PR DESCRIPTION
### Motivation
- Remove an unresolved `BuildConfig.VERSION_CODE` reference in the in-app update checker which caused build/runtime issues by deriving the installed version at runtime instead of referencing generated constants.
- Make the Android Gradle scripts compatible with recent AGP/Gradle conventions to remove deprecation warnings and use the plugins DSL.

### Description
- Replaced uses of `BuildConfig.VERSION_CODE` in `MainActivity.kt` with a new `getInstalledVersionCode()` helper that reads the installed APK version via `PackageManager` and uses API-safe calls for Android 13+ and older devices.
- Updated update-check logic to parse `latestVersionCode` with a fallback to the runtime installed version and compare against the runtime value before prompting an update.
- Added required imports (`PackageManager`, `Build`) and implemented safe `longVersionCode`/`versionCode` handling and clamped to `Int.MAX_VALUE` to avoid overflow on older APIs.
- Modernized `Android App/app/build.gradle` by switching to assignment-style properties (e.g. `namespace = ...`, `versionCode = ...`), updating `proguardFiles` and other syntax to match current AGP expectations, and replaced the top-level `buildscript` with the `plugins` DSL in `Android App/build.gradle`.

### Testing
- Ran `gradle help --warning-mode=all` in the `Android App/` directory which completed successfully.
- Attempted `gradle :app:assembleDebug` which failed due to a missing Android SDK configuration (`sdk.dir` / `ANDROID_HOME`) in this environment, so a full compilation could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ea58a2f14832d9a3458c4c18f7df8)