### PR TITLE
Enable editing and archiving work roles in metadata defaults

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -117,8 +117,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $slug = trim((string)($_POST['slug'] ?? ''));
             $label = trim((string)($_POST['label'] ?? ''));
             if ($slug === '' || $label === '') throw new InvalidArgumentException(t($t,'invalid_work_function','Select a valid work function.'));
-            $pdo->prepare('UPDATE work_function_catalog SET label=? WHERE slug=?')->execute([$label,$slug]);
+            update_work_function_label($pdo, $slug, $label);
             $_SESSION[$metadataFlashKey] = t($t,'work_function_catalog_updated','Work function updated.');
+            header('Location: ' . url_for('admin/work_function_defaults.php')); exit;
+        }
+        if ($mode === 'role_archive') {
+            $slug = trim((string)($_POST['slug'] ?? ''));
+            if ($slug === '') throw new InvalidArgumentException(t($t,'invalid_work_function','Select a valid work function.'));
+            archive_work_function($pdo, $slug);
+            $_SESSION[$metadataFlashKey] = t($t,'work_function_catalog_archived','Work function archived.');
             header('Location: ' . url_for('admin/work_function_defaults.php')); exit;
         }
 
@@ -254,7 +261,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </summary>
       <div class="md-defaults-group-body">
         <?php foreach ($workRoles as $slug => $record): if (($record['archived_at'] ?? null)!==null) continue; ?>
-          <form method="post" class="md-work-function-row md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="mode" value="role_update"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'work_function_label_name','Work function name')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary"><?=t($t,'save','Save Changes')?></button></form>
+          <form method="post" class="md-work-function-row md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'work_function_label_name','Work function name')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="role_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="role_archive" onclick="return confirm('<?=htmlspecialchars(t($t,'work_function_archive_confirm','Archive this work function? Existing assignments will be removed.'), ENT_QUOTES, 'UTF-8')?>');"><?=t($t,'work_function_archive','Archive')?></button></form>
         <?php endforeach; ?>
       </div>
     </details>


### PR DESCRIPTION
### Motivation
- Admins need the ability to rename and deactivate/archive existing Work Roles from the metadata UI rather than relying on static built-in strings.
- The metadata page should use the existing work function helpers to ensure validation, cache invalidation, and consistent behavior when updating catalog entries.

### Description
- Replace the inline SQL update with a call to `update_work_function_label($pdo, $slug, $label)` to rename roles with consistent validation and cache handling in `admin/work_function_defaults.php`.
- Add a new `role_archive` POST mode that calls `archive_work_function($pdo, $slug)` and sets the `work_function_catalog_archived` flash message to archive (deactivate) a role and clear related assignments/users.
- Update the Work Role UI rows to include both `Save Changes` and `Archive` buttons with a localized confirmation prompt to allow in-place renaming and archiving from the Metadata page.

### Testing
- Ran PHP lint checks which succeeded: `php -l admin/work_function_defaults.php` and `php -l lib/work_functions.php` (both reported no syntax errors). 
- Ran the metadata-related smoke test `php tests/work_function_assignments_test.php` which failed in this environment with the message: `Initial assignment save did not match expectations.`
- The change was exercised in the dev server in this environment but app runtime required DB connectivity so full end-to-end page load validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5d7fb6518832d883c5c2f13c478d4)