### PR TITLE
Improve dark theme text contrast with near-white tokens

### DIFF
--- a/config.php
+++ b/config.php
@@ -1334,9 +1334,9 @@ function site_theme_tokens(array $cfg): array
     $darkSurface = shade_color($primary, 0.95);
     $darkSurfaceAlt = shade_color($primary, 0.92);
     $darkSurfaceMuted = shade_color($primary, 0.89);
-    $darkText = tint_color($primary, 0.96);
-    $darkTextSecondary = tint_color($primary, 0.9);
-    $darkTextMuted = tint_color($primary, 0.84);
+    $darkText = tint_color($primary, 0.985);
+    $darkTextSecondary = tint_color($primary, 0.95);
+    $darkTextMuted = tint_color($primary, 0.9);
     $darkBorder = rgba_string($darkText, 0.48);
     $darkBorderStrong = rgba_string($darkText, 0.62);
     $darkDivider = rgba_string($darkText, 0.36);
@@ -1503,7 +1503,7 @@ function site_theme_tokens(array $cfg): array
         '--app-surface' => $darkSurface,
         '--app-surface-alt' => $darkSurfaceAlt,
         '--app-surface-muted' => $darkSurfaceMuted,
-        '--app-surface-highlight' => tint_color($darkSurfaceAlt, 0.1),
+        '--app-surface-highlight' => $darkText,
         '--app-bg' => $darkBgGradient,
         '--app-shadow-soft' => $darkShadow,
         '--app-shadow-strong' => $darkShadowStrong,


### PR DESCRIPTION
### Motivation
- Increase text/background contrast in the dark theme so body text, secondary text and muted text appear near-white and remain legible on dark surfaces.

### Description
- Adjusted dark theme color tokens in `config.php` by brightening `--app-text-primary`, `--app-text-secondary`, and `--app-text-muted` (updated `tint_color` parameters) and set `--app-surface-highlight` to reuse the near-white primary text token.

### Testing
- Ran `php -l config.php` to verify no syntax errors (success) and launched a temporary PHP server plus a Playwright script to capture a dark-mode screenshot for visual confirmation (`artifacts/dark-theme-contrast.png`) (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b0db0410832da50288dce0b908c9)