### PR TITLE
Harden placeholder department handling and add DB cleanup script

### DIFF
--- a/scripts/cleanup_placeholder_departments.php
+++ b/scripts/cleanup_placeholder_departments.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Cleanup script for accidental placeholder department/team data.
+ *
+ * Usage:
+ *   php scripts/cleanup_placeholder_departments.php --dry-run
+ *   php scripts/cleanup_placeholder_departments.php --apply
+ */
+
+define('APP_BOOTSTRAPPED', true);
+require_once __DIR__ . '/../config.php';
+
+function connect_to_database(): PDO
+{
+    $dbHost = getenv('DB_HOST') ?: '127.0.0.1';
+    $dbName = getenv('DB_NAME') ?: 'epss_v300';
+    $dbUser = getenv('DB_USER') ?: 'epss_user';
+    $dbPass = getenv('DB_PASS') ?: 'StrongPassword123!';
+    $dbPortRaw = getenv('DB_PORT');
+
+    $dsn = sprintf(
+        'mysql:host=%s;%sdbname=%s;charset=utf8mb4',
+        $dbHost,
+        ($dbPortRaw !== false && $dbPortRaw !== '') ? 'port=' . ((int)$dbPortRaw) . ';' : '',
+        $dbName
+    );
+
+    return new PDO($dsn, $dbUser, $dbPass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES => false,
+    ]);
+}
+
+function usage(): void
+{
+    echo "Usage: php scripts/cleanup_placeholder_departments.php [--dry-run|--apply]\n";
+}
+
+$mode = $argv[1] ?? '--dry-run';
+if (!in_array($mode, ['--dry-run', '--apply'], true)) {
+    usage();
+    exit(1);
+}
+
+$apply = $mode === '--apply';
+
+$placeholderRegex = '^(none|na|n_a|null|unknown|not_applicable)(_[0-9]+)?$';
+
+try {
+    $pdo = connect_to_database();
+} catch (PDOException $e) {
+    fwrite(STDERR, 'Unable to connect to database: ' . $e->getMessage() . PHP_EOL);
+    exit(2);
+}
+
+$findDepartmentSlugs = $pdo->prepare(
+    "SELECT slug FROM department_catalog WHERE LOWER(slug) REGEXP :re OR LOWER(TRIM(label)) REGEXP :re"
+);
+$findDepartmentSlugs->execute([':re' => $placeholderRegex]);
+$departmentSlugs = array_values(array_unique(array_map(
+    static fn(array $r): string => trim((string)($r['slug'] ?? '')),
+    $findDepartmentSlugs->fetchAll()
+)));
+$departmentSlugs = array_values(array_filter($departmentSlugs, static fn(string $s): bool => $s !== ''));
+
+$findTeamSlugs = $pdo->prepare(
+    "SELECT slug FROM department_team_catalog WHERE LOWER(slug) REGEXP :re OR LOWER(TRIM(label)) REGEXP :re"
+);
+$findTeamSlugs->execute([':re' => $placeholderRegex]);
+$teamSlugs = array_values(array_unique(array_map(
+    static fn(array $r): string => trim((string)($r['slug'] ?? '')),
+    $findTeamSlugs->fetchAll()
+)));
+$teamSlugs = array_values(array_filter($teamSlugs, static fn(string $s): bool => $s !== ''));
+
+$summary = [
+    'department_slugs_to_archive' => $departmentSlugs,
+    'team_slugs_to_archive' => $teamSlugs,
+    'users_department_to_null' => 0,
+    'users_cadre_to_null' => 0,
+    'questionnaire_department_rows_to_delete' => 0,
+];
+
+if ($departmentSlugs !== []) {
+    $placeholders = implode(',', array_fill(0, count($departmentSlugs), '?'));
+
+    $countUsersDepartment = $pdo->prepare("SELECT COUNT(*) FROM users WHERE department IN ($placeholders)");
+    $countUsersDepartment->execute($departmentSlugs);
+    $summary['users_department_to_null'] = (int)$countUsersDepartment->fetchColumn();
+
+    $countQuestionnaireDepartment = $pdo->prepare("SELECT COUNT(*) FROM questionnaire_department WHERE department_slug IN ($placeholders)");
+    $countQuestionnaireDepartment->execute($departmentSlugs);
+    $summary['questionnaire_department_rows_to_delete'] = (int)$countQuestionnaireDepartment->fetchColumn();
+}
+
+if ($teamSlugs !== []) {
+    $placeholders = implode(',', array_fill(0, count($teamSlugs), '?'));
+    $countUsersCadre = $pdo->prepare("SELECT COUNT(*) FROM users WHERE cadre IN ($placeholders)");
+    $countUsersCadre->execute($teamSlugs);
+    $summary['users_cadre_to_null'] = (int)$countUsersCadre->fetchColumn();
+}
+
+echo "Cleanup mode: " . ($apply ? 'APPLY' : 'DRY RUN') . PHP_EOL;
+echo json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+
+if (!$apply) {
+    exit(0);
+}
+
+try {
+    $pdo->beginTransaction();
+
+    if ($departmentSlugs !== []) {
+        $placeholders = implode(',', array_fill(0, count($departmentSlugs), '?'));
+
+        $clearUsersDepartment = $pdo->prepare("UPDATE users SET department = NULL WHERE department IN ($placeholders)");
+        $clearUsersDepartment->execute($departmentSlugs);
+
+        $deleteQuestionnaireDepartment = $pdo->prepare("DELETE FROM questionnaire_department WHERE department_slug IN ($placeholders)");
+        $deleteQuestionnaireDepartment->execute($departmentSlugs);
+
+        $archiveDepartments = $pdo->prepare("UPDATE department_catalog SET archived_at = CURRENT_TIMESTAMP WHERE slug IN ($placeholders)");
+        $archiveDepartments->execute($departmentSlugs);
+
+        $archiveDepartmentTeams = $pdo->prepare("UPDATE department_team_catalog SET archived_at = CURRENT_TIMESTAMP WHERE department_slug IN ($placeholders)");
+        $archiveDepartmentTeams->execute($departmentSlugs);
+    }
+
+    if ($teamSlugs !== []) {
+        $placeholders = implode(',', array_fill(0, count($teamSlugs), '?'));
+
+        $clearUsersCadre = $pdo->prepare("UPDATE users SET cadre = NULL WHERE cadre IN ($placeholders)");
+        $clearUsersCadre->execute($teamSlugs);
+
+        $archiveTeams = $pdo->prepare("UPDATE department_team_catalog SET archived_at = CURRENT_TIMESTAMP WHERE slug IN ($placeholders)");
+        $archiveTeams->execute($teamSlugs);
+    }
+
+    $pdo->commit();
+    echo "Cleanup applied successfully." . PHP_EOL;
+} catch (Throwable $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    fwrite(STDERR, 'Cleanup failed: ' . $e->getMessage() . PHP_EOL);
+    exit(3);
+}

