### PR TITLE
Fix placeholder department/team backfill in catalogs

### DIFF
--- a/lib/department_teams.php
+++ b/lib/department_teams.php
@@ -42,6 +42,18 @@ function canonical_department_team_slug(string $value): string
     return canonical_department_slug($value);
 }
 
+function is_placeholder_department_value(string $value): bool
+{
+    $canonical = canonical_department_slug($value);
+    return in_array($canonical, ['none', 'na', 'n_a', 'null', 'unknown', 'not_applicable'], true);
+}
+
+function is_placeholder_team_value(string $value): bool
+{
+    $canonical = canonical_department_team_slug($value);
+    return in_array($canonical, ['none', 'na', 'n_a', 'null', 'unknown', 'not_applicable'], true);
+}
+
 function unique_slug(string $candidate, array $existing): string
 {
     $base = $candidate;
@@ -127,7 +139,7 @@ function ensure_department_catalog(PDO $pdo): void
         if ($userStmt) {
             while ($value = $userStmt->fetchColumn()) {
                 $label = trim((string)$value);
-                if ($label === '') {
+                if ($label === '' || is_placeholder_department_value($label)) {
                     continue;
                 }
                 $slug = canonical_department_slug($label);
@@ -222,13 +234,22 @@ function ensure_department_team_catalog(PDO $pdo): void
 
         $insert = $pdo->prepare('INSERT INTO department_team_catalog (slug, department_slug, label, sort_order, archived_at) VALUES (?, ?, ?, ?, NULL)');
         $seenSlugs = array_fill_keys(array_keys($teamRows), true);
+        $seenLabelsByDepartment = [];
+        foreach ($teamRows as $existingRow) {
+            $existingDepartment = trim((string)($existingRow['department_slug'] ?? ''));
+            $existingLabel = trim((string)($existingRow['label'] ?? ''));
+            if ($existingDepartment === '' || $existingLabel === '') {
+                continue;
+            }
+            $seenLabelsByDepartment[$existingDepartment][strtolower($existingLabel)] = true;
+        }
         $sort = count($teamRows) + 1;
 
         $sourceStmt = $pdo->query("SELECT DISTINCT department, cadre FROM users WHERE cadre IS NOT NULL AND TRIM(cadre) <> '' ORDER BY department, cadre");
         if ($sourceStmt) {
             while ($row = $sourceStmt->fetch(PDO::FETCH_ASSOC)) {
                 $teamLabel = trim((string)($row['cadre'] ?? ''));
-                if ($teamLabel === '') {
+                if ($teamLabel === '' || is_placeholder_team_value($teamLabel)) {
                     continue;
                 }
                 $dep = resolve_department_slug($pdo, (string)($row['department'] ?? ''));
@@ -237,14 +258,7 @@ function ensure_department_team_catalog(PDO $pdo): void
                 }
 
                 // If a row already exists by exact label+department, skip.
-                $exists = false;
-                foreach ($teamRows as $r) {
-                    if (strcasecmp($r['label'], $teamLabel) === 0 && $r['department_slug'] === $dep) {
-                        $exists = true;
-                        break;
-                    }
-                }
-                if ($exists) {
+                if (isset($seenLabelsByDepartment[$dep][strtolower($teamLabel)])) {
                     continue;
                 }
 
@@ -259,6 +273,7 @@ function ensure_department_team_catalog(PDO $pdo): void
                 $insert->execute([$slug, $dep, $teamLabel, $sort]);
                 $seenSlugs[$slug] = true;
                 $teamRows[$slug] = ['department_slug' => $dep, 'label' => $teamLabel];
+                $seenLabelsByDepartment[$dep][strtolower($teamLabel)] = true;
                 $sort++;
             }
         }
@@ -341,7 +356,7 @@ function department_options(PDO $pdo): array
 function resolve_department_slug(PDO $pdo, string $value): string
 {
     $value = trim($value);
-    if ($value === '') {
+    if ($value === '' || is_placeholder_department_value($value)) {
         return '';
     }
 

--- a/tests/department_team_catalog_test.php
+++ b/tests/department_team_catalog_test.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/department_teams.php';
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, department TEXT, cadre TEXT)');
+
+$pdo->exec("INSERT INTO users (department, cadre) VALUES
+    ('none', 'none'),
+    ('None', 'N/A'),
+    ('Finance & Grants', 'Logistics'),
+    ('finance', 'logistics'),
+    ('Unknown', 'Unknown'),
+    ('', 'Dispatch')");
+
+$catalog = department_catalog($pdo);
+if (isset($catalog['none'])) {
+    fwrite(STDERR, "Placeholder department 'none' should not be backfilled into catalog.\n");
+    exit(1);
+}
+
+if (resolve_department_slug($pdo, 'none') !== '') {
+    fwrite(STDERR, "'none' should resolve to an empty department slug.\n");
+    exit(1);
+}
+
+$teams = department_team_catalog($pdo);
+$matches = [];
+foreach ($teams as $row) {
+    if (strcasecmp((string)($row['label'] ?? ''), 'logistics') === 0 && (string)($row['department_slug'] ?? '') === 'finance') {
+        $matches[] = $row;
+    }
+    if (strcasecmp((string)($row['label'] ?? ''), 'none') === 0) {
+        fwrite(STDERR, "Placeholder team 'none' should not be backfilled into catalog.\n");
+        exit(1);
+    }
+}
+
+if (count($matches) !== 1) {
+    fwrite(STDERR, "Expected one normalized logistics team for finance department, found " . count($matches) . ".\n");
+    exit(1);
+}
+
+echo "Department/team catalog tests passed.\n";


### PR DESCRIPTION
### Motivation
- Legacy backfill was treating literal placeholder values in `users.department` and `users.cadre` (e.g. `none`, `N/A`, `unknown`) as real metadata, causing spurious catalog entries and extra work on page load. 
- The aim is to prevent placeholder values from being added to department/team catalogs and to make resolution of department inputs robust to those placeholders. 

### Description
- Add `is_placeholder_department_value()` and `is_placeholder_team_value()` helpers and use them to skip placeholder labels during catalog backfill in `lib/department_teams.php`. 
- Update `resolve_department_slug()` to treat placeholder inputs as invalid and return an empty result for them. 
- Optimize team seeding by tracking seen labels per department (`$seenLabelsByDepartment`) to avoid repeated scans and duplicate backfills when creating team rows. 
- Add a regression test `tests/department_team_catalog_test.php` that verifies placeholder departments/teams are skipped, `resolve_department_slug('none')` returns empty, and duplicate/mixed-case team labels are normalized to a single catalog entry. 

### Testing
- Ran PHP syntax check with `php -l lib/department_teams.php` which succeeded. 
- Ran the new regression test with `php tests/department_team_catalog_test.php` which passed. 
- Ran the existing coverage test `php tests/work_function_assignments_test.php` which currently fails with `Initial assignment save did not match expectations.` and will need follow-up investigation to determine whether this change exposed a separate issue or revealed a test/environment assumption.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915491679c832dbb8ab73a41c643fc)