### PR TITLE
Fix required-fields popup staying visible on profile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1637,6 +1637,10 @@ body.theme-dark .md-help-bubble::before {
   justify-content: center;
 }
 
+.md-required-popup[hidden] {
+  display: none;
+}
+
 .md-required-popup__backdrop {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
### Motivation

- The profile page's required-fields popup used a base `display:flex` style that prevented the native `hidden` attribute from hiding it, leaving the page unusable after dismissal.

### Description

- Added an explicit CSS rule `.md-required-popup[hidden] { display: none; }` to `assets/css/styles.css` so `popup.hidden = true` actually hides the dialog.

### Testing

- Verified `php -l profile.php` (no syntax errors) and validated the fix by running a dev server and capturing a Playwright screenshot of `http://127.0.0.1:8080/profile.php`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eabc1c27c832d8863c774adbd13bb)