### PR TITLE
Persist conditional logic and align server equality with client (case-insensitive)

### DIFF
--- a/config.php
+++ b/config.php
@@ -947,6 +947,15 @@ function ensure_questionnaire_item_schema(PDO $pdo): void
         if (!isset($existing['is_required'])) {
             $pdo->exec("ALTER TABLE questionnaire_item ADD COLUMN is_required TINYINT(1) NOT NULL DEFAULT 0 AFTER allow_multiple");
         }
+        if (!isset($existing['condition_source_linkid'])) {
+            $pdo->exec("ALTER TABLE questionnaire_item ADD COLUMN condition_source_linkid VARCHAR(255) NULL AFTER requires_correct");
+        }
+        if (!isset($existing['condition_operator'])) {
+            $pdo->exec("ALTER TABLE questionnaire_item ADD COLUMN condition_operator VARCHAR(20) NULL AFTER condition_source_linkid");
+        }
+        if (!isset($existing['condition_value'])) {
+            $pdo->exec("ALTER TABLE questionnaire_item ADD COLUMN condition_value VARCHAR(500) NULL AFTER condition_operator");
+        }
     } catch (PDOException $e) {
         error_log('ensure_questionnaire_item_schema: ' . $e->getMessage());
     }

--- a/migration.sql
+++ b/migration.sql
@@ -1297,3 +1297,51 @@ INSERT INTO work_function_catalog (slug, label, sort_order) VALUES
 ON DUPLICATE KEY UPDATE
   label = VALUES(label),
   sort_order = VALUES(sort_order);
+
+SET @qi_condition_source_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'questionnaire_item'
+    AND COLUMN_NAME = 'condition_source_linkid'
+);
+SET @qi_condition_source_sql = IF(
+  @qi_condition_source_exists = 0,
+  'ALTER TABLE questionnaire_item ADD COLUMN condition_source_linkid VARCHAR(255) NULL AFTER requires_correct',
+  'DO 1'
+);
+PREPARE stmt FROM @qi_condition_source_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @qi_condition_operator_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'questionnaire_item'
+    AND COLUMN_NAME = 'condition_operator'
+);
+SET @qi_condition_operator_sql = IF(
+  @qi_condition_operator_exists = 0,
+  'ALTER TABLE questionnaire_item ADD COLUMN condition_operator VARCHAR(20) NULL AFTER condition_source_linkid',
+  'DO 1'
+);
+PREPARE stmt FROM @qi_condition_operator_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @qi_condition_value_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'questionnaire_item'
+    AND COLUMN_NAME = 'condition_value'
+);
+SET @qi_condition_value_sql = IF(
+  @qi_condition_value_exists = 0,
+  'ALTER TABLE questionnaire_item ADD COLUMN condition_value VARCHAR(500) NULL AFTER condition_operator',
+  'DO 1'
+);
+PREPARE stmt FROM @qi_condition_value_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
### Motivation
- Make conditional visibility fully round-trip between the builder, storage, and runtime so conditions can be authored in the admin UI and honoured on submit. 
- Fix inconsistent conditional evaluation between browser and server by making `equals`/`not_equals` semantics case-insensitive to match the client. 
- Ensure visibility evaluation is order-independent so a conditional can reference answers posted earlier or later in the payload. 

### Description
- Added DB/schema support by introducing `condition_source_linkid`, `condition_operator`, and `condition_value` in `config.php` and `migration.sql` so items can store condition metadata. 
- Persisted and surfaced condition fields in the admin flow by updating `admin/questionnaire_manage.php` to include the new columns in fetches and in `INSERT`/`UPDATE` parameter lists for items. 
- Enhanced the builder UI in `assets/js/questionnaire-builder.js` to render/edit/serialize the condition fields and to implement case-insensitive `equals`, `not_equals`, and `contains` visibility toggling with `data-condition-*` attributes. 
- Reworked `submit_assessment.php` to collect posted values into a map and evaluate `$matchesCondition` against that map so visibility checks are order-independent and `equals`/`not_equals` now perform case-insensitive comparisons while `contains` remains a case-insensitive substring check. 

### Testing
- Ran PHP syntax checks with `php -l submit_assessment.php`, `php -l admin/questionnaire_manage.php`, and `php -l config.php` and all returned no syntax errors. 
- Verified client script syntax with `node --check assets/js/questionnaire-builder.js` which succeeded. 
- Exercised the admin builder with a Playwright script that loaded the builder, added a conditional item, attempted a save, and captured screenshots to validate end-to-end builder/save behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998b48d94d0832d8457905c25f03a57)