### PR TITLE
Increase dark mode contrast across theme variables

### DIFF
--- a/config.php
+++ b/config.php
@@ -1330,16 +1330,16 @@ function site_theme_tokens(array $cfg): array
 
     $bgGradient = sprintf('linear-gradient(140deg, %s 0%%, %s 45%%, %s 100%%)', $palette['bgStart'], $palette['bgMid'], $palette['bgEnd']);
 
-    $darkBackground = shade_color($primary, 0.94);
-    $darkSurface = shade_color($primary, 0.9);
-    $darkSurfaceAlt = shade_color($primary, 0.86);
-    $darkSurfaceMuted = shade_color($primary, 0.82);
-    $darkText = tint_color($primary, 0.88);
-    $darkTextSecondary = tint_color($primary, 0.78);
-    $darkTextMuted = tint_color($primary, 0.68);
-    $darkBorder = rgba_string($darkText, 0.38);
-    $darkBorderStrong = rgba_string($darkText, 0.5);
-    $darkDivider = rgba_string($darkText, 0.28);
+    $darkBackground = shade_color($primary, 0.975);
+    $darkSurface = shade_color($primary, 0.95);
+    $darkSurfaceAlt = shade_color($primary, 0.92);
+    $darkSurfaceMuted = shade_color($primary, 0.89);
+    $darkText = tint_color($primary, 0.96);
+    $darkTextSecondary = tint_color($primary, 0.9);
+    $darkTextMuted = tint_color($primary, 0.84);
+    $darkBorder = rgba_string($darkText, 0.48);
+    $darkBorderStrong = rgba_string($darkText, 0.62);
+    $darkDivider = rgba_string($darkText, 0.36);
     $darkShadow = '0 18px 46px ' . rgba_string(shade_color($primary, 0.74), 0.7);
     $darkShadowStrong = '0 22px 60px ' . rgba_string(shade_color($primary, 0.7), 0.78);
     $darkPrimarySoft = rgba_string($primaryLight, 0.22);
@@ -1374,8 +1374,8 @@ function site_theme_tokens(array $cfg): array
     $darkOnPrimary = contrast_color($primaryLight);
     $darkOnPrimarySoft = rgba_string($darkOnPrimary, 0.22);
     $darkOnPrimarySubtle = rgba_string($darkOnPrimary, 0.16);
-    $darkOnSurfaceMuted = tint_color($primary, 0.72);
-    $darkBgGradient = sprintf('radial-gradient(circle at top, %s 0%%, %s 45%%, %s 100%%)', shade_color($primary, 0.86), shade_color($primary, 0.9), shade_color($primary, 0.96));
+    $darkOnSurfaceMuted = tint_color($primary, 0.86);
+    $darkBgGradient = sprintf('radial-gradient(circle at top, %s 0%%, %s 48%%, %s 100%%)', shade_color($primary, 0.91), shade_color($primary, 0.955), shade_color($primary, 0.985));
 
     $root = [
         '--brand-primary' => $primary,


### PR DESCRIPTION
### Motivation
- Improve readability and visual separation in the dark theme by increasing contrast between backgrounds, surfaces, text, and borders.

### Description
- Darken background and surface tones by increasing shade levels for ` $darkBackground`, `$darkSurface`, `$darkSurfaceAlt`, and `$darkSurfaceMuted`.
- Brighten dark-mode text tones by increasing tint values for `$darkText`, `$darkTextSecondary`, and `$darkTextMuted`.
- Strengthen separators by increasing opacity on `$darkBorder`, `$darkBorderStrong`, and `$darkDivider` and raise the muted-on-surface value via `$darkOnSurfaceMuted`.
- Adjust the dark radial background gradient stops in `$darkBgGradient` to create clearer depth while preserving brand hue.

### Testing
- Ran `php -l config.php` which reported no syntax errors and succeeded. 
- Started the local dev server and captured a Playwright screenshot of `http://127.0.0.1:8080/login.php`, producing an artifact; the page hit a DB connection error in this environment but the screenshot was still generated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699156187a30832da55b14faef12946a)