### PR TITLE
Close top navigation submenu when pointer leaves top-level item

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -433,6 +433,16 @@
 
       trigger.addEventListener('focus', () => openSubmenuForItem(item));
       item.addEventListener('mouseenter', () => openSubmenuForItem(item));
+      item.addEventListener('mouseleave', (event) => {
+        if (isMobileView()) {
+          return;
+        }
+        const nextTarget = event.relatedTarget;
+        if (nextTarget instanceof Node && item.contains(nextTarget)) {
+          return;
+        }
+        setItemExpanded(item, false);
+      });
     });
 
     mobilePanel = document.createElement('div');


### PR DESCRIPTION
### Motivation
- The top navigation submenus sometimes stayed open after moving the pointer away from a specific top-level item (e.g. “My Performance”), causing confusing UI behavior on desktop viewports.

### Description
- Added a per-item `mouseleave` handler in `assets/js/app.js` that closes the submenu for that top-level item when the pointer leaves it on desktop viewports. 
- The handler preserves mobile behavior by early-returning when `isMobileView()` is true and avoids closing the submenu if the pointer moved into a descendant of the same item by checking `event.relatedTarget`.
- Accessibility state updates (`aria-expanded` / `aria-hidden`) are handled via the existing `setItemExpanded` helper so keyboard/focus behavior remains unchanged.

### Testing
- Ran `node --check assets/js/app.js`, which passed successfully.
- Linted PHP files with `find . -type f -name '*.php' -not -path './vendor/*' -print0 | xargs -0 -n1 php -l`, which completed without syntax errors.
- Attempted browser-driven validation with Playwright against `http://127.0.0.1:8080/login.php`, but the Chromium process in the test container crashed (SIGSEGV) so visual/interactive confirmation could not be produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c9259478832da24c1355c0fe2707)