### PR TITLE
Rework Builder item layout and rebuild Type/Condition dropdown UX

### DIFF
--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -683,15 +683,31 @@
 
 .qb-item-main {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.qb-item-main-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.4rem 0.55rem;
+  grid-template-columns: minmax(180px, 230px) minmax(0, 1fr);
+  gap: 0.55rem;
+}
+
+.qb-item-config-row {
+  display: grid;
+  grid-template-columns: minmax(170px, 210px) minmax(0, 1fr) auto;
+  gap: 0.55rem;
   align-items: end;
 }
 
 .qb-item-main .qb-actions {
   align-self: end;
   justify-content: flex-end;
+}
+
+.qb-item-actions .md-button {
+  min-width: 110px;
 }
 
 .qb-inactive {
@@ -737,8 +753,7 @@
 .qb-field--item-type,
 .qb-field--item-condition {
   min-width: 160px;
-  max-width: 210px;
-  flex: 0 0 190px;
+  max-width: none;
 }
 
 .qb-field--item-type .qb-select,
@@ -751,6 +766,73 @@
   height: 2.2rem;
   min-height: 2.2rem;
   padding: 0.3rem 0.55rem;
+}
+
+
+.qb-item-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.qb-chip-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.15));
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  background: var(--app-primary-soft, rgba(32, 84, 147, 0.08));
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.qb-chip-toggle input[type="checkbox"] {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+.qb-item-condition-card {
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  background: var(--app-surface-alt, rgba(32, 84, 147, 0.05));
+  padding: 0.55rem 0.65rem;
+}
+
+.qb-item-condition-title {
+  margin: 0 0 0.45rem;
+  font-size: 0.83rem;
+  font-weight: 700;
+  color: var(--app-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.qb-item-condition-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(150px, 1fr));
+  gap: 0.5rem;
+}
+
+.qb-field--item-control .qb-select {
+  min-width: 0;
+}
+
+.qb-field--item-link {
+  min-width: 170px;
+}
+
+@media (max-width: 920px) {
+  .qb-item-main-grid,
+  .qb-item-config-row,
+  .qb-item-condition-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .qb-item-actions {
+    justify-content: flex-start;
+  }
 }
 
 .qb-weight-field {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -1102,60 +1102,66 @@ const Builder = (() => {
   function buildItemRow(questionnaire, sectionClientId, item) {
     const scorable = isScorable(item.type);
     const showRequiresCorrect = item.type === 'choice' && !item.allow_multiple;
+    const conditionEnabled = Boolean(item.condition_source_linkid);
     const optionsHtml = ['choice', 'likert'].includes(item.type)
       ? buildOptionsEditor(sectionClientId, item)
       : '';
     return `
       <div class="qb-item" data-item="${item.clientId}" data-section="${sectionClientId || ''}">
         <div class="qb-item-main">
-          <div class="qb-field">
-            <label>Question Code</label>
-            <input type="text" data-role="item-link" value="${escapeAttr(item.linkId)}">
+          <div class="qb-item-main-grid">
+            <div class="qb-field qb-field--item-link">
+              <label>Question Code</label>
+              <input type="text" data-role="item-link" value="${escapeAttr(item.linkId)}" placeholder="e.g. q_team_support">
+            </div>
+            <div class="qb-field qb-field--item-text">
+              <label>Question</label>
+              <input type="text" data-role="item-text" value="${escapeAttr(item.text)}" placeholder="Question prompt shown to employees">
+            </div>
           </div>
-          <div class="qb-field">
-            <label>Question</label>
-            <input type="text" data-role="item-text" value="${escapeAttr(item.text)}">
+
+          <div class="qb-item-config-row">
+            <div class="qb-field qb-field--item-type qb-field--item-control">
+              <label>Response Type</label>
+              <select class="qb-select" data-role="item-type">
+                ${QUESTION_TYPES
+                  .map((type) => `<option value="${type}" ${type === item.type ? 'selected' : ''}>${QUESTION_TYPE_LABELS[type] || type}</option>`)
+                  .join('')}
+              </select>
+            </div>
+            <div class="qb-item-toggles">
+              <label class="qb-chip-toggle"><input type="checkbox" data-role="item-required" ${item.is_required ? 'checked' : ''}> Required</label>
+              <label class="qb-chip-toggle"><input type="checkbox" data-role="item-multi" ${item.allow_multiple ? 'checked' : ''} ${item.type !== 'choice' ? 'disabled' : ''}> Allow multiple</label>
+              ${showRequiresCorrect
+                ? `<label class="qb-chip-toggle"><input type="checkbox" data-role="item-requires-correct" ${item.requires_correct ? 'checked' : ''}> Require correct answer</label>`
+                : ''}
+              <label class="qb-chip-toggle"><input type="checkbox" data-role="item-active" ${item.is_active ? 'checked' : ''} ${item.hasResponses ? 'disabled' : ''}> Active</label>
+            </div>
+            <div class="qb-actions qb-item-actions">
+              <button type="button" class="md-button md-outline" data-role="remove-item" ${item.hasResponses ? 'disabled' : ''}>Remove</button>
+            </div>
           </div>
-          <div class="qb-field qb-field--item-type">
-            <label>Type</label>
-            <select class="qb-select" data-role="item-type">
-              ${QUESTION_TYPES
-                .map((type) => `<option value="${type}" ${type === item.type ? 'selected' : ''}>${QUESTION_TYPE_LABELS[type] || type}</option>`)
-                .join('')}
-            </select>
-          </div>
-          <div class="qb-field qb-toggle">
-            <label><input type="checkbox" data-role="item-required" ${item.is_required ? 'checked' : ''}> Required</label>
-          </div>
-          <div class="qb-field qb-toggle">
-            <label><input type="checkbox" data-role="item-multi" ${item.allow_multiple ? 'checked' : ''} ${item.type !== 'choice' ? 'disabled' : ''}> Allow multiple</label>
-          </div>
-          ${showRequiresCorrect
-            ? `<div class="qb-field qb-toggle">
-                <label><input type="checkbox" data-role="item-requires-correct" ${item.requires_correct ? 'checked' : ''}> Require correct answer</label>
-              </div>`
-            : ''}
-          <div class="qb-field qb-toggle">
-            <label><input type="checkbox" data-role="item-active" ${item.is_active ? 'checked' : ''} ${item.hasResponses ? 'disabled' : ''}> Active</label>
-          </div>
-          <div class="qb-field">
-            <label>Show when question code</label>
-            <input type="text" data-role="item-condition-source" value="${escapeAttr(item.condition_source_linkid || '')}" placeholder="e.g. q_department">
-          </div>
-          <div class="qb-field qb-field--item-condition">
-            <label>Condition</label>
-            <select class="qb-select" data-role="item-condition-operator">
-              <option value="equals" ${(item.condition_operator || 'equals') === 'equals' ? 'selected' : ''}>Equals</option>
-              <option value="not_equals" ${(item.condition_operator || '') === 'not_equals' ? 'selected' : ''}>Does not equal</option>
-              <option value="contains" ${(item.condition_operator || '') === 'contains' ? 'selected' : ''}>Contains</option>
-            </select>
-          </div>
-          <div class="qb-field">
-            <label>Condition value</label>
-            <input type="text" data-role="item-condition-value" value="${escapeAttr(item.condition_value || '')}" placeholder="Expected answer">
-          </div>
-          <div class="qb-actions">
-            <button type="button" class="md-button md-outline" data-role="remove-item" ${item.hasResponses ? 'disabled' : ''}>Remove</button>
+
+          <div class="qb-item-condition-card">
+            <p class="qb-item-condition-title">Display condition (optional)</p>
+            <div class="qb-item-condition-grid">
+              <div class="qb-field">
+                <label>Show when question code</label>
+                <input type="text" data-role="item-condition-source" value="${escapeAttr(item.condition_source_linkid || '')}" placeholder="e.g. q_department">
+              </div>
+              <div class="qb-field qb-field--item-condition qb-field--item-control">
+                <label>Condition</label>
+                <select class="qb-select" data-role="item-condition-operator" ${conditionEnabled ? '' : 'disabled'}>
+                  <option value="equals" ${(item.condition_operator || 'equals') === 'equals' ? 'selected' : ''}>Equals</option>
+                  <option value="not_equals" ${(item.condition_operator || '') === 'not_equals' ? 'selected' : ''}>Does not equal</option>
+                  <option value="contains" ${(item.condition_operator || '') === 'contains' ? 'selected' : ''}>Contains</option>
+                </select>
+              </div>
+              <div class="qb-field">
+                <label>Condition value</label>
+                <input type="text" data-role="item-condition-value" value="${escapeAttr(item.condition_value || '')}" placeholder="Expected answer" ${conditionEnabled ? '' : 'disabled'}>
+              </div>
+            </div>
           </div>
         </div>
         <div class="qb-item-secondary">
@@ -1413,7 +1419,7 @@ const Builder = (() => {
         return;
     }
     markDirty();
-    if (['item-type', 'item-multi', 'item-requires-correct'].includes(role)) {
+    if (['item-type', 'item-multi', 'item-requires-correct', 'item-condition-source'].includes(role)) {
       const itemRow = event.target.closest('[data-item]');
       rerenderItemRow(questionnaire, itemRow);
     }
@@ -1546,6 +1552,10 @@ const Builder = (() => {
         break;
       case 'item-condition-source':
         item.condition_source_linkid = input.value.trim();
+        if (!item.condition_source_linkid) {
+          item.condition_operator = 'equals';
+          item.condition_value = '';
+        }
         break;
       case 'item-condition-operator':
         item.condition_operator = input.value || 'equals';


### PR DESCRIPTION
### Motivation
- The questionnaire builder item row was visually cluttered and poorly organized, making it hard to scan and edit question type and condition settings.
- The Type and Condition controls needed clearer grouping and explicit enable/disable behavior to avoid accidental misconfiguration.

### Description
- Reworked the item row markup in `assets/js/questionnaire-builder.js` by rebuilding `buildItemRow` to group fields into identity, configuration (response type + toggles), and a dedicated display-condition panel, and added `conditionEnabled` to drive enable/disable state for operator/value fields.
- Added immediate re-rendering when the condition source changes by including `item-condition-source` in the rerender trigger and clearing `condition_operator`/`condition_value` when the source is removed (`applyFieldChange` updates).
- Recreated the Type area as `Response Type` and repositioned related toggles into compact chip-style controls and moved the Remove action into the new config row for better UX (`assets/css/questionnaire-builder.css` and `assets/js/questionnaire-builder.js`).
- Introduced new CSS rules (`.qb-item-main-grid`, `.qb-item-config-row`, `.qb-item-condition-card`, `.qb-chip-toggle`, responsive grid behavior) to support the new layout and mobile stacking in `assets/css/questionnaire-builder.css`.

### Testing
- Ran the unit/browser test `node tests/questionnaire_builder.test.js` and it passed (`questionnaire_builder.test.js: ok`).
- Ran a Playwright script to capture a screenshot of `/admin/questionnaire_manage.php`, but the page failed to load due to a database connection error (`SQLSTATE[HY000] [2002] Connection refused`), so the full in-browser verification could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a10abd1b04832d9c23c52d75c55253)