### PR TITLE
Align index landing styles with login and remove partner/contact blocks

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -20,10 +20,7 @@ body.landing-body {
   min-height: 100vh;
   font-family: "Inter", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--app-text-primary, #0f1c31);
-  background:
-    radial-gradient(140% 140% at 15% 20%, color-mix(in srgb, var(--md-primary) 18%, transparent) 0%, transparent 72%),
-    radial-gradient(120% 120% at 85% 5%, color-mix(in srgb, var(--md-accent) 14%, transparent) 0%, transparent 74%),
-    color-mix(in srgb, var(--md-bg) 78%, #0f172a 22%);
+  background: linear-gradient(135deg, #f4f7fb 0%, #eaf0f7 100%);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -38,9 +35,12 @@ body.landing-body {
   position: sticky;
   top: 0;
   z-index: 12;
-  backdrop-filter: blur(12px);
-  background: color-mix(in srgb, var(--md-surface) 90%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--app-border) 60%, transparent);
+  background: linear-gradient(
+    135deg,
+    var(--app-primary, #0d63d9) 0%,
+    color-mix(in srgb, var(--app-primary, #0d63d9) 70%, #2ba7ff 30%) 100%
+  );
+  border-bottom: 1px solid color-mix(in srgb, var(--app-primary, #0d63d9) 72%, #ffffff 28%);
 }
 
 .landing-topbar__inner {
@@ -62,7 +62,7 @@ body.landing-body {
 
 .landing-nav a {
   text-decoration: none;
-  color: var(--app-text-primary, #10213d);
+  color: #f7fbff;
   font-weight: 600;
   font-size: 0.95rem;
   padding: 0.4rem 0.65rem;
@@ -71,8 +71,8 @@ body.landing-body {
 
 .landing-nav a:hover,
 .landing-nav a:focus-visible {
-  color: var(--landing-primary);
-  background: color-mix(in srgb, var(--landing-primary) 10%, transparent);
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.14);
 }
 
 
@@ -187,6 +187,7 @@ body.landing-body {
   backdrop-filter: blur(12px);
   box-shadow: var(--landing-shadow-sm);
   text-decoration: none;
+  color: #f7fbff;
 }
 
 .landing-brand__logo {

--- a/index.php
+++ b/index.php
@@ -12,8 +12,6 @@ $logoRenderPath = site_logo_url($cfg);
 $logo = htmlspecialchars($logoRenderPath, ENT_QUOTES, 'UTF-8');
 $logoAlt = htmlspecialchars($cfg['site_name'] ?? 'Logo', ENT_QUOTES, 'UTF-8');
 $siteName = htmlspecialchars($cfg['site_name'] ?? 'My Performance', ENT_QUOTES, 'UTF-8');
-$address = htmlspecialchars($cfg['address'] ?? '', ENT_QUOTES, 'UTF-8');
-$contact = htmlspecialchars($cfg['contact'] ?? '', ENT_QUOTES, 'UTF-8');
 $bodyClass = trim(htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8') . ' landing-body');
 $bodyStyle = htmlspecialchars(site_body_style($cfg), ENT_QUOTES, 'UTF-8');
 $brandStyle = site_brand_style($cfg);
@@ -27,8 +25,6 @@ $heroSubtitle = htmlspecialchars(t($t, 'hero_subtitle', 'From planning to recogn
 $heroBadgeOne = htmlspecialchars(t($t, 'hero_badge_one', 'Goal alignment'), ENT_QUOTES, 'UTF-8');
 $heroBadgeTwo = htmlspecialchars(t($t, 'hero_badge_two', '360° feedback'), ENT_QUOTES, 'UTF-8');
 $heroBadgeThree = htmlspecialchars(t($t, 'hero_badge_three', 'Learning insights'), ENT_QUOTES, 'UTF-8');
-$addressLabel = htmlspecialchars(t($t, 'address_label', 'Address'), ENT_QUOTES, 'UTF-8');
-$contactLabel = htmlspecialchars(t($t, 'contact_label', 'Contact'), ENT_QUOTES, 'UTF-8');
 $featureItems = [
     [
         'title' => htmlspecialchars(t($t, 'feature_insights_title', 'Actionable insights'), ENT_QUOTES, 'UTF-8'),
@@ -84,7 +80,6 @@ $newsCards = [
     htmlspecialchars(t($t, 'news_three', 'Supervisor scorecards include stronger competency benchmarking insights.'), ENT_QUOTES, 'UTF-8'),
 ];
 
-$partners = ['MoPS', 'MoE', 'Civil Service Commission', 'Regional Bureaus', 'HR Council'];
 ?>
 <!doctype html>
 <html lang="<?= $langAttr ?>" data-base-url="<?= $baseUrl ?>">
@@ -194,17 +189,6 @@ $partners = ['MoPS', 'MoE', 'Civil Service Commission', 'Regional Bureaus', 'HR 
         </div>
       </section>
 
-      <section class="landing-section landing-section--partners">
-        <div class="landing-section__header">
-          <h2><?= htmlspecialchars(t($t, 'partners_heading', 'Trusted partners'), ENT_QUOTES, 'UTF-8') ?></h2>
-        </div>
-        <div class="landing-partners-grid">
-          <?php foreach ($partners as $partner): ?>
-            <span><?= htmlspecialchars($partner, ENT_QUOTES, 'UTF-8') ?></span>
-          <?php endforeach; ?>
-        </div>
-      </section>
-
       <section class="landing-section landing-section--cta">
         <div class="landing-section__content">
           <h2><?= htmlspecialchars(t($t, 'cta_heading', 'Start your next performance cycle with confidence'), ENT_QUOTES, 'UTF-8') ?></h2>
@@ -216,21 +200,6 @@ $partners = ['MoPS', 'MoE', 'Civil Service Commission', 'Regional Bureaus', 'HR 
     </main>
 
     <footer class="landing-footer" id="contact">
-      <div class="landing-footer__contact" aria-label="<?= htmlspecialchars(t($t, 'contact_details_label', 'Contact details'), ENT_QUOTES, 'UTF-8') ?>">
-        <h3><?= htmlspecialchars(t($t, 'contact_us', 'Contact us'), ENT_QUOTES, 'UTF-8') ?></h3>
-        <?php if ($address !== ''): ?>
-          <div><strong><?= $addressLabel ?>:</strong> <?= $address ?></div>
-        <?php endif; ?>
-        <?php if ($contact !== ''): ?>
-          <div><strong><?= $contactLabel ?>:</strong> <?= $contact ?></div>
-        <?php endif; ?>
-      </div>
-      <div class="landing-footer__links">
-        <h3><?= htmlspecialchars(t($t, 'quick_links', 'Quick links'), ENT_QUOTES, 'UTF-8') ?></h3>
-        <a href="#services"><?= htmlspecialchars(t($t, 'services', 'Services'), ENT_QUOTES, 'UTF-8') ?></a>
-        <a href="#events"><?= htmlspecialchars(t($t, 'events', 'Events'), ENT_QUOTES, 'UTF-8') ?></a>
-        <a href="#news"><?= htmlspecialchars(t($t, 'news', 'News'), ENT_QUOTES, 'UTF-8') ?></a>
-      </div>
       <div class="landing-footer__meta">
         <h3><?= htmlspecialchars(t($t, 'languages', 'Languages'), ENT_QUOTES, 'UTF-8') ?></h3>
         <div class="landing-footer__languages" aria-label="<?= htmlspecialchars(t($t, 'language_switch_label', 'Change language'), ENT_QUOTES, 'UTF-8') ?>">


### PR DESCRIPTION
### Motivation
- Harmonise the public landing page look with the authenticated `login.php` styling so the site presents a consistent brand experience.
- Remove redundant footer and page blocks (`Contact us`, `Quick Links`, `Trusted partners`) to simplify the landing page content per design request.

### Description
- Updated `assets/css/landing.css` to use the same light page background as the login page and applied the login tile's blue gradient to the top header (`.landing-topbar`), plus adjusted topbar/brand/link contrast for readability.
- Adjusted `.landing-nav` and `.landing-brand` styles so navigation and brand text remain legible on the new blue header.
- Removed page/footer content from `index.php`: the `Trusted partners` section and the `Contact us` and `Quick Links` footer blocks, and removed related unused PHP variables (`$address`, `$contact`, `$partners`, `$addressLabel`, `$contactLabel`).
- Kept the language switcher in the footer and preserved layout/structure of other landing sections.

### Testing
- Ran `php -l index.php` and `php -l login.php`, both reported no syntax errors.
- Launched a local dev server and captured an automated screenshot of `index.php` for visual verification (screenshot produced successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c4a28818832dbe2720388f8559bb)