### PR TITLE
Add assessment-page anti-copy interaction guards

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -22,6 +22,77 @@
   const themeOverrideStorageKey = 'hrassess:theme:override';
   const darkModeDisabled = body && body.getAttribute('data-disable-dark-mode') === '1';
 
+
+  const isAssessmentProtected = document.body && document.body.getAttribute('data-assessment-protected') === 'true';
+  const hasEditableTarget = (eventTarget) => {
+    const el = eventTarget instanceof Element ? eventTarget : null;
+    if (!el) {
+      return false;
+    }
+    const editable = el.closest('input, textarea, [contenteditable="true"], [contenteditable=""]');
+    if (!editable) {
+      return false;
+    }
+    if (editable instanceof HTMLInputElement) {
+      const type = (editable.type || '').toLowerCase();
+      return !['checkbox', 'radio', 'button', 'submit', 'reset', 'range', 'color', 'file'].includes(type);
+    }
+    return true;
+  };
+
+  const installAssessmentContentProtection = () => {
+    if (!isAssessmentProtected) {
+      return;
+    }
+
+    document.addEventListener('contextmenu', (event) => {
+      if (hasEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+    });
+
+    document.addEventListener('copy', (event) => {
+      if (hasEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+    });
+
+    document.addEventListener('cut', (event) => {
+      if (hasEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+    });
+
+    document.addEventListener('paste', (event) => {
+      if (hasEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      const key = (event.key || '').toLowerCase();
+      const blockedShortcut = (
+        (event.ctrlKey || event.metaKey) && ['c', 'x', 'v', 's', 'p', 'u'].includes(key)
+      ) || (
+        (event.ctrlKey || event.metaKey) && event.shiftKey && ['i', 'j', 'c', 's'].includes(key)
+      ) || key === 'printscreen' || key === 'f12';
+
+      if (!blockedShortcut) {
+        return;
+      }
+      if (hasEditableTarget(event.target) && ['c', 'x', 'v'].includes(key)) {
+        return;
+      }
+      event.preventDefault();
+    });
+  };
+
+  installAssessmentContentProtection();
+
   const applyTheme = (theme) => {
     const next = theme === 'dark' ? 'dark' : 'light';
     document.body.classList.toggle('theme-dark', next === 'dark');

--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -635,7 +635,7 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
 <link rel="manifest" href="<?=asset_url('manifest.php')?>">
 <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
 <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
-</head><body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
+</head><body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>" data-assessment-protected="true">
 <?php include __DIR__.'/templates/header.php'; ?>
 <section class="md-section">
 <div class="md-card md-elev-2 md-assessment-shell">


### PR DESCRIPTION
### Motivation
- Prevent copying or capturing assessment content on the questionnaire submission page by restricting context menu, clipboard actions and common shortcuts while preserving form editing.

### Description
- Mark the assessment page with a scoped flag by adding `data-assessment-protected="true"` to the `<body>` on `submit_assessment.php` so protections apply only to that page.
- Add client-side guards in `assets/js/app.js` that activate when the body flag is present to block right-click (`contextmenu`), `copy`, `cut`, and `paste` events outside editable fields and to block common keyboard shortcuts for copy/paste/print/devtools (`Ctrl/Cmd + C/X/V/S/P/U`, `Ctrl/Cmd + Shift + I/J/C/S`, `F12`, `PrintScreen`).
- The guards permit normal editing workflows by allowing copy/cut/paste inside text inputs, textareas and `contenteditable` elements.

### Testing
- Ran PHP lint: `php -l submit_assessment.php` — succeeded.
- Validated JS syntax: `node --check assets/js/app.js` — succeeded.
- Launched a local PHP dev server and ran a Playwright capture to verify the protected page rendered, but the application request encountered a database connection error in this environment (`SQLSTATE[HY000] [2002] Connection refused`) while capturing; server started successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971fee60e4832d89c7caec232b2d11)