### PR TITLE
Fix conditional field visibility and compact builder select controls

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -722,6 +722,9 @@
 .qb-field--item-type .qb-select,
 .qb-field--item-condition .qb-select {
   white-space: nowrap;
+  height: 2.2rem;
+  min-height: 2.2rem;
+  padding: 0.3rem 0.55rem;
 }
 
 .qb-weight-field {

--- a/submit_assessment.php
+++ b/submit_assessment.php
@@ -1339,14 +1339,24 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
 
 
     const toggleConditionalVisibility = () => {
-      const conditionalFields = Array.from(document.querySelectorAll('[data-condition-source][data-condition-operator][data-condition-value]'));
+      const conditionalFields = Array.from(document.querySelectorAll('[data-question-anchor]'));
       conditionalFields.forEach((field) => {
+        if (!(field instanceof HTMLElement)) {
+          return;
+        }
         const source = normalizeConditionLinkId(field.getAttribute('data-condition-source') || '');
         const operator = (field.getAttribute('data-condition-operator') || 'equals').toLowerCase();
         const expected = (field.getAttribute('data-condition-value') || '').trim();
+        const followupParentLinkId = normalizeConditionLinkId(field.getAttribute('data-other-parent-linkid') || '');
+        const hasCondition = source !== '';
+        const hasFollowupRule = field.hasAttribute('data-other-followup') && followupParentLinkId !== '';
+
+        if (!hasCondition && !hasFollowupRule) {
+          return;
+        }
 
         let showByFollowup = true;
-        if (followupParentLinkId) {
+        if (hasFollowupRule) {
           const selectedLower = selectedValuesForLinkId(followupParentLinkId).map((value) => value.toLowerCase());
           showByFollowup = selectedLower.includes('other');
         }
@@ -1413,8 +1423,9 @@ $renderQuestionField = static function (array $it, array $t, array $answers) use
     document.addEventListener('change', handleQuestionValueChange);
     document.addEventListener('input', handleQuestionValueChange);
 
-    document.addEventListener('change', handleQuestionValueChange);
-    document.addEventListener('input', handleQuestionValueChange);
+    const refreshDependentVisibility = () => {
+      toggleConditionalVisibility();
+    };
 
     for (let pass = 0; pass < 10; pass += 1) {
       refreshDependentVisibility();


### PR DESCRIPTION
### Motivation
- Conditional and "other" follow-up rules were not being applied reliably because visibility logic only scanned elements that already had all condition attributes, causing some dependent fields to remain hidden even when conditions were met.
- The questionnaire builder `Type` and `Condition` select controls were taller than intended after previous attempts to compact them.

### Description
- Rewrote the client-side conditional evaluator in `submit_assessment.php` to scan all question anchors (`[data-question-anchor]`) and then apply per-field conditional and follow-up rules only when configured, with safe guards for missing attributes.
- Restored a `refreshDependentVisibility()` wrapper and ensured change/input handlers call it repeatedly to reliably re-evaluate dependent visibility as answers change.
- Adjusted builder control styles in `assets/css/questionnaire-builder.css` to reduce the height and padding of the `Type` and `Condition` selects (`height: 2.2rem`, reduced padding).

### Testing
- Ran PHP lint checks with `php -l submit_assessment.php` and `php -l admin/questionnaire_manage.php`, both reported no syntax errors (succeeded).
- Launched a development server and ran a Playwright script to capture `submit_assessment.php`; screenshot capture succeeded but the page returned a DB connection error in this environment (server started, but DB connection refused).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0eefdb240832da5ed8a7a4cf84f92)