### PR TITLE
Polish questionnaire builder UX with progress rail, readiness checklist, nav search, and save feedback

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1847,6 +1847,12 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
     <div class="md-page-header__content">
       <h1 class="md-page-title" id="qb-page-title" tabindex="-1"><?=t($t,'manage_questionnaires','Manage Questionnaires')?></h1>
       <p class="md-page-subtitle"><?=t($t,'qb_builder_intro','Build and organize questionnaires for upcoming assessments.')?></p>
+      <ol class="qb-progress-rail" aria-label="<?=htmlspecialchars(t($t, 'qb_progress_rail', 'Questionnaire build flow'), ENT_QUOTES, 'UTF-8')?>">
+        <li class="qb-progress-step is-active"><?=t($t, 'qb_progress_step_start', '1. Start')?></li>
+        <li class="qb-progress-step"><?=t($t, 'qb_progress_step_structure', '2. Structure')?></li>
+        <li class="qb-progress-step"><?=t($t, 'qb_progress_step_questions', '3. Questions & scoring')?></li>
+        <li class="qb-progress-step"><?=t($t, 'qb_progress_step_publish', '4. Publish')?></li>
+      </ol>
     </div>
   </header>
   <?php if ($msg): ?>
@@ -1904,7 +1910,7 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
       </div>
       <div class="qb-start-actions">
         <button class="md-button md-elev-2" id="qb-open-selected"><?=t($t,'edit_selected','Edit selected')?></button>
-        <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_fhir','Export questionnaire')?></button>
+        <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_selected','Export selected')?></button>
       </div>
     </div>
     <div class="md-card md-elev-2 qb-start-card qb-import-start">
@@ -1948,6 +1954,26 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
               'Assign weights so priority questions total about 100%. Items left at 0 are informational only and do not affect scores or analytics.'
           )?></p>
         </div>
+        <div class="qb-publish-readiness" id="qb-publish-readiness" aria-live="polite">
+          <h4><?=t($t, 'qb_publish_ready_title', 'Publish readiness')?></h4>
+          <ul class="qb-readiness-list">
+            <li data-ready="title"><?=t($t, 'qb_readiness_title', 'Title added')?></li>
+            <li data-ready="content"><?=t($t, 'qb_readiness_content', 'At least one question')?></li>
+            <li data-ready="scoring"><?=t($t, 'qb_readiness_scoring', 'Scoring configured')?></li>
+          </ul>
+        </div>
+      </div>
+      <div class="md-card md-elev-2 qb-sidebar-card qb-danger-zone">
+        <h3 class="md-card-title"><?=t($t, 'qb_danger_zone', 'Danger zone')?></h3>
+        <p class="md-hint"><?=t($t, 'qb_danger_zone_hint', 'Deleting is irreversible. Use only when you are certain.')?></p>
+        <div class="qb-start-actions">
+          <button class="md-button md-outline qb-danger" id="qb-delete-questionnaire" type="button">
+            <?=t($t,'qb_delete_questionnaire','Delete questionnaire')?>
+          </button>
+          <button class="md-button md-outline qb-danger" id="qb-destroy-questionnaire" type="button">
+            <?=t($t,'qb_delete_questionnaire_destroy','Delete questionnaire + responses')?>
+          </button>
+        </div>
       </div>
     </aside>
     <div class="qb-manager-main">
@@ -1960,15 +1986,10 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
           <div class="qb-toolbar-actions">
             <button class="md-button md-outline md-elev-1" id="qb-preview-questionnaire" type="button"><?=t($t,'qb_preview_label','Preview questionnaire')?></button>
             <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_fhir','Export questionnaire')?></button>
-            <button class="md-button md-outline qb-danger" id="qb-delete-questionnaire" type="button">
-              <?=t($t,'qb_delete_questionnaire','Delete questionnaire')?>
-            </button>
-            <button class="md-button md-outline qb-danger" id="qb-destroy-questionnaire" type="button">
-              <?=t($t,'qb_delete_questionnaire_destroy','Delete questionnaire + responses')?>
-            </button>
             <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
           </div>
         </div>
