### PR TITLE
Use correct-answer scoring and add per-section include_in_scoring

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -119,6 +119,7 @@ CREATE TABLE questionnaire_section (
   description TEXT NULL,
   order_index INT NOT NULL DEFAULT 0,
   is_active TINYINT(1) NOT NULL DEFAULT 1,
+  include_in_scoring TINYINT(1) NOT NULL DEFAULT 1,
   FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -163,3 +163,51 @@ function questionnaire_even_likert_weights(array $items, float $totalWeight = 10
     }
     return $weights;
 }
+
+/**
+ * Determine if an item can be scored using the correct-answer method.
+ *
+ * @param array<string, mixed> $item
+ */
+function questionnaire_item_uses_correct_answer(array $item): bool
+{
+    $type = strtolower((string)($item['type'] ?? ''));
+    if ($type !== 'choice') {
+        return false;
+    }
+    if (!empty($item['allow_multiple'])) {
+        return false;
+    }
+    return !empty($item['requires_correct']);
+}
+
+/**
+ * Decide whether a section should be included in scoring.
+ *
+ * @param array<string, mixed> $section
+ */
+function questionnaire_section_included_in_scoring(array $section): bool
+{
+    if (array_key_exists('include_in_scoring', $section)) {
+        return !empty($section['include_in_scoring']);
+    }
+    return true;
+}
+
+/**
+ * Evaluate whether a question was answered correctly.
+ *
+ * @param array<int, mixed> $answerSet
+ */
+function questionnaire_answer_is_correct(array $answerSet, string $correctValue): bool
+{
+    if ($correctValue === '') {
+        return false;
+    }
+    foreach ($answerSet as $entry) {
+        if (is_array($entry) && isset($entry['valueString']) && (string)$entry['valueString'] === $correctValue) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -147,6 +147,9 @@ ALTER TABLE questionnaire
 ALTER TABLE questionnaire_section
   ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER order_index;
 
+ALTER TABLE questionnaire_section
+  ADD COLUMN IF NOT EXISTS include_in_scoring TINYINT(1) NOT NULL DEFAULT 1 AFTER is_active;
+
 ALTER TABLE questionnaire_item
   ADD COLUMN IF NOT EXISTS is_required TINYINT(1) NOT NULL DEFAULT 0 AFTER allow_multiple;
 
@@ -180,6 +183,10 @@ DEALLOCATE PREPARE stmt;
 UPDATE questionnaire_section
 SET is_active = 1
 WHERE is_active IS NULL;
+
+UPDATE questionnaire_section
+SET include_in_scoring = 1
+WHERE include_in_scoring IS NULL;
 
 UPDATE questionnaire_item
 SET is_active = 1


### PR DESCRIPTION
### Motivation
- Provide a simpler, consistent scoring model that counts correct answers rather than relying on manual weight distribution. 
- Allow administrators to exclude entire sections from scoring via a stored `include_in_scoring` flag. 
- Keep analytics and per-response/per-section breakdowns aligned with submission scoring rules. 

### Description
- Add a new `include_in_scoring` column to `questionnaire_section` in `init.sql` and `upgrade_to_v3.sql` and backfill existing rows to default-included. 
- Introduce shared scoring helpers in `lib/scoring.php`: `questionnaire_item_uses_correct_answer`, `questionnaire_section_included_in_scoring`, and `questionnaire_answer_is_correct`. 
- Switch submission scoring in `submit_assessment.php` from weighted-point aggregation to correct-answer percentage (`correct / total included`) and only count items that meet the correct-answer and section-inclusion rules. 
- Update analytics (`admin/analytics.php`) and section breakdown generation (`lib/performance_sections.php`) to compute scores using the same correct-answer + section inclusion logic and to fetch per-item correct answers. 
- Update admin questionnaire save flow (`admin/questionnaire_manage.php`) and the questionnaire builder UI (`assets/js/questionnaire-builder.js`) to persist and expose `include_in_scoring` per section, remove manual weight UI/actions and related client-side weight controls, and simplify scoring UI. 

### Testing
- Ran `php -l` on modified PHP files: `lib/scoring.php`, `submit_assessment.php`, `lib/performance_sections.php`, `admin/analytics.php`, and `admin/questionnaire_manage.php` and all returned no syntax errors. 
- Verified client script with `node --check assets/js/questionnaire-builder.js` and it passed. 
- Started a local PHP server and captured a browser screenshot of the updated admin questionnaire UI via a Playwright script to validate the new `Include in scoring` toggle rendered correctly. 
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998894e19b0832dbedf0a3b53b821e1)