### PR TITLE
Connectivity button: green when online, orange when offline; larger status dot

### DIFF
--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -58,7 +58,7 @@ body.md-bg {
   gap: 6px;
   padding: 6px 14px;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.18);
+  background: var(--status-success-soft, rgba(34, 197, 94, 0.22));
   color: inherit;
   border: none;
   cursor: pointer;
@@ -75,11 +75,11 @@ body.md-bg {
 }
 
 .md-status-dot {
-  width: 10px;
-  height: 10px;
+  width: 14px;
+  height: 14px;
   border-radius: 50%;
   background: var(--status-success);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2);
   transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
@@ -88,7 +88,7 @@ body.md-bg {
 }
 
 .md-status-indicator.is-offline {
-  background: rgba(255, 140, 0, 0.18);
+  background: var(--status-warning-surface, rgba(255, 140, 0, 0.2));
 }
 
 .md-status-indicator.is-offline .md-status-dot {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -502,7 +502,7 @@ button,
   gap: 0.5rem;
   padding: 0 1rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.16);
+  background: var(--status-success-soft, rgba(34, 197, 94, 0.22));
   color: inherit;
   border: none;
   cursor: pointer;
@@ -520,11 +520,11 @@ button,
 }
 
 .md-status-dot {
-  width: 0.6rem;
-  height: 0.6rem;
+  width: 0.9rem;
+  height: 0.9rem;
   border-radius: 50%;
   background: var(--status-success);
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.45);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2);
   transition: background 0.3s ease, box-shadow 0.3s ease;
 }
 
@@ -533,7 +533,7 @@ button,
 }
 
 .md-status-indicator.is-offline {
-  background: rgba(255, 140, 0, 0.18);
+  background: var(--status-warning-surface, rgba(255, 140, 0, 0.2));
 }
 
 .md-status-indicator.is-offline .md-status-dot {


### PR DESCRIPTION
### Motivation
- The connectivity control should clearly communicate online/offline state by using a green appearance when online and an orange appearance when offline, and the colored circle should occupy more of the button for better visibility.

### Description
- Updated `assets/css/styles.css` to set the online indicator background to `var(--status-success-soft, rgba(34, 197, 94, 0.22))`, increase `.md-status-dot` from `0.6rem` to `0.9rem`, and adjust the dot ring to a matching green tint; the offline background now uses `var(--status-warning-surface, rgba(255, 140, 0, 0.2))`.
- Applied the same changes to `assets/css/material.css` (dot size from `10px` to `14px`, green-tinted background/ring and offline surface variable) to keep theme variants consistent.
- Left unrelated appbar/button styles unchanged and ensured the styling change is scoped to the connectivity indicator classes `.md-status-indicator` and `.md-status-dot`.

### Testing
- Verified the CSS diffs for `assets/css/styles.css` and `assets/css/material.css` to confirm the intended style changes were applied successfully.
- Launched a local PHP server with `php -S 0.0.0.0:8000` and validated the app served correctly.
- Captured a Playwright screenshot of the running app to verify the updated connectivity UI (artifact generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f889f3d74832d80aa22ecd8db37c9)