### PR TITLE
Guard department slug resolution in submit_assessment.php

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -23,7 +23,10 @@ try {
         $isStaff = (($user['role'] ?? '') === 'staff');
 
         if ($isStaff) {
-            $department = resolve_department_slug($pdo, trim((string)($user['department'] ?? '')));
+            $rawDepartment = trim((string)($user['department'] ?? ''));
+            $department = function_exists('resolve_department_slug')
+                ? resolve_department_slug($pdo, $rawDepartment)
+                : $rawDepartment;
             if ($department !== '') {
                 $departmentStmt = $pdo->prepare(
                     "SELECT q.id AS id, q.title AS title FROM questionnaire_department qd " .


### PR DESCRIPTION
### Motivation
- Prevent a fatal “undefined function” error during staff department slug resolution when `resolve_department_slug` is not present by falling back to the raw department value.

### Description
- Replace the direct call to `resolve_department_slug($pdo, ...)` with a guarded call that uses `function_exists('resolve_department_slug')` and otherwise uses the trimmed raw department value in `submit_assessment.php`.

### Testing
- Ran `php -l submit_assessment.php` which returned `No syntax errors detected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69937c4a1d68832dbb76d4f63af9531e)