### PR TITLE
Move Profile to app bar, remove Account & Tools, and modernize profile page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -655,6 +655,32 @@ button,
 }
 
 
+.md-appbar-link.md-appbar-profile {
+  padding: 0;
+  width: var(--app-button-height);
+  min-width: var(--app-button-height);
+  height: var(--app-button-height);
+  border-radius: 50%;
+  background: var(--app-on-primary-subtle);
+}
+
+.md-appbar-link.md-appbar-profile:hover,
+.md-appbar-link.md-appbar-profile:focus {
+  background: var(--app-on-primary-soft);
+}
+
+.md-appbar-profile-initials {
+  width: 100%;
+  height: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
 .md-lang-switch a {
   margin: 0 0.15rem;
   padding: 0.25rem 0.55rem;
@@ -1342,6 +1368,44 @@ body.theme-dark .md-field.md-field--compact select {
 
 .md-field.md-field-inline {
   align-items: flex-start;
+}
+
+.md-profile-section {
+  max-width: 1120px;
+  margin-inline: auto;
+}
+
+.md-profile-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  align-items: start;
+}
+
+.md-profile-card {
+  padding-bottom: 1.2rem;
+}
+
+.md-profile-card .md-card-title {
+  margin-bottom: 0.5rem;
+}
+
+.md-profile-fields {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.md-profile-card--preferences .md-profile-fields {
+  grid-template-columns: 1fr;
+}
+
+.md-profile-actions {
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 960px) {
+  .md-profile-layout {
+    grid-template-columns: 1fr;
+  }
 }
 .md-phone-input {
   display: flex;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -604,64 +604,6 @@
     document.head.appendChild(manifest);
   }
 
-  const installButton = document.getElementById('appbar-install-btn');
-  let deferredInstallPrompt = null;
-  const isStandalone = () => {
-    const mediaQuery = typeof window.matchMedia === 'function' ? window.matchMedia('(display-mode: standalone)') : null;
-    return (mediaQuery && mediaQuery.matches) || window.navigator.standalone === true;
-  };
-  const updateInstallButtonVisibility = () => {
-    if (!installButton) {
-      return;
-    }
-    const shouldShow = Boolean(deferredInstallPrompt) && !isStandalone();
-    installButton.hidden = !shouldShow;
-    installButton.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
-    if (!shouldShow) {
-      installButton.disabled = false;
-    }
-  };
-  if (installButton) {
-    installButton.addEventListener('click', async () => {
-      if (!deferredInstallPrompt) {
-        updateInstallButtonVisibility();
-        return;
-      }
-      installButton.disabled = true;
-      try {
-        await deferredInstallPrompt.prompt();
-        if (deferredInstallPrompt.userChoice) {
-          await deferredInstallPrompt.userChoice.catch(() => undefined);
-        }
-      } catch (err) {
-        // Ignore prompt errors.
-      }
-      deferredInstallPrompt = null;
-      updateInstallButtonVisibility();
-      installButton.disabled = false;
-      installButton.blur();
-    });
-  }
-  const standaloneMedia = window.matchMedia ? window.matchMedia('(display-mode: standalone)') : null;
-  if (standaloneMedia) {
-    const handleStandaloneChange = () => updateInstallButtonVisibility();
-    if (typeof standaloneMedia.addEventListener === 'function') {
-      standaloneMedia.addEventListener('change', handleStandaloneChange);
-    } else if (typeof standaloneMedia.addListener === 'function') {
-      standaloneMedia.addListener(handleStandaloneChange);
-    }
-  }
-  window.addEventListener('beforeinstallprompt', (event) => {
-    event.preventDefault();
-    deferredInstallPrompt = event;
-    updateInstallButtonVisibility();
-  });
-  window.addEventListener('appinstalled', () => {
-    deferredInstallPrompt = null;
-    updateInstallButtonVisibility();
-  });
-  updateInstallButtonVisibility();
-
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker.register(normalizedBase + '/service-worker.js', { scope: normalizedBase + '/' })

--- a/profile.php
+++ b/profile.php
@@ -173,37 +173,48 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
 </head><body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>" style="<?=htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8')?>">
 <?php include __DIR__.'/templates/header.php'; ?>
-<section class="md-section">
-  <div class="md-card md-elev-2">
-    <h2 class="md-card-title"><?=t($t,'profile_information','Profile Information')?></h2>
-      <?php if ($message): ?><div class="md-alert success"><?=htmlspecialchars($message, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
-      <?php if ($error): ?><div class="md-alert error"><?=htmlspecialchars($error, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
-      <?php if ($pendingNotice): ?>
-        <div class="md-alert warning">
-          <?=htmlspecialchars(t($t, 'pending_account_notice', 'Your account is pending supervisor approval. You can update your profile while you wait.'), ENT_QUOTES, 'UTF-8')?>
-        </div>
-      <?php endif; ?>
-      <?php if ($forceResetNotice): ?>
-        <div class="md-alert warning">
-          <?=htmlspecialchars(t($t, 'force_password_reset_notice', 'For security, you must set a new password before continuing.'), ENT_QUOTES, 'UTF-8')?>
-        </div>
-      <?php endif; ?>
-    <div class="md-required-popup" data-required-popup hidden>
-      <div class="md-required-popup__backdrop" data-required-popup-close></div>
-      <div class="md-required-popup__dialog" role="dialog" aria-modal="true" aria-labelledby="required-popup-title">
-        <div class="md-required-popup__header">
-          <div class="md-required-popup__title" id="required-popup-title">
-            <?=t($t,'required_fields_title','Required fields missing')?>
-          </div>
-          <button type="button" class="md-required-popup__close" data-required-popup-close aria-label="<?=htmlspecialchars(t($t,'close','Close'), ENT_QUOTES, 'UTF-8')?>">×</button>
-        </div>
-        <p class="md-required-popup__body">
-          <?=t($t,'required_fields_body','Please complete all mandatory fields marked in red before saving your profile.')?>
-        </p>
-      </div>
+<section class="md-section md-profile-section">
+  <header class="md-page-header md-profile-header">
+    <div class="md-page-header__content">
+      <h1 class="md-page-title"><?=t($t,'profile','Profile')?></h1>
+      <p class="md-page-subtitle"><?=t($t,'profile_summary','Update your profile details and settings.')?></p>
     </div>
-    <form method="post" class="md-form-grid" action="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" data-profile-form>
-      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+  </header>
+
+  <?php if ($message): ?><div class="md-alert success"><?=htmlspecialchars($message, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
+  <?php if ($error): ?><div class="md-alert error"><?=htmlspecialchars($error, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
+  <?php if ($pendingNotice): ?>
+    <div class="md-alert warning">
+      <?=htmlspecialchars(t($t, 'pending_account_notice', 'Your account is pending supervisor approval. You can update your profile while you wait.'), ENT_QUOTES, 'UTF-8')?>
+    </div>
+  <?php endif; ?>
+  <?php if ($forceResetNotice): ?>
+    <div class="md-alert warning">
+      <?=htmlspecialchars(t($t, 'force_password_reset_notice', 'For security, you must set a new password before continuing.'), ENT_QUOTES, 'UTF-8')?>
+    </div>
+  <?php endif; ?>
+
+  <div class="md-required-popup" data-required-popup hidden>
+    <div class="md-required-popup__backdrop" data-required-popup-close></div>
+    <div class="md-required-popup__dialog" role="dialog" aria-modal="true" aria-labelledby="required-popup-title">
+      <div class="md-required-popup__header">
+        <div class="md-required-popup__title" id="required-popup-title">
+          <?=t($t,'required_fields_title','Required fields missing')?>
+        </div>
+        <button type="button" class="md-required-popup__close" data-required-popup-close aria-label="<?=htmlspecialchars(t($t,'close','Close'), ENT_QUOTES, 'UTF-8')?>">×</button>
+      </div>
+      <p class="md-required-popup__body">
+        <?=t($t,'required_fields_body','Please complete all mandatory fields marked in red before saving your profile.')?>
+      </p>
+    </div>
+  </div>
+
+  <form method="post" class="md-profile-layout" action="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" data-profile-form>
+    <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+
+    <article class="md-card md-elev-2 md-profile-card">
+      <h2 class="md-card-title"><?=t($t,'profile_information','Profile Information')?></h2>
+      <div class="md-form-grid md-profile-fields">
       <label class="md-field md-field--required">
         <span><?=t($t,'full_name','Full Name')?></span>
         <input name="full_name" value="<?=htmlspecialchars($user['full_name'] ?? '')?>" required>
@@ -282,6 +293,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <?php endforeach; ?>
         </select>
       </label>
+      </div>
+    </article>
+
+    <article class="md-card md-elev-2 md-profile-card md-profile-card--preferences">
+      <h2 class="md-card-title"><?=htmlspecialchars(t($t,'account_tools','Account & Tools'), ENT_QUOTES, 'UTF-8')?></h2>
+      <div class="md-form-grid md-profile-fields">
       <label class="md-field">
         <span><?=t($t,'preferred_language','Preferred Language')?></span>
         <?php $lval = $_SESSION['lang'] ?? ($user['language'] ?? 'en'); ?>
@@ -295,11 +312,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <span><?=t($t,'new_password','New Password (optional)')?></span>
         <input type="password" name="password" minlength="6">
       </label>
-      <div class="md-form-actions">
+      </div>
+      <div class="md-form-actions md-profile-actions">
         <button class="md-button md-primary md-elev-2"><?=t($t,'save','Save Changes')?></button>
       </div>
-    </form>
-  </div>
+    </article>
+  </form>
 </section>
 
 <script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">

--- a/templates/header.php
+++ b/templates/header.php
@@ -76,6 +76,22 @@ $nextLocale = $localeCount > 0
     : $currentLocale;
 $currentLocaleBadge = strtoupper((string)$currentLocale);
 $currentLocaleFlag = asset_url('assets/images/flags/flag-' . $currentLocale . '.svg');
+$profileDisplayName = trim((string)($user['full_name'] ?? $user['username'] ?? t($t, 'profile', 'Profile')));
+$initialParts = preg_split('/\s+/', $profileDisplayName) ?: [];
+$profileInitials = '';
+foreach ($initialParts as $part) {
+    $part = trim((string)$part);
+    if ($part === '') {
+        continue;
+    }
+    $profileInitials .= strtoupper(substr($part, 0, 1));
+    if (strlen($profileInitials) >= 2) {
+        break;
+    }
+}
+if ($profileInitials === '') {
+    $profileInitials = strtoupper(substr($profileDisplayName, 0, 2));
+}
 ?>
 <?php if ($brandStyle !== ''): ?>
 <style id="md-brand-style"><?=htmlspecialchars($brandStyle, ENT_QUOTES, 'UTF-8')?></style>
@@ -140,6 +156,15 @@ $currentLocaleFlag = asset_url('assets/images/flags/flag-' . $currentLocale . '.
         loading="lazy"
         decoding="async"
       >
+    </a>
+    <a
+      href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>"
+      class="md-appbar-link md-appbar-profile"
+      aria-label="<?=htmlspecialchars(t($t, 'profile', 'Profile') . ': ' . $profileDisplayName, ENT_QUOTES, 'UTF-8')?>"
+      title="<?=htmlspecialchars($profileDisplayName, ENT_QUOTES, 'UTF-8')?>"
+    >
+      <span class="md-appbar-profile-initials" aria-hidden="true"><?=htmlspecialchars($profileInitials, ENT_QUOTES, 'UTF-8')?></span>
+      <span class="visually-hidden"><?=htmlspecialchars(t($t, 'profile', 'Profile'), ENT_QUOTES, 'UTF-8')?></span>
     </a>
     <a
       href="<?=htmlspecialchars(url_for('logout.php'), ENT_QUOTES, 'UTF-8')?>"
@@ -571,41 +596,6 @@ $currentLocaleFlag = asset_url('assets/images/flags/flag-' . $currentLocale . '.
         </ul>
       </li>
     <?php endif; ?>
-    <li class="md-topnav-item" data-topnav-item>
-      <button type="button" class="md-topnav-trigger" data-topnav-trigger data-topnav-icon="account" aria-haspopup="true" aria-expanded="false">
-        <span class="md-topnav-label">
-          <span class="md-topnav-title"><?=t($t, 'account_tools', 'Account & Tools')?></span>
-          <span class="md-topnav-desc"><?=t($t, 'account_tools_summary', 'Quick actions, profile, and preferences.')?></span>
-        </span>
-        <span class="md-topnav-chevron" aria-hidden="true"></span>
-      </button>
-      <ul class="md-topnav-submenu">
-        <li>
-          <button
-            type="button"
-            class="md-topnav-link"
-            id="appbar-install-btn"
-            hidden
-            aria-hidden="true"
-          >
-            <span class="md-topnav-link-content">
-              <span class="md-topnav-link-title"><?=htmlspecialchars(t($t, 'install_app', 'Install App'), ENT_QUOTES, 'UTF-8')?></span>
-              <span class="md-topnav-link-desc"><?=t($t, 'install_app_summary', 'Add this app to your device for quick access.')?></span>
-            </span>
-            <span class="md-topnav-link-icon" aria-hidden="true">↓</span>
-          </button>
-        </li>
-        <li>
-          <a href="<?=htmlspecialchars(url_for('profile.php'), ENT_QUOTES, 'UTF-8')?>" class="md-topnav-link">
-            <span class="md-topnav-link-content">
-              <span class="md-topnav-link-title"><?=htmlspecialchars($user['full_name'] ?? $user['username'] ?? 'Profile')?></span>
-              <span class="md-topnav-link-desc"><?=t($t, 'profile_summary', 'Update your profile details and settings.')?></span>
-            </span>
-            <span class="md-topnav-link-icon" aria-hidden="true">&rsaquo;</span>
-          </a>
-        </li>
-      </ul>
-    </li>
   </ul>
 </nav>
 <div class="md-topnav-backdrop" data-topnav-backdrop aria-hidden="true" hidden></div>


### PR DESCRIPTION
### Motivation
- Surface direct access to the user profile by placing it in the app bar as a compact, accessible avatar with initials. 
- Remove the no-longer-needed `Account & Tools` top-nav group (and the related `Install App` entry) to simplify top navigation.
- Improve the profile page layout to look more professional and consistent with the rest of the UI.

### Description
- Added initials-avatar link in the app bar that navigates to `profile.php` and generates initials from `user.full_name` / `user.username` for display and ARIA labeling (`templates/header.php`).
- Removed the `Account & Tools` top-nav dropdown and the in-menu `Install App` / profile submenu entries from the top navigation (`templates/header.php`).
- Removed the install prompt wiring from the client app JS since the install UI entrypoint was removed (`assets/js/app.js`).
- Reworked `profile.php` into a two-column responsive layout with a page header and separate cards for profile information and preferences/security, preserving existing fields and validation behavior (`profile.php`).
- Added CSS rules to support the circular initials avatar and the new profile page layout and responsiveness (`assets/css/styles.css`).

### Testing
- Ran PHP syntax checks with `php -l templates/header.php` and `php -l profile.php`, both succeeded.
- Validated JS by executing `node -e "new Function(require('fs').readFileSync('assets/js/app.js','utf8')); console.log('js ok')"`, which returned success.
- Launched a local PHP server and captured a visual snapshot of the updated profile page via a Playwright script, producing a screenshot artifact (`browser:/tmp/codex_browser_invocations/3154c3ba63ec3554/artifacts/artifacts/profile-page.png`). All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb78525cc832d9bfb3afc72b7553e)