### PR TITLE
Start Department Defaults collapsed and add expand indicator

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -196,10 +196,13 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
 <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
 <style>
   .md-defaults-group { margin-bottom: .9rem; border: 1px solid rgba(0,0,0,.08); border-radius: 10px; background: rgba(255,255,255,.72); }
-  .md-defaults-group > summary { cursor: pointer; padding: .7rem .9rem; font-weight: 700; list-style: none; display: flex; justify-content: space-between; align-items: center; }
+  .md-defaults-group > summary { cursor: pointer; padding: .7rem .9rem; font-weight: 700; list-style: none; display: flex; justify-content: flex-start; align-items: center; gap: .5rem; }
+  .md-defaults-group > summary::before { content: '▸'; font-size: .95rem; color: rgba(0,0,0,.65); transition: transform .2s ease; }
+  .md-defaults-group[open] > summary::before { transform: rotate(90deg); }
   .md-defaults-group > summary::-webkit-details-marker { display: none; }
+  .md-defaults-meta { margin-left: auto; }
   .md-defaults-group-body { padding: .35rem .9rem .85rem; }
-  .md-defaults-meta { color: #6b7280; font-size: .86rem; font-weight: 500; margin-left: .6rem; }
+  .md-defaults-meta { color: #6b7280; font-size: .86rem; font-weight: 500; }
   .md-work-function-row { margin-bottom: .6rem; }
   .md-compact-actions { display: flex; flex-wrap: wrap; gap: .65rem; align-items: flex-end; }
   .md-compact-actions .md-field { margin: 0; flex: 1 1 220px; }
@@ -218,7 +221,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
     <?php if ($msg !== ''): ?><div class="md-alert success"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
     <?php if ($metadataErrors): ?><div class="md-alert error"><?php foreach ($metadataErrors as $err): ?><p><?=htmlspecialchars($err, ENT_QUOTES, 'UTF-8')?></p><?php endforeach; ?></div><?php endif; ?>
 
-    <details class="md-defaults-group" open>
+    <details class="md-defaults-group">
       <summary>
         <span><?=htmlspecialchars(t($t,'department','Department'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=count($departmentOptions)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -256,7 +259,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </details>
 
-    <details class="md-defaults-group" open>
+    <details class="md-defaults-group">
       <summary>
         <span><?=htmlspecialchars(t($t,'assignment_overview','Department questionnaire defaults'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=count($questionnaires)?> <?=htmlspecialchars(t($t,'questionnaires','Questionnaires'), ENT_QUOTES, 'UTF-8')?></span>


### PR DESCRIPTION
### Motivation

- Reduce visual clutter on the Department Defaults page by having all top-level groups collapsed on first load so administrators can scan headings before expanding details. 
- Make it obvious that each section is expandable by adding a clear visual affordance for expand/collapse state.

### Description

- Updated `admin/work_function_defaults.php` to remove the `open` attribute from top-level `<details>` blocks so the Departments and Department questionnaire defaults sections start collapsed. 
- Added CSS to render a chevron indicator (`▸`) before each top-level `<summary>` and rotate it when its parent `<details>` is open. 
- Adjusted summary layout (`justify-content` / `gap`) and aligned item-count metadata using `margin-left: auto` so the indicator does not overlap the count. 
- All changes are contained in `admin/work_function_defaults.php` (inline style block and markup tweaks).

### Testing

- Ran PHP syntax check with `php -l admin/work_function_defaults.php` which succeeded. 
- Launched a local PHP dev server with `php -S 0.0.0.0:8080 -t /workspace/CAS2025` and attempted to render the updated route, and used a Playwright script to capture a screenshot artifact of the page; the screenshot capture completed but the environment produced a database connection error when loading the route. 
- No runtime PHP syntax errors were detected after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb09bd1d8832d99ad11c9e579c59c)