### PR TITLE
Fix conditional visibility when dependency field is a textarea

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -1266,6 +1266,9 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
             }
             return [String(control.value || '').trim().toLowerCase()];
           }
+          if (control instanceof HTMLTextAreaElement) {
+            return [String(control.value || '').trim().toLowerCase()];
+          }
           if (control instanceof HTMLSelectElement) {
             return Array.from(control.selectedOptions).map((option) => String(option.value || '').trim().toLowerCase());
           }
@@ -1315,6 +1318,9 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
             if ((control.type === 'checkbox' || control.type === 'radio') && !control.checked) {
               return [];
             }
+            return [String(control.value || '').trim()];
+          }
+          if (control instanceof HTMLTextAreaElement) {
             return [String(control.value || '').trim()];
           }
           if (control instanceof HTMLSelectElement) {


### PR DESCRIPTION
### Motivation
- Conditional show/hide logic failed when the source question was a `textarea`, causing dependent fields (including "Other" follow-ups) to not appear or hide correctly.

### Description
- Read values from `HTMLTextAreaElement` when building `selectedValues` in `toggleOtherFollowupVisibility` so typed answers trigger "Other" follow-ups correctly in `submit_assessment.php`.
- Read values from `HTMLTextAreaElement` when building `selectedValues` in `toggleConditionalVisibility` so `equals`, `not_equals`, and `contains` conditions evaluate against textarea answers.
- Changes are limited to `submit_assessment.php` where the DOM control value collection logic is extended to include `textarea` controls.

### Testing
- Ran `php -l submit_assessment.php` which reported no syntax errors and succeeded.
- Ran `node tests/questionnaire_builder.test.js` which completed successfully (test output: `questionnaire_builder.test.js: ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bcf850928832d917fd1188397e9d3)