### PR TITLE
Fix preview button no-op when no active questionnaire is selected

### DIFF
--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -106,6 +106,7 @@ const Builder = (() => {
     previewNoDescription: 'No description provided.',
     previewRootTitle: 'Items without a section',
     previewNoItems: 'No questions yet. Add items in the builder to preview them.',
+    previewUnavailable: 'Select or create a questionnaire before opening preview.',
     previewRequiredTag: 'Required',
     previewConditionPrefix: 'Shown when',
     previewOptionPlaceholder: 'Option',
@@ -364,9 +365,15 @@ const Builder = (() => {
   function openPreview() {
     const modal = document.querySelector(selectors.previewModal);
     const body = document.querySelector(selectors.previewBody);
-    if (!modal || !body) return;
+    if (!modal || !body) {
+      renderMessage('Preview is unavailable right now.', 'error');
+      return;
+    }
     const active = state.questionnaires.find((q) => q.clientId === state.activeKey);
-    if (!active) return;
+    if (!active) {
+      renderMessage(STRINGS.previewUnavailable, 'error');
+      return;
+    }
 
     body.innerHTML = buildPreviewContent(active);
     modal.hidden = false;
@@ -1267,10 +1274,12 @@ const Builder = (() => {
     const saveBtn = document.querySelector(selectors.saveButton);
     const floatingSaveBtn = document.querySelector(selectors.floatingSaveButton);
     const publishBtn = document.querySelector(selectors.publishButton);
+    const previewBtn = document.querySelector(selectors.previewButton);
     const disabled = state.questionnaires.length === 0 || state.saving;
     if (saveBtn) saveBtn.disabled = disabled || (!state.dirty && !state.loading);
     if (floatingSaveBtn) floatingSaveBtn.disabled = disabled || (!state.dirty && !state.loading);
     if (publishBtn) publishBtn.disabled = disabled || (!state.dirty && !state.loading);
+    if (previewBtn) previewBtn.disabled = state.questionnaires.length === 0;
   }
 
   function handleListInput(event) {


### PR DESCRIPTION
### Motivation
- Users reported clicking "Preview questionnaire" and nothing visible happening because `openPreview()` returned early without feedback when no questionnaire or modal nodes were present. 
- Prevent dead-clicks by surfacing a clear error and disabling the Preview button when previewing is impossible.

### Description
- Add a new localized fallback string `previewUnavailable` and use it to show an error when there is no active questionnaire to preview. 
- Show an explicit error via `renderMessage()` when the preview modal/body nodes are missing instead of silently returning. 
- Disable the Preview toolbar button when `state.questionnaires.length === 0` so users cannot click a non-functional control.

### Testing
- Ran `node --check assets/js/questionnaire-builder.js` which completed successfully. 
- Executed a Playwright script to load the admin page and capture a screenshot; the script produced a screenshot artifact but the test environment returned a `Not Found` response for the page so the in-browser preview UI could not be fully validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c98f5802c832d8107df4e0c704b03)