### PR TITLE
Tighten Type and Condition dropdown sizing in questionnaire builder

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -711,6 +711,19 @@
   flex: 1 1 150px;
 }
 
+
+.qb-field--item-type,
+.qb-field--item-condition {
+  min-width: 160px;
+  max-width: 210px;
+  flex: 0 0 190px;
+}
+
+.qb-field--item-type .qb-select,
+.qb-field--item-condition .qb-select {
+  white-space: nowrap;
+}
+
 .qb-weight-field {
   flex: 1 1 180px;
   max-width: 220px;

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1116,7 +1116,7 @@ const Builder = (() => {
             <label>Question</label>
             <input type="text" data-role="item-text" value="${escapeAttr(item.text)}">
           </div>
-          <div class="qb-field">
+          <div class="qb-field qb-field--item-type">
             <label>Type</label>
             <select class="qb-select" data-role="item-type">
               ${QUESTION_TYPES
@@ -1142,7 +1142,7 @@ const Builder = (() => {
             <label>Show when question code</label>
             <input type="text" data-role="item-condition-source" value="${escapeAttr(item.condition_source_linkid || '')}" placeholder="e.g. q_department">
           </div>
-          <div class="qb-field">
+          <div class="qb-field qb-field--item-condition">
             <label>Condition</label>
             <select class="qb-select" data-role="item-condition-operator">
               <option value="equals" ${(item.condition_operator || 'equals') === 'equals' ? 'selected' : ''}>Equals</option>


### PR DESCRIPTION
### Motivation

- The 'Type' and 'Condition' dropdowns in the questionnaire item editor were growing into oversized/multi-line controls and needed to remain compact and single-line to preserve layout density.

### Description

- Added dedicated wrapper classes `qb-field--item-type` and `qb-field--item-condition` around the two select controls in `assets/js/questionnaire-builder.js` so they can be targeted independently.
- Added focused CSS rules to `assets/css/questionnaire-builder.css` that apply `min-width`, `max-width`, `flex: 0 0 <basis>`, and `white-space: nowrap` to those wrappers to keep the selects compact and single-line.
- The change scopes sizing to only those two fields so other form controls retain their existing responsive behavior.

### Testing

- Ran `git diff --check` to ensure no whitespace or diff errors and it reported no issues.
- Launched a local PHP development server (`php -S 0.0.0.0:8000 -t /workspace/CAS2025`) and verified the page loads successfully.
- Executed a Playwright-based browser script to load `/admin/questionnaire_manage.php` and capture a screenshot showing the updated dropdown layout, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f50d3b730832d9b29d02dd879614a)