### PR TITLE
Add missing condition columns to questionnaire_item in bootstrap and upgrade SQL

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -135,6 +135,9 @@ CREATE TABLE questionnaire_item (
   allow_multiple TINYINT(1) NOT NULL DEFAULT 0,
   is_required TINYINT(1) NOT NULL DEFAULT 0,
   requires_correct TINYINT(1) NOT NULL DEFAULT 0,
+  condition_source_linkid VARCHAR(255) NULL,
+  condition_operator VARCHAR(20) NULL,
+  condition_value VARCHAR(500) NULL,
   is_active TINYINT(1) NOT NULL DEFAULT 1,
   FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE CASCADE,
   FOREIGN KEY (section_id) REFERENCES questionnaire_section(id) ON DELETE SET NULL

--- a/upgrade_to_v3.sql
+++ b/upgrade_to_v3.sql
@@ -157,7 +157,16 @@ ALTER TABLE questionnaire_item
   ADD COLUMN IF NOT EXISTS requires_correct TINYINT(1) NOT NULL DEFAULT 0 AFTER is_required;
 
 ALTER TABLE questionnaire_item
-  ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER requires_correct;
+  ADD COLUMN IF NOT EXISTS condition_source_linkid VARCHAR(255) NULL AFTER requires_correct;
+
+ALTER TABLE questionnaire_item
+  ADD COLUMN IF NOT EXISTS condition_operator VARCHAR(20) NULL AFTER condition_source_linkid;
+
+ALTER TABLE questionnaire_item
+  ADD COLUMN IF NOT EXISTS condition_value VARCHAR(500) NULL AFTER condition_operator;
+
+ALTER TABLE questionnaire_item
+  ADD COLUMN IF NOT EXISTS is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER condition_value;
 
 ALTER TABLE questionnaire_item_option
   ADD COLUMN IF NOT EXISTS is_correct TINYINT(1) NOT NULL DEFAULT 0 AFTER value;


### PR DESCRIPTION
### Motivation
- Conditional visibility is gated at runtime by the presence of `condition_source_linkid`, `condition_operator`, and `condition_value`, so missing columns disable the feature. 
- Fresh installs (via `init.sql`) and some upgrade paths (via `upgrade_to_v3.sql`) did not include those columns while `migration.sql` did, causing inconsistent behaviour where conditional visibility appeared broken.

### Description
- Added `condition_source_linkid VARCHAR(255)`, `condition_operator VARCHAR(20)`, and `condition_value VARCHAR(500)` to the `CREATE TABLE questionnaire_item` definition in `init.sql` to enable condition metadata on fresh bootstraps. 
- Updated `upgrade_to_v3.sql` to `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for the three condition columns and moved the `is_active` addition to come after `condition_value` so upgrades add the columns in the correct order. 
- Verified the runtime feature checks in `submit_assessment.php` and `admin/questionnaire_manage.php` rely on these columns, ensuring the schema change will re-enable conditional visibility where appropriate.

### Testing
- No automated unit or integration tests were executed for this change; validation consisted of repository scans and manual diff inspection to confirm the schema updates were applied to `init.sql` and `upgrade_to_v3.sql`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c9523847c832da4d3b183b7e72426)