--- a/tests/department_team_catalog_test.php
+++ b/tests/department_team_catalog_test.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/department_teams.php';
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, department TEXT, cadre TEXT)');
+
+$pdo->exec("INSERT INTO users (department, cadre) VALUES
+    ('none', 'none'),
+    ('none_2', 'none_7'),
+    ('None', 'N/A'),
+    ('Finance & Grants', 'Logistics'),
+    ('finance', 'logistics'),
+    ('Unknown', 'Unknown'),
+    ('', 'Dispatch')");
+
+$catalog = department_catalog($pdo);
+if (isset($catalog['none'])) {
+    fwrite(STDERR, "Placeholder department 'none' should not be backfilled into catalog.\n");
+    exit(1);
+}
+
+if (isset($catalog['none_2'])) {
+    fwrite(STDERR, "Placeholder department variants like 'none_2' should not be backfilled into catalog.\n");
+    exit(1);
+}
+
+if (resolve_department_slug($pdo, 'none') !== '') {
+    fwrite(STDERR, "'none' should resolve to an empty department slug.\n");
+    exit(1);
+}
+
+$teams = department_team_catalog($pdo);
+$matches = [];
+foreach ($teams as $row) {
+    if (strcasecmp((string)($row['label'] ?? ''), 'logistics') === 0 && (string)($row['department_slug'] ?? '') === 'finance') {
+        $matches[] = $row;
+    }
+    if (strcasecmp((string)($row['label'] ?? ''), 'none') === 0) {
+        fwrite(STDERR, "Placeholder team 'none' should not be backfilled into catalog.\n");
+        exit(1);
+    }
+    if (strcasecmp((string)($row['label'] ?? ''), 'none_7') === 0) {
+        fwrite(STDERR, "Placeholder team variants like 'none_7' should not be backfilled into catalog.\n");
+        exit(1);
+    }
+}
+
+if (count($matches) !== 1) {
+    fwrite(STDERR, "Expected one normalized logistics team for finance department, found " . count($matches) . ".\n");
+    exit(1);
+}
+
+echo "Department/team catalog tests passed.\n";


### PR DESCRIPTION
### Motivation
- Large volumes of placeholder department/team values like `none`, `unknown` and their numbered variants (e.g. `none_2`) were being treated as real metadata and backfilled into catalogs, causing catalog bloat and page load issues. 
- The backfill and resolution logic needs to treat these placeholders as invalid to prevent future runaway creation. 
- A safe, auditable cleanup utility is required to identify and neutralize existing placeholder-created rows in the database. 

### Description
- Add robust placeholder detection (`is_placeholder_department_value()` and `is_placeholder_team_value()`) that matches plain placeholders and numbered variants and use them to skip backfill and seeding in `lib/department_teams.php`. 
- Prevent duplicate backfills by tracking an existing case-insensitive label->slug map and by tracking `seen` slugs/labels per department during team seeding in `lib/department_teams.php`. 
- Make `resolve_department_slug()` strict so placeholder inputs always return an empty result and never resolve to active slugs in `lib/department_teams.php`. 
- Add `scripts/cleanup_placeholder_departments.php` which provides `--dry-run` and `--apply` modes to find placeholder slugs (by slug or label), archive matching `department_catalog`/`department_team_catalog` rows, clear `users.department` and `users.cadre`, and remove affected `questionnaire_department` rows. 
- Extend `tests/department_team_catalog_test.php` to cover numbered placeholder variants (`none_2`, `none_7`) and verify placeholders are not backfilled and duplicate/mixed-case entries are normalized. 

### Testing
- Ran PHP lint for `lib/department_teams.php` and `scripts/cleanup_placeholder_departments.php`, both succeeded. 
- Executed `php tests/department_team_catalog_test.php`, which passed. 
- Ran `php tests/work_function_assignments_test.php`, which currently fails with `Initial assignment save did not match expectations.` and will require follow-up investigation. 
- Attempting `php scripts/cleanup_placeholder_departments.php --dry-run` in this environment failed to connect to the database (`SQLSTATE[HY000] [2002] Connection refused`), so dry-run/apply should be run in the target environment against the real DB.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69915491679c832dbb8ab73a41c643fc)