### PR TITLE
Add colorful hero section to landing page

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -289,6 +289,76 @@ body.landing-body {
   background: rgba(255, 255, 255, 0.12);
 }
 
+
+.landing-section--hero {
+  margin-top: 0.25rem;
+}
+
+.landing-hero-panel {
+  width: var(--landing-container-width);
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 3.25rem);
+  border-radius: var(--landing-radius-lg);
+  background:
+    radial-gradient(100% 140% at 0% 0%, color-mix(in srgb, var(--landing-accent) 24%, transparent), transparent 70%),
+    radial-gradient(120% 120% at 100% 100%, color-mix(in srgb, var(--landing-primary) 22%, transparent), transparent 75%),
+    linear-gradient(135deg, color-mix(in srgb, var(--md-surface) 92%, transparent), color-mix(in srgb, var(--app-primary-soft, #d7e5ff) 38%, transparent));
+  border: 1px solid color-mix(in srgb, var(--landing-primary) 20%, transparent);
+  box-shadow: var(--landing-shadow-md);
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+  align-items: center;
+}
+
+.landing-hero-copy__eyebrow {
+  margin: 0;
+  display: inline-block;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--landing-primary) 14%, transparent);
+  color: var(--landing-primary-dark);
+  font-size: 0.84rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.landing-hero-copy__title {
+  margin: 1rem 0 0.8rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.18;
+  color: var(--landing-primary-darker);
+}
+
+.landing-hero-copy__subtitle {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--app-text-secondary, #43546a);
+  line-height: 1.75;
+  font-size: 1.06rem;
+}
+
+.landing-hero-copy__actions {
+  margin-top: 1.7rem;
+}
+
+.landing-hero-badges {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(145px, 1fr));
+  gap: 0.85rem;
+}
+
+.landing-hero-badges span {
+  padding: 1rem 1.1rem;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--md-surface) 90%, transparent);
+  color: var(--landing-primary-dark);
+  font-weight: 600;
+  box-shadow: 0 10px 20px color-mix(in srgb, var(--app-shadow-soft) 60%, transparent);
+  border: 1px solid color-mix(in srgb, var(--landing-primary) 18%, transparent);
+}
+
 .landing-main {
   flex: 1;
   background: transparent;
@@ -577,8 +647,13 @@ body.landing-body {
     padding: 0.75rem 0;
   }
 
-  .landing-hero {
+  .landing-hero,
+  .landing-hero-panel {
     text-align: center;
+  }
+
+  .landing-hero-panel {
+    grid-template-columns: 1fr;
   }
 
   .landing-brand {

--- a/index.php
+++ b/index.php
@@ -21,6 +21,12 @@ $baseUrl = htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8');
 $langAttr = htmlspecialchars($locale, ENT_QUOTES, 'UTF-8');
 $loginUrl = htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8');
 $primaryCta = htmlspecialchars(t($t, 'sign_in', 'Sign In'), ENT_QUOTES, 'UTF-8');
+$heroEyebrow = htmlspecialchars(t($t, 'hero_eyebrow', 'National performance excellence platform'), ENT_QUOTES, 'UTF-8');
+$heroTitle = htmlspecialchars(t($t, 'hero_title', 'Bring every performance conversation into one vibrant workspace'), ENT_QUOTES, 'UTF-8');
+$heroSubtitle = htmlspecialchars(t($t, 'hero_subtitle', 'From planning to recognition, help teams stay aligned with clear goals, real-time updates, and easy collaboration.'), ENT_QUOTES, 'UTF-8');
+$heroBadgeOne = htmlspecialchars(t($t, 'hero_badge_one', 'Goal alignment'), ENT_QUOTES, 'UTF-8');
+$heroBadgeTwo = htmlspecialchars(t($t, 'hero_badge_two', '360° feedback'), ENT_QUOTES, 'UTF-8');
+$heroBadgeThree = htmlspecialchars(t($t, 'hero_badge_three', 'Learning insights'), ENT_QUOTES, 'UTF-8');
 $addressLabel = htmlspecialchars(t($t, 'address_label', 'Address'), ENT_QUOTES, 'UTF-8');
 $contactLabel = htmlspecialchars(t($t, 'contact_label', 'Contact'), ENT_QUOTES, 'UTF-8');
 $featureItems = [
@@ -108,6 +114,24 @@ $partners = ['MoPS', 'MoE', 'Civil Service Commission', 'Regional Bureaus', 'HR 
     </header>
 
     <main class="landing-main" aria-labelledby="features-heading">
+      <section class="landing-section landing-section--hero">
+        <div class="landing-hero-panel">
+          <div class="landing-hero-copy">
+            <p class="landing-hero-copy__eyebrow"><?= $heroEyebrow ?></p>
+            <h1 class="landing-hero-copy__title"><?= $heroTitle ?></h1>
+            <p class="landing-hero-copy__subtitle"><?= $heroSubtitle ?></p>
+            <div class="landing-hero-copy__actions">
+              <a class="landing-button landing-button--accent" href="<?= $loginUrl ?>"><?= $primaryCta ?></a>
+            </div>
+          </div>
+          <div class="landing-hero-badges" aria-label="<?= htmlspecialchars(t($t, 'hero_badges_label', 'Platform highlights'), ENT_QUOTES, 'UTF-8') ?>">
+            <span><?= $heroBadgeOne ?></span>
+            <span><?= $heroBadgeTwo ?></span>
+            <span><?= $heroBadgeThree ?></span>
+          </div>
+        </div>
+      </section>
+
       <section class="landing-section landing-section--stats">
         <div class="landing-stats-grid">
           <?php foreach ($statTiles as $tile): ?>


### PR DESCRIPTION
### Motivation
- Improve the landing experience by adding a prominent, colorful hero to introduce the product and surface key platform highlights above the stats section.
- Provide localized text fields for eyebrow/title/subtitle and structured highlight badges so content can be translated and customised.

### Description
- Added localized hero content variables in `index.php` (`$heroEyebrow`, `$heroTitle`, `$heroSubtitle`, `$heroBadgeOne`, `$heroBadgeTwo`, `$heroBadgeThree`) and inserted a new hero markup block above the stats section that reuses the existing sign-in CTA.
- Implemented a two-column hero layout with a copy column and a badge column in `assets/css/landing.css`, including gradient panel background, shadows, and badge card styling.
- Added responsive rules so the hero collapses to a single column on small screens and keeps CTA prominence with the existing `landing-button--accent` styling.

### Testing
- Ran `php -l index.php` and `php -l config.php` and both reported no syntax errors (success).
- Launched a local PHP dev server with `php -S 0.0.0.0:8000` and verified the page renders by capturing a screenshot with a Playwright script (screenshot captured successfully).
- Basic responsive check performed by applying the media-query changes in the stylesheet and confirming the hero collapses to one column at small widths (manual viewport test via Playwright).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b3aef9c4832d845d606596f64a62)