### PR TITLE
Add confirmation popup before final assessment submission

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -1316,6 +1316,12 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
         const submitAction = resolveSubmitAction(event);
         lastSubmitAction = null;
         const isFinalSubmit = submitAction === 'submit_final';
+        const finalSubmitConfirmationMessage = 'Please review your responses carefully before submitting. Once submitted, you will not be able to make any changes.';
+
+        if (isFinalSubmit && !window.confirm(finalSubmitConfirmationMessage)) {
+          event.preventDefault();
+          return;
+        }
 
         if (!isAppOnline()) {
           event.preventDefault();


### PR DESCRIPTION
### Motivation
- Prevent accidental finalization by prompting users to confirm when they click the final `Submit` action so they can review responses before they become immutable.

### Description
- Add a JavaScript confirmation dialog in the assessment form submit handler in `submit_assessment.php` that triggers only for the `submit_final` action and uses the exact message `Please review your responses carefully before submitting. Once submitted, you will not be able to make any changes.`, cancelling submission when the user declines.

### Testing
- Ran a PHP syntax check with `php -l /workspace/CAS2025/submit_assessment.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997204b9398832da6cd46fc15252a61)