### PR TITLE
Fix local draft loss on final submit confirmation flow

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -1481,12 +1481,6 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
         } else {
           pendingSubmit = isFinalSubmit;
           persistDraft();
-          if (isFinalSubmit) {
-            clearDraft();
-            offlineStatus.dataset.state = '';
-            offlineStatus.textContent = '';
-            offlineStatus.hidden = true;
-          }
         }
       });
 


### PR DESCRIPTION
### Motivation
- Final submit flow was clearing the local draft in the browser immediately when online, causing saved answers to be lost if the server-side save failed or validation returned the form, so the form appeared reset.

### Description
- Removed the premature client-side `clearDraft()`/offline status clearing in `submit_assessment.php` so final submit now only persists the draft/pending state and does not wipe local storage before the server confirms the save.

### Testing
- Ran syntax check with `php -l submit_assessment.php` which returned no errors, and inspected the `git diff` to confirm only the premature `clearDraft()` path was removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699861aa26cc832dbfcd52c4a53b94ea)