### PR TITLE
Fix conditional field visibility selector handling

### DIFF
--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -1185,6 +1185,33 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
       }
     };
 
+    const escapeAttributeValue = (value) => {
+      const raw = String(value || '');
+      if (window.CSS && typeof window.CSS.escape === 'function') {
+        return window.CSS.escape(raw);
+      }
+      return raw.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    };
+
+    const controlsForLinkId = (linkId) => {
+      const source = String(linkId || '').trim();
+      if (!source) {
+        return [];
+      }
+      const escaped = escapeAttributeValue(source);
+      const selector = `[name="item_${escaped}"], [name="item_${escaped}[]"]`;
+      try {
+        return Array.from(form.querySelectorAll(selector));
+      } catch (error) {
+        const direct = `item_${source}`;
+        const multiple = `item_${source}[]`;
+        return Array.from(form.querySelectorAll('[name]')).filter((control) => {
+          const name = control.getAttribute('name') || '';
+          return name === direct || name === multiple;
+        });
+      }
+    };
+
 
     const questionFields = () => Array.from(document.querySelectorAll('#assessment-form [data-question-anchor]'));
 
@@ -1258,7 +1285,7 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
         if (!parentLinkId) {
           return;
         }
-        const parentControls = Array.from(document.querySelectorAll(`[name="item_${parentLinkId}"], [name="item_${parentLinkId}[]"]`));
+        const parentControls = controlsForLinkId(parentLinkId);
         const selectedValues = parentControls.flatMap((control) => {
           if (control instanceof HTMLInputElement) {
             if ((control.type === 'checkbox' || control.type === 'radio') && !control.checked) {
@@ -1312,7 +1339,7 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
           field.hidden = false;
           return;
         }
-        const controls = Array.from(document.querySelectorAll(`[name="item_${source}"], [name="item_${source}[]"]`));
+        const controls = controlsForLinkId(source);
         const selectedValues = controls.flatMap((control) => {
           if (control instanceof HTMLInputElement) {
             if ((control.type === 'checkbox' || control.type === 'radio') && !control.checked) {


### PR DESCRIPTION
### Motivation
- Conditional fields could not reliably evaluate their source controls when a `linkId` contained characters that break CSS attribute selectors, causing those conditional fields to remain visible incorrectly. 
- This prevented follow-up (`Other`) fields and other conditionally shown questions from hiding or becoming required as intended.

### Description
- Added a safe helper `controlsForLinkId(linkId)` that finds source controls by `linkId`, using `escapeAttributeValue` to escape values for attribute selectors and falling back to name-equality checks when selector parsing fails. 
- Replaced direct dynamic selector usage with `controlsForLinkId` in the follow-up (`Other`) visibility logic and the generic conditional visibility logic. 
- Preserved existing behavior for toggling `required` and clearing values when conditional fields are hidden.

### Testing
- Ran a syntax check with `php -l submit_assessment.php` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d170d1764832d8ee60d17e48e193e)