### PR TITLE
Guard PDO rollBack calls with inTransaction in submit_assessment.php

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -320,7 +320,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 }
             }
             if (!$isDraftSave && $missingRequired) {
-                $pdo->rollBack();
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
                 $err = t($t, 'required_questions_missing', 'Please complete all required questions before submitting.');
                 if (count($missingRequired) <= 5) {
                     $err .= ' ' . t($t, 'missing_questions_list', 'Missing:') . ' ' . implode(', ', array_map(static function ($label) use ($t) {
@@ -351,7 +353,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 exit;
             }
         } catch (Exception $e) {
-            $pdo->rollBack();
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
             error_log('submit_assessment failed: ' . $e->getMessage());
             $err = t($t, 'submission_failed', 'We could not save your responses. Please try again.');
         }


### PR DESCRIPTION
### Motivation
- Prevent a fatal "No active transaction" error when `PDO::rollBack()` is invoked after a transaction has already been closed during submission validation or exception handling.

### Description
- Add transaction-state guards using `if ($pdo->inTransaction()) { $pdo->rollBack(); }` in `submit_assessment.php` in the required-field validation flow and the exception `catch` block so rollback is only attempted when a transaction is active.

### Testing
- Ran `php -l submit_assessment.php` to check syntax, which reported no errors.
- No automated unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997431058d8832da919705f480a2f74)