### PR TITLE
Refactor questionnaire builder workspace UI and add danger-drawer styles

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -1920,8 +1920,8 @@ if ($qbJsVersion) {
       </div>
       <div class="qb-start-actions">
         <button class="md-button md-elev-2" id="qb-open-selected"><?=t($t,'edit_selected','Edit selected')?></button>
-        <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_selected','Export selected')?></button>
       </div>
+      <p class="md-hint qb-start-inline-note"><?=t($t,'qb_start_edit_export_hint','Use the workspace actions to preview or export after opening a questionnaire.')?></p>
     </div>
     <div class="md-card md-elev-2 qb-start-card qb-import-start">
       <div class="qb-start-card-header">
@@ -1973,10 +1973,10 @@ if ($qbJsVersion) {
           </ul>
         </div>
       </div>
-      <div class="md-card md-elev-2 qb-sidebar-card qb-danger-zone">
+      <div class="md-card md-elev-2 qb-sidebar-card qb-danger-zone qb-danger-drawer">
         <h3 class="md-card-title"><?=t($t, 'qb_danger_zone', 'Danger zone')?></h3>
         <p class="md-hint"><?=t($t, 'qb_danger_zone_hint', 'Deleting is irreversible. Use only when you are certain.')?></p>
-        <div class="qb-start-actions">
+        <div class="qb-start-actions qb-danger-actions">
           <button class="md-button md-outline qb-danger" id="qb-delete-questionnaire" type="button">
             <?=t($t,'qb_delete_questionnaire','Delete questionnaire')?>
           </button>
@@ -1992,11 +1992,20 @@ if ($qbJsVersion) {
         <span class="qb-scroll-top-label"><?=t($t,'qb_scroll_to_top','Back to top')?></span>
       </button>
       <div class="md-card md-elev-2 qb-builder-card">
-        <div class="qb-toolbar">
-          <div class="qb-toolbar-actions">
-            <button class="md-button md-outline md-elev-1" id="qb-preview-questionnaire" type="button"><?=t($t,'qb_preview_label','Preview questionnaire')?></button>
-            <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_fhir','Export questionnaire')?></button>
-            <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
+        <div class="qb-workspace-head">
+          <div class="qb-workspace-head-copy">
+            <p class="md-overline"><?=t($t, 'qb_workspace_label', 'Workspace')?></p>
+            <h3 class="md-card-title"><?=t($t, 'qb_workspace_title', 'Questionnaire editor')?></h3>
+            <p class="md-hint"><?=t($t, 'qb_workspace_hint', 'Build sections and questions here, then preview and publish when checks are ready.')?></p>
+          </div>
+          <div class="qb-toolbar" aria-label="<?=htmlspecialchars(t($t, 'qb_workspace_actions', 'Workspace actions'), ENT_QUOTES, 'UTF-8')?>">
+            <div class="qb-toolbar-actions qb-toolbar-actions--secondary">
+              <button class="md-button md-outline md-elev-1" id="qb-preview-questionnaire" type="button"><?=t($t,'qb_preview_label','Preview questionnaire')?></button>
+              <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_fhir','Export questionnaire')?></button>
+            </div>
+            <div class="qb-toolbar-actions">
+              <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
+            </div>
           </div>
         </div>
         <div class="qb-save-status" id="qb-save-status" aria-live="polite"><?=t($t,'qb_unsaved_changes','Unsaved changes')?></div>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -21,6 +21,10 @@
   justify-content: flex-end;
 }
 
+.qb-toolbar-actions--secondary .md-button {
+  --md-button-padding-x: 0.8rem;
+}
+
 .qb-select-label {
   font-weight: 600;
 }
@@ -61,6 +65,29 @@
   gap: 0.75rem;
 }
 
+.qb-workspace-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.15rem 0.15rem 0.35rem;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.qb-workspace-head-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 240px;
+}
+
+.qb-workspace-head-copy .md-overline,
+.qb-workspace-head-copy .md-card-title,
+.qb-workspace-head-copy .md-hint {
+  margin: 0;
+}
+
 .qb-start-grid {
   display: grid;
   gap: 0.4rem;
@@ -87,6 +114,11 @@
 
 .qb-start-card .md-hint {
   margin-top: 0.15rem;
+}
+
+.qb-start-inline-note {
+  margin: 0;
+  font-size: 0.82rem;
 }
 
 .qb-start-card-header {
@@ -182,6 +214,46 @@
   flex-direction: column;
   gap: 0.75rem;
   padding: 0.85rem 1rem;
+}
+
+
+.qb-danger-drawer {
+  margin-top: auto;
+  position: sticky;
+  bottom: 0.5rem;
+  border: 1px solid #d1242f;
+  background: #fff5f5;
+  box-shadow: 0 0 0 1px rgba(209, 36, 47, 0.08);
+}
+
+.qb-danger-drawer .md-card-title {
+  color: #9a1c23;
+}
+
+.qb-danger-drawer .md-hint {
+  margin: 0;
+  color: #6e1a1f;
+}
+
+.qb-danger-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.45rem;
+}
+
+.qb-danger-actions .md-button {
+  width: 100%;
+  justify-content: center;
+  border-color: #d1242f;
+  color: #9a1c23;
+  background: #fff;
+}
+
+.qb-danger-actions .md-button:hover,
+.qb-danger-actions .md-button:focus-visible {
+  background: #d1242f;
+  color: #fff;
+  border-color: #d1242f;
 }
 
 .qb-tabs-vertical {
@@ -309,6 +381,21 @@
     flex: 1 1 auto;
     position: static;
     top: auto;
+  }
+
+  .qb-workspace-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .qb-toolbar {
+    justify-content: flex-start;
+  }
+
+
+  .qb-danger-drawer {
+    position: static;
+    bottom: auto;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Improve the editor workspace layout and clarify where preview/export actions live while emphasizing the irreversible deletion controls.
- Make the sidebar danger controls visually distinct and stick to the bottom on large viewports for better discoverability.

### Description
- Restructured the workspace header in `admin/questionnaire_manage.php` by replacing the old `.qb-toolbar` with a `.qb-workspace-head` block that includes descriptive copy and separated action groups for preview/export and publish. 
- Removed the inline export control from the start/edit card and added an inline hint (`.qb-start-inline-note`) instructing users to use the workspace actions after opening a questionnaire. 
- Added new danger-area classes to `admin/questionnaire_manage.php` (`qb-danger-drawer` on the container and `qb-danger-actions` for the buttons) and updated markup to stack danger buttons. 
- Extended `assets/css/questionnaire-builder.css` with styles for `.qb-workspace-head`, `.qb-workspace-head-copy`, `.qb-toolbar-actions--secondary`, `.qb-start-inline-note`, `.qb-danger-drawer`, and `.qb-danger-actions`, plus responsive adjustments to preserve layout on small screens. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4f69fb950832d965bb8a279059596)