+        <div class="qb-save-status" id="qb-save-status" aria-live="polite"><?=t($t,'qb_unsaved_changes','Unsaved changes')?></div>
         <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
         <div id="qb-list" class="qb-list" aria-live="polite"></div>
       </div>
@@ -1984,7 +2005,8 @@ $bootstrapQuestionnaires = qb_fetch_questionnaires($pdo);
     </div>
   </div>
   <button type="button" class="md-button md-outline md-floating-save-draft qb-floating-save" id="qb-save-floating" disabled>
-    <?=t($t,'save','Save Changes')?>
+    <span><?=t($t,'save','Save Changes')?></span>
+    <small id="qb-save-floating-label"><?=t($t,'qb_unsaved_changes','Unsaved changes')?></small>
   </button>
 </section>
 <?php if ($recentImportId): ?>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -1013,3 +1013,85 @@ body.qb-preview-open {
   margin: 0.2rem 0 0;
   color: var(--app-muted, rgba(0, 0, 0, 0.7));
 }
+
+.qb-progress-rail {
+  margin: 0.55rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.qb-progress-step {
+  font-size: 0.78rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: var(--app-primary-soft);
+  color: var(--app-primary-dark, var(--app-primary));
+}
+
+.qb-progress-step.is-active {
+  background: var(--app-primary);
+  color: var(--md-on-primary, #fff);
+}
+
+.qb-section-nav-search {
+  width: 100%;
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.12));
+  border-radius: 6px;
+  padding: 0.4rem 0.55rem;
+}
+
+.qb-publish-readiness h4 {
+  margin: 0.2rem 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.qb-readiness-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.qb-readiness-list li {
+  font-size: 0.86rem;
+  color: var(--app-muted);
+}
+
+.qb-readiness-list li::before {
+  content: '○';
+  margin-right: 0.35rem;
+}
+
+.qb-readiness-list li.is-ready {
+  color: var(--app-success, #1f8a47);
+}
+
+.qb-readiness-list li.is-ready::before {
+  content: '✓';
+}
+
+.qb-danger-zone {
+  border-left: 3px solid var(--app-danger, #b3261e);
+}
+
+.qb-save-status {
+  font-size: 0.84rem;
+  color: var(--app-muted, rgba(0, 0, 0, 0.65));
+  margin-top: -0.2rem;
+}
+
+.qb-floating-save {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.qb-floating-save small {
+  font-size: 0.72rem;
+  opacity: 0.82;
+}


### PR DESCRIPTION
### Motivation
- Improve clarity of the questionnaire builder flow and surface publish readiness so authors can complete required steps before publishing.
- Reduce risk of accidental destructive actions by grouping deletes into a dedicated danger area and provide clearer save-state feedback.
- Make large questionnaires easier to navigate with a searchable section nav and keyboard save shortcut for faster editing.

### Description
- Added a 4-step progress rail and updated start card wording in `admin/questionnaire_manage.php` to clarify the build workflow and change the start-card export label to `Export selected`.
- Introduced a publish-readiness checklist and moved destructive actions into a sidebar “Danger zone” in `admin/questionnaire_manage.php` to improve guidance and safety.
- Implemented section-nav search/filter, keyboard save shortcut (`Ctrl/Cmd + S`), and save-state synchronization by adding `renderPublishReadiness`, `countActiveItems`, and `updateSaveStatus` plus state fields (`lastSavedAt`, `navFilter`) in `assets/js/questionnaire-builder.js`; updated `saveAll` and `markDirty` to update the save status.
- Added supporting styles for the progress rail, nav search, readiness indicators, danger zone, and floating save label in `assets/css/questionnaire-builder.css`.

### Testing
- Ran `php -l admin/questionnaire_manage.php` which reported no syntax errors (success).
- Ran `node --check assets/js/questionnaire-builder.js` with no syntax issues (success).
- Started a local PHP dev server and attempted a Playwright screenshot run for visual validation, but the Chromium process crashed with a SIGSEGV in this environment (automated visual capture failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c62201660832d8e5993ff0e74bebb)