### PR TITLE
Include proficiency labels for questionnaire totals across UI and PDFs

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1019,6 +1019,14 @@ $formatScore = static function ($score, int $precision = 1): string {
     return number_format((float)$score, $precision);
 };
 
+$formatProficiencyLevel = static function ($score) use ($t): string {
+    if ($score === null) {
+        return '—';
+    }
+    $level = questionnaire_proficiency_level((float)$score);
+    return $level !== '' ? $level : t($t, 'not_available', 'N/A');
+};
+
 $selectedAggregate = [
     'total' => count($selectedResponses),
     'approved' => 0,
@@ -1581,6 +1589,7 @@ $pageHelpKey = 'team.analytics';
             <th><?=t($t, 'status_draft', 'Draft')?></th>
             <th><?=t($t, 'status_rejected', 'Rejected')?></th>
             <th><?=t($t, 'average_score', 'Average score (%)')?></th>
+            <th><?=t($t, 'proficiency_level', 'Proficiency level')?></th>
           </tr>
         </thead>
         <tbody>
@@ -1598,6 +1607,7 @@ $pageHelpKey = 'team.analytics';
               <td><?= (int)$row['draft_count'] ?></td>
               <td><?= (int)$row['rejected_count'] ?></td>
               <td><?= $formatScore($row['avg_score'] ?? null) ?></td>
+              <td><?=htmlspecialchars($formatProficiencyLevel($row['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
             </tr>
           <?php endforeach; ?>
         </tbody>
@@ -1626,6 +1636,7 @@ $pageHelpKey = 'team.analytics';
         <p class="md-upgrade-meta">
           <?=t($t, 'selected_summary', 'Average score: ')?>
           <?=$formatScore($selectedAverage)?> ·
+          <?=t($t, 'proficiency_level', 'Proficiency level')?>: <?=htmlspecialchars($formatProficiencyLevel($selectedAverage), ENT_QUOTES, 'UTF-8')?> ·
           <?=t($t, 'approved_responses', 'Approved responses')?>: <?=$selectedAggregate['approved']?> ·
           <?=t($t, 'status_submitted', 'Submitted')?>: <?=$selectedAggregate['submitted']?> ·
           <?=t($t, 'status_draft', 'Draft')?>: <?=$selectedAggregate['draft']?> ·
@@ -1638,6 +1649,7 @@ $pageHelpKey = 'team.analytics';
               <th><?=t($t, 'performance_period', 'Performance Period')?></th>
               <th><?=t($t, 'status', 'Status')?></th>
               <th><?=t($t, 'score', 'Score (%)')?></th>
+              <th><?=t($t, 'proficiency_level', 'Proficiency level')?></th>
               <th><?=t($t, 'date', 'Submitted on')?></th>
               <th><?=t($t, 'review_comment', 'Review comment')?></th>
               <th><?=t($t, 'view', 'View')?></th>
@@ -1656,6 +1668,7 @@ $pageHelpKey = 'team.analytics';
                 <td><?=htmlspecialchars($row['period_label'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars($statusLabels[$statusKey] ?? ucfirst((string)$statusKey), ENT_QUOTES, 'UTF-8')?></td>
                 <td><?= isset($row['score']) && $row['score'] !== null ? (int)$row['score'] : '—' ?></td>
+                <td><?=htmlspecialchars($formatProficiencyLevel($row['score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars($row['created_at'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars($row['review_comment'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
                 <td><a class="md-button" href="<?=htmlspecialchars(url_for('admin/view_submission.php?id=' . (int)$row['id']), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'open', 'Open')?></a></td>
@@ -1746,6 +1759,7 @@ $pageHelpKey = 'team.analytics';
               <th><?=t($t, 'count', 'Responses')?></th>
               <th><?=t($t, 'approved', 'Approved')?></th>
               <th><?=t($t, 'average_score', 'Average score (%)')?></th>
+              <th><?=t($t, 'proficiency_level', 'Proficiency level')?></th>
             </tr>
           </thead>
           <tbody>
@@ -1764,6 +1778,7 @@ $pageHelpKey = 'team.analytics';
                 <td><?= (int)$row['total_responses'] ?></td>
                 <td><?= (int)$row['approved_count'] ?></td>
                 <td><?= $formatScore($row['avg_score'] ?? null) ?></td>
+                <td><?=htmlspecialchars($formatProficiencyLevel($row['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
               </tr>
             <?php endforeach; ?>
           </tbody>

--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/simple_pdf.php';
 require_once __DIR__ . '/performance_sections.php';
+require_once __DIR__ . '/scoring.php';
 
 function analytics_report_has_period_start_column(PDO $pdo): bool
 {
@@ -362,6 +363,7 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
         ['Draft', analytics_report_format_number($summary['draft_count'] ?? 0)],
         ['Rejected', analytics_report_format_number($summary['rejected_count'] ?? 0)],
         ['Average score', analytics_report_format_score($summary['avg_score'])],
+        ['Average proficiency', questionnaire_proficiency_level(isset($summary['avg_score']) ? (float)$summary['avg_score'] : null) ?: '—'],
         ['Latest submission', analytics_report_format_date($summary['latest_at'])],
         ['Unique participants', analytics_report_format_number($snapshot['total_participants'] ?? 0)],
     ];
@@ -380,14 +382,15 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
             analytics_report_format_number($row['draft_count'] ?? 0),
             analytics_report_format_number($row['rejected_count'] ?? 0),
             analytics_report_format_score($row['avg_score'] ?? null),
+            questionnaire_proficiency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
         ];
     }
 
     if ($questionnaireRows) {
         $pdf->addTable(
-            ['Questionnaire', 'Total', 'Approved', 'Submitted', 'Draft', 'Rejected', 'Avg'],
+            ['Questionnaire', 'Total', 'Approved', 'Submitted', 'Draft', 'Rejected', 'Avg', 'Proficiency'],
             $questionnaireRows,
-            [40, 7, 9, 10, 8, 9, 7]
+            [34, 7, 9, 10, 8, 9, 7, 16]
         );
     } else {
         $pdf->addParagraph('No questionnaire responses have been recorded yet.');
@@ -401,14 +404,15 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
                 analytics_report_format_number($row['total_responses'] ?? 0),
                 analytics_report_format_number($row['approved_count'] ?? 0),
                 analytics_report_format_score($row['avg_score'] ?? null),
+                questionnaire_proficiency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
             ];
         }
         if ($workRows) {
             $pdf->addSubheading('Performance by work function');
             $pdf->addTable(
-                ['Work function', 'Responses', 'Approved', 'Avg'],
+                ['Work function', 'Responses', 'Approved', 'Avg', 'Proficiency'],
                 $workRows,
-                [40, 14, 14, 10]
+                [30, 12, 12, 10, 14]
             );
         }
     }
@@ -545,12 +549,13 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
                 analytics_report_format_number($row['total_responses'] ?? 0),
                 analytics_report_format_number($row['approved_count'] ?? 0),
                 analytics_report_format_score($row['avg_score'] ?? null),
+                questionnaire_proficiency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
             ];
         }
         $pdf->addTable(
-            ['User', 'Work function', 'Responses', 'Approved', 'Avg score'],
+            ['User', 'Work function', 'Responses', 'Approved', 'Avg score', 'Proficiency'],
             $detailRows,
-            [28, 18, 12, 10, 10]
+            [24, 16, 10, 10, 10, 14]
         );
     }
 

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -211,3 +211,62 @@ function questionnaire_answer_is_correct(array $answerSet, string $correctValue)
     }
     return false;
 }
+
+/**
+ * Resolve a proficiency level label from a score percentage.
+ */
+function questionnaire_proficiency_level(?float $score): string
+{
+    if ($score === null) {
+        return '';
+    }
+    if ($score >= 85.0) {
+        return 'Expert';
+    }
+    if ($score >= 70.0) {
+        return 'Strong Proficiency';
+    }
+    if ($score >= 60.0) {
+        return 'Intermediate';
+    }
+    if ($score >= 50.0) {
+        return 'Basic';
+    }
+    return 'Not Proficient';
+}
+
+/**
+ * Resolve proficiency level and interpretation details for a score percentage.
+ *
+ * @return array{level:string, interpretation:string}
+ */
+function questionnaire_proficiency_details(?float $score): array
+{
+    $level = questionnaire_proficiency_level($score);
+    return match ($level) {
+        'Expert' => [
+            'level' => 'Expert',
+            'interpretation' => 'Exceptional mastery; capable of leading complex assignments and mentoring others.',
+        ],
+        'Strong Proficiency' => [
+            'level' => 'Strong Proficiency',
+            'interpretation' => 'Fully meets expectations; operates independently at the expected level.',
+        ],
+        'Intermediate' => [
+            'level' => 'Intermediate',
+            'interpretation' => 'Partial mastery; requires targeted development to reach full proficiency.',
+        ],
+        'Basic' => [
+            'level' => 'Basic',
+            'interpretation' => 'Limited understanding; requires close supervision and structured learning.',
+        ],
+        'Not Proficient' => [
+            'level' => 'Not Proficient',
+            'interpretation' => 'Does not meet minimum expectations; needs foundational skill development.',
+        ],
+        default => [
+            'level' => '',
+            'interpretation' => '',
+        ],
+    };
+}

--- a/my_performance.php
+++ b/my_performance.php
@@ -175,6 +175,14 @@ $statusLabels = [
     'rejected' => t($t, 'status_rejected', 'Rejected'),
 ];
 
+$formatProficiencyLevel = static function ($score): string {
+    if ($score === null) {
+        return '—';
+    }
+    $level = questionnaire_proficiency_level((float)$score);
+    return $level !== '' ? $level : 'N/A';
+};
+
 $flash = $_GET['msg'] ?? '';
 $flashMessage = '';
 if ($flash === 'submitted') {
@@ -262,7 +270,7 @@ $pageHelpKey = 'workspace.my_performance';
       <p><?=t($t,'no_trend_data','Submit assessments to generate your performance trend.')?></p>
     <?php endif; ?>
     <table class="md-table">
-      <thead><tr><th><?=t($t,'date','Date')?></th><th><?=t($t,'questionnaire','Questionnaire')?></th><th><?=t($t,'performance_period','Performance Period')?></th><th><?=t($t,'score','Score (%)')?></th><th><?=t($t,'status','Status')?></th><th><?=t($t,'actions','Actions')?></th></tr></thead>
+      <thead><tr><th><?=t($t,'date','Date')?></th><th><?=t($t,'questionnaire','Questionnaire')?></th><th><?=t($t,'performance_period','Performance Period')?></th><th><?=t($t,'score','Score (%)')?></th><th><?=t($t,'proficiency_level','Proficiency level')?></th><th><?=t($t,'status','Status')?></th><th><?=t($t,'actions','Actions')?></th></tr></thead>
       <tbody>
       <?php foreach ($responses as $r): ?>
         <?php
@@ -274,6 +282,7 @@ $pageHelpKey = 'workspace.my_performance';
           <td><?=htmlspecialchars($r['title'])?></td>
           <td><?=htmlspecialchars($r['period_label'])?></td>
           <td><?= is_null($r['score']) ? '-' : (int)$r['score']?></td>
+          <td><?=htmlspecialchars($formatProficiencyLevel($r['score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
           <td><?=htmlspecialchars($statusLabel)?></td>
           <td><span class="md-muted">—</span></td>
         </tr>


### PR DESCRIPTION
### Motivation
- Provide consistent, human-readable proficiency labels derived from questionnaire total percentage scores so stakeholders can interpret averages and individual totals at a glance.
- Keep the scope limited to questionnaire total scores only and avoid changing section-level scoring logic or section-level tables.

### Description
- Added shared scoring helpers in `lib/scoring.php`: `questionnaire_proficiency_level(?float): string` and `questionnaire_proficiency_details(?float): array` to map percentage ranges to labels and interpretations.
- Updated the admin analytics UI (`admin/analytics.php`) to surface a proficiency column and a local `$formatProficiencyLevel` helper for questionnaire averages, selected-response summary, and participant breakdown tables.
- Extended PDF reporting in `lib/analytics_report.php` to include an `Average proficiency` summary row and add `Proficiency` columns to questionnaire, work-function, and top-contributors tables using the shared scoring helper.
- Updated the user-facing pages by adding proficiency labels to the `My Performance` HTML table (`my_performance.php`) and to the downloadable PDF generator (`my_performance_download.php`) by importing `lib/scoring.php`, adding a summary `Proficiency level` row, and adding a `Proficiency level` column to the recent responses table while adjusting column widths.

### Testing
- Ran PHP syntax checks with `php -l lib/scoring.php`, `php -l admin/analytics.php`, `php -l lib/analytics_report.php`, `php -l my_performance.php`, and `php -l my_performance_download.php`, and all reported no syntax errors.
- Attempted an automated Playwright screenshot of the page render as visual validation, but the environment returned `ERR_EMPTY_RESPONSE` so no page render was captured.
- Committed the changes and created the PR after successful lint validation of the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bac288cf4832d831642309631f0f9)