### PR TITLE
Add training recommendation report to analytics dashboard

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -577,6 +577,7 @@ usort($kpiBreakdownRows, static function (array $a, array $b): int {
 
 $selectedResponses = [];
 $selectedUserBreakdown = [];
+$trainingRecommendationReport = [];
 $sectionColumns = [];
 $sectionScoresByResponse = [];
 $sectionAggregates = [];
@@ -895,6 +896,19 @@ $workFunctionSummary = [];
 $departmentSummary = [];
 $teamSummary = [];
 try {
+    $trainingRecommendationStmt = $pdo->query(
+        'SELECT cc.id AS course_id, cc.title AS course_title, '
+        . 'COUNT(DISTINCT qr.user_id) AS recommended_staff_count, '
+        . "GROUP_CONCAT(DISTINCT CONCAT_WS(' ', NULLIF(u.full_name, ''), CONCAT('(', u.username, ')')) ORDER BY u.full_name, u.username SEPARATOR '; ') AS recommended_staff "
+        . 'FROM training_recommendation tr '
+        . 'JOIN course_catalogue cc ON cc.id = tr.course_id '
+        . 'JOIN questionnaire_response qr ON qr.id = tr.questionnaire_response_id '
+        . 'JOIN users u ON u.id = qr.user_id '
+        . 'GROUP BY cc.id, cc.title '
+        . 'ORDER BY recommended_staff_count DESC, cc.title ASC'
+    );
+    $trainingRecommendationReport = $trainingRecommendationStmt ? $trainingRecommendationStmt->fetchAll(PDO::FETCH_ASSOC) : [];
+
     $workFunctionStmt = $pdo->query(
         "SELECT u.work_function, COUNT(*) AS total_responses, "
         . "SUM(qr.status='approved') AS approved_count, "
@@ -1788,6 +1802,32 @@ $pageHelpKey = 'team.analytics';
       <?php endif; ?>
     </div>
   <?php endif; ?>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'training_recommendation_report', 'Training recommendations by staff')?></h2>
+    <?php if ($trainingRecommendationReport): ?>
+      <table class="md-table">
+        <thead>
+          <tr>
+            <th><?=t($t, 'training_course', 'Training')?></th>
+            <th><?=t($t, 'recommended_staff_count', 'Recommended staff')?></th>
+            <th><?=t($t, 'staff_members', 'Staff members')?></th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($trainingRecommendationReport as $row): ?>
+            <tr>
+              <td><?=htmlspecialchars($row['course_title'] ?? t($t, 'unknown', 'Unknown'), ENT_QUOTES, 'UTF-8')?></td>
+              <td><?= (int)($row['recommended_staff_count'] ?? 0) ?></td>
+              <td><?=htmlspecialchars((string)($row['recommended_staff'] ?? '—'), ENT_QUOTES, 'UTF-8')?></td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+    <?php else: ?>
+      <p class="md-upgrade-meta"><?=t($t, 'training_recommendation_report_empty', 'No training recommendations have been recorded yet.')?></p>
+    <?php endif; ?>
+  </div>
 
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'department_performance', 'Department Performance')?></h2>


### PR DESCRIPTION
### Motivation
- Provide a planning/coordination view that maps each training/course to the staff who have been recommended that course.
- Surface course → staff mappings directly in the analytics UI so planners can quickly identify demand per course.

### Description
- Added a new dataset query that aggregates `training_recommendation` by course with `COUNT(DISTINCT qr.user_id)` and a `GROUP_CONCAT` of recommended staff (joins `course_catalogue`, `questionnaire_response`, and `users`) and stored results in `$trainingRecommendationReport`.
- Added a new card to `admin/analytics.php` titled “Training recommendations by staff” rendering a table with columns: Training, Recommended staff (count), and Staff members (semicolon-delimited full name + username), and an empty-state message when no recommendations exist.
- All changes are contained in `admin/analytics.php` and the SQL orders courses by number of recommended staff then title.

### Testing
- Ran `php -l admin/analytics.php` to validate syntax; result: success.
- Opened the analytics page via an automated Playwright script and captured a full-page screenshot of the updated analytics view; the script completed and produced the screenshot artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec3a2aea4832db90fa404783b96dd)