### PR TITLE
Fix analytics summary SQL syntax errors caused by escaped quotes

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -694,7 +694,7 @@ if ($selectedQuestionnaireId) {
     $userStmt = $pdo->prepare(
         'SELECT u.id AS user_id, u.username, u.full_name, u.department, u.cadre, u.work_function, '
         . 'COUNT(*) AS total_responses, '
-        . 'SUM(qr.status=\'approved\') AS approved_count, '
+        . "SUM(qr.status='approved') AS approved_count, "
         . 'AVG(qr.score) AS avg_score '
         . 'FROM questionnaire_response qr '
         . 'JOIN users u ON u.id = qr.user_id '
@@ -897,7 +897,7 @@ $teamSummary = [];
 try {
     $workFunctionStmt = $pdo->query(
         "SELECT u.work_function, COUNT(*) AS total_responses, "
-        . "SUM(qr.status=\'approved\') AS approved_count, "
+        . "SUM(qr.status='approved') AS approved_count, "
         . "AVG(qr.score) AS avg_score "
         . "FROM questionnaire_response qr "
         . "JOIN users u ON u.id = qr.user_id "
@@ -908,7 +908,7 @@ try {
 
     $departmentSummaryStmt = $pdo->query(
         "SELECT u.department, COUNT(*) AS total_responses, "
-        . "SUM(qr.status=\'approved\') AS approved_count, "
+        . "SUM(qr.status='approved') AS approved_count, "
         . "AVG(qr.score) AS avg_score "
         . "FROM questionnaire_response qr "
         . "JOIN users u ON u.id = qr.user_id "
@@ -919,7 +919,7 @@ try {
 
     $teamSummaryStmt = $pdo->query(
         "SELECT u.cadre, COUNT(*) AS total_responses, "
-        . "SUM(qr.status=\'approved\') AS approved_count, "
+        . "SUM(qr.status='approved') AS approved_count, "
         . "AVG(qr.score) AS avg_score "
         . "FROM questionnaire_response qr "
         . "JOIN users u ON u.id = qr.user_id "


### PR DESCRIPTION
### Motivation
- Analytics summary and breakdown queries were generating SQL fragments with backslash-escaped single quotes (e.g. `\'approved\'`), which produced runtime SQL syntax errors in some MySQL configurations and caused the reported failure near `\'approved\' AS approved_count, AVG(qr.score)`.
- The change aims to emit valid SQL string literals for status checks so the analytics pages and exports no longer fail due to quoting issues.

### Description
- Normalized SQL string construction in `admin/analytics.php` so status checks are emitted as `SUM(qr.status='approved')` (using PHP double-quoted strings) instead of emitting backslash-escaped quotes.
- Updated four occurrences used in the user breakdown and work-function / department / team summary queries to use consistent quoting.
- Ensured the resulting PHP file parses cleanly by running a syntax check with `php -l`.

### Testing
- Ran `php -l admin/analytics.php` and it passed with no syntax errors (success).
- Ran `php tests/analytics_report_snapshot_test.php` which exercised analytics logic but failed in this environment due to the test DB driver not supporting MySQL `SHOW` statements (`SHOW`-related schema lookups failed), so the functional test could not fully validate MySQL-specific behavior (failure due to environment, not the SQL quoting change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc03aee20832daf927ce0c39b5fcc)