### PR TITLE
Keep top menu collapsed after login

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -556,10 +556,6 @@
           toggle.setAttribute('aria-expanded', 'false');
         }
         closeSubmenus();
-        const activeItem = topnav.querySelector('[data-topnav-item].is-active');
-        if (activeItem instanceof HTMLElement) {
-          setItemExpanded(activeItem, true);
-        }
         lastFocusedElement = null;
         return;
       }


### PR DESCRIPTION
### Motivation
- Prevent the desktop top navigation from auto-expanding the active group during initial viewport sync so the menu (including the "My Performance" section) remains fully collapsed after login.

### Description
- Remove the desktop auto-expand behavior in `syncTopnavForViewport` by updating `assets/js/app.js` so the active topnav item is no longer programmatically opened on non-mobile view.

### Testing
- Ran `node --check assets/js/app.js` which completed successfully.
- Ran an automated Playwright verification script, but the app returned HTTP 500 due to a local DB connection refusal in this environment so the UI screenshot verification failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c7c36bbb8832db2dfcdad08cf0a4b)