### PR TITLE
Restore admin menu JS by including shared footer in work_function_defaults.php

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -278,4 +278,5 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
     </details>
   </div>
 </section>
+<?php include __DIR__ . '/../templates/footer.php'; ?>
 </body></html>


### PR DESCRIPTION
### Motivation
- The admin defaults page was missing the shared footer include, which prevented footer-injected JavaScript (used by the admin shell/menu) from loading and caused the admin navigation menu to be unresponsive on `admin/work_function_defaults.php`.

### Description
- Add a shared footer include (`templates/footer.php`) to the bottom of `admin/work_function_defaults.php` so the standard footer scripts are executed on this page.

### Testing
- Ran a syntax check with `php -l admin/work_function_defaults.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993828569e4832dbd260240e80c9952)