### PR TITLE
Add score-band editing and active/inactive controls to course mappings

### DIFF
--- a/admin/course_mappings.php
+++ b/admin/course_mappings.php
@@ -43,6 +43,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $questionnaireIdValue = $questionnaireId > 0 ? $questionnaireId : null;
         $minScore = max(0, min(100, (int)($_POST['min_score'] ?? 0)));
         $maxScore = max(0, min(100, (int)($_POST['max_score'] ?? 100)));
+        $isActive = isset($_POST['is_active']) ? 1 : 0;
 
         if ($code === '' || $title === '') {
             $errors[] = t($t, 'course_mapping_error_required', 'Code and title are required.');
@@ -59,10 +60,31 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         if ($errors === []) {
             $stmt = $pdo->prepare(
-                'INSERT INTO course_catalogue (code, title, moodle_url, recommended_for, questionnaire_id, min_score, max_score) VALUES (?, ?, ?, ?, ?, ?, ?)'
+                'INSERT INTO course_catalogue (code, title, moodle_url, recommended_for, questionnaire_id, min_score, max_score, is_active) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
             );
-            $stmt->execute([$code, $title, $moodleUrl !== '' ? $moodleUrl : null, $recommendedFor, $questionnaireIdValue, $minScore, $maxScore]);
+            $stmt->execute([$code, $title, $moodleUrl !== '' ? $moodleUrl : null, $recommendedFor, $questionnaireIdValue, $minScore, $maxScore, $isActive]);
             $_SESSION['course_mapping_flash'] = t($t, 'course_mapping_saved', 'Course mapping saved.');
+            header('Location: ' . url_for('admin/course_mappings.php'));
+            exit;
+        }
+    }
+
+    if ($action === 'update') {
+        $courseId = (int)($_POST['course_id'] ?? 0);
+        $minScore = max(0, min(100, (int)($_POST['min_score'] ?? 0)));
+        $maxScore = max(0, min(100, (int)($_POST['max_score'] ?? 100)));
+        $isActive = isset($_POST['is_active']) ? 1 : 0;
+
+        if ($courseId <= 0) {
+            $errors[] = t($t, 'course_mapping_error_not_found', 'Select a valid course mapping.');
+        }
+        if ($minScore > $maxScore) {
+            $errors[] = t($t, 'course_mapping_error_score_range', 'Minimum score must be less than or equal to maximum score.');
+        }
+
+        if ($errors === []) {
+            $pdo->prepare('UPDATE course_catalogue SET min_score = ?, max_score = ?, is_active = ? WHERE id = ?')->execute([$minScore, $maxScore, $isActive, $courseId]);
+            $_SESSION['course_mapping_flash'] = t($t, 'course_mapping_updated', 'Course mapping updated.');
             header('Location: ' . url_for('admin/course_mappings.php'));
             exit;
         }
@@ -80,7 +102,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 $listStmt = $pdo->query(
-    'SELECT id, code, title, moodle_url, recommended_for, questionnaire_id, min_score, max_score '
+    'SELECT id, code, title, moodle_url, recommended_for, questionnaire_id, min_score, max_score, is_active '
     . 'FROM course_catalogue ORDER BY recommended_for, questionnaire_id IS NULL, questionnaire_id, min_score, title'
 );
 $mappings = $listStmt ? $listStmt->fetchAll(PDO::FETCH_ASSOC) : [];
@@ -139,6 +161,9 @@ $drawerKey = 'admin.course_mappings';
       <label><?=t($t, 'max_score', 'Maximum Score')?>
         <input class="md-input" type="number" name="max_score" min="0" max="100" value="100" required>
       </label>
+      <label class="md-check">
+        <input type="checkbox" name="is_active" value="1" checked> <?=t($t, 'active', 'Active')?>
+      </label>
       <button type="submit" class="md-button"><?=t($t, 'save', 'Save')?></button>
     </form>
   </div>
@@ -146,7 +171,7 @@ $drawerKey = 'admin.course_mappings';
   <div class="md-card md-elev-2">
     <h3 class="md-card-title"><?=t($t, 'configured_course_mappings', 'Configured Mappings')?></h3>
     <table class="md-table">
-      <thead><tr><th><?=t($t, 'course_code', 'Course Code')?></th><th><?=t($t, 'course', 'Course')?></th><th><?=t($t, 'work_function', 'Work Function')?></th><th><?=t($t, 'questionnaire', 'Questionnaire')?></th><th><?=t($t, 'score_band', 'Score Band')?></th><th><?=t($t, 'moodle_url', 'Moodle URL')?></th><th><?=t($t, 'actions', 'Actions')?></th></tr></thead>
+      <thead><tr><th><?=t($t, 'course_code', 'Course Code')?></th><th><?=t($t, 'course', 'Course')?></th><th><?=t($t, 'work_function', 'Work Function')?></th><th><?=t($t, 'questionnaire', 'Questionnaire')?></th><th><?=t($t, 'score_band', 'Score Band')?></th><th><?=t($t, 'status', 'Status')?></th><th><?=t($t, 'moodle_url', 'Moodle URL')?></th><th><?=t($t, 'actions', 'Actions')?></th></tr></thead>
       <tbody>
       <?php foreach ($mappings as $row): ?>
         <?php $rowQuestionnaireId = (int)($row['questionnaire_id'] ?? 0); ?>
@@ -155,10 +180,23 @@ $drawerKey = 'admin.course_mappings';
           <td><?=htmlspecialchars((string)$row['title'])?></td>
           <td><?=htmlspecialchars((string)($workFunctions[(string)$row['recommended_for']] ?? $row['recommended_for']))?></td>
           <td><?=htmlspecialchars($rowQuestionnaireId > 0 ? ($questionnaireOptions[$rowQuestionnaireId] ?? ('#' . $rowQuestionnaireId)) : t($t, 'all_questionnaires', 'All Questionnaires'), ENT_QUOTES, 'UTF-8')?></td>
-          <td><?= (int)$row['min_score'] ?> - <?= (int)$row['max_score'] ?>%</td>
+          <td>
+            <form method="post" class="md-form-inline">
+              <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+              <input type="hidden" name="action" value="update">
+              <input type="hidden" name="course_id" value="<?= (int)$row['id'] ?>">
+              <input class="md-input" style="width:70px" type="number" name="min_score" min="0" max="100" value="<?= (int)$row['min_score'] ?>" required>
+              -
+              <input class="md-input" style="width:70px" type="number" name="max_score" min="0" max="100" value="<?= (int)$row['max_score'] ?>" required>%
+          </td>
+          <td>
+              <label class="md-check"><input type="checkbox" name="is_active" value="1" <?=((int)($row['is_active'] ?? 1) === 1 ? 'checked' : '')?>> <?=((int)($row['is_active'] ?? 1) === 1 ? t($t, 'active', 'Active') : t($t, 'inactive', 'Inactive'))?></label>
+          </td>
           <td><?php if (!empty($row['moodle_url'])): ?><a href="<?=htmlspecialchars((string)$row['moodle_url'])?>" target="_blank" rel="noopener"><?=htmlspecialchars((string)$row['moodle_url'])?></a><?php else: ?>—<?php endif; ?></td>
           <td>
-            <form method="post" onsubmit="return confirm('<?=htmlspecialchars(t($t, 'confirm_delete_mapping', 'Delete this mapping?'), ENT_QUOTES, 'UTF-8')?>');">
+              <button type="submit" class="md-button md-outline"><?=t($t, 'save', 'Save')?></button>
+            </form>
+            <form method="post" onsubmit="return confirm('<?=htmlspecialchars(t($t, 'confirm_delete_mapping', 'Delete this mapping?'), ENT_QUOTES, 'UTF-8')?>');" style="margin-top:8px;">
               <input type="hidden" name="csrf" value="<?=csrf_token()?>">
               <input type="hidden" name="action" value="delete">
               <input type="hidden" name="course_id" value="<?= (int)$row['id'] ?>">

--- a/lib/course_recommendations.php
+++ b/lib/course_recommendations.php
@@ -21,6 +21,7 @@ function ensure_course_recommendation_schema(PDO $pdo): void
                 . 'questionnaire_id INTEGER NULL, '
                 . 'min_score INTEGER NOT NULL DEFAULT 0, '
                 . 'max_score INTEGER NOT NULL DEFAULT 100, '
+                . 'is_active INTEGER NOT NULL DEFAULT 1, '
                 . 'created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP'
                 . ')');
             $pdo->exec('CREATE TABLE IF NOT EXISTS training_recommendation ('
@@ -32,6 +33,11 @@ function ensure_course_recommendation_schema(PDO $pdo): void
                 . ')');
             try {
                 $pdo->exec('ALTER TABLE course_catalogue ADD COLUMN questionnaire_id INTEGER NULL');
+            } catch (Throwable $e) {
+                // Ignore duplicate-column errors.
+            }
+            try {
+                $pdo->exec('ALTER TABLE course_catalogue ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1');
             } catch (Throwable $e) {
                 // Ignore duplicate-column errors.
             }
@@ -47,6 +53,7 @@ function ensure_course_recommendation_schema(PDO $pdo): void
             . 'questionnaire_id INT NULL, '
             . 'min_score INT NOT NULL DEFAULT 0, '
             . 'max_score INT NOT NULL DEFAULT 100, '
+            . 'is_active TINYINT(1) NOT NULL DEFAULT 1, '
             . 'created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, '
             . 'INDEX idx_course_catalogue_match (recommended_for, questionnaire_id, min_score, max_score)'
             . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
@@ -59,6 +66,11 @@ function ensure_course_recommendation_schema(PDO $pdo): void
             $pdo->exec('CREATE INDEX idx_course_catalogue_match ON course_catalogue (recommended_for, questionnaire_id, min_score, max_score)');
         } catch (Throwable $e) {
             // Ignore duplicate index errors.
+        }
+        try {
+            $pdo->exec('ALTER TABLE course_catalogue ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1 AFTER max_score');
+        } catch (Throwable $e) {
+            // Ignore duplicate-column errors.
         }
 
         $pdo->exec('CREATE TABLE IF NOT EXISTS training_recommendation ('
@@ -85,7 +97,7 @@ function find_course_matches(PDO $pdo, string $workFunction, int $score, ?int $q
             $stmt = $pdo->prepare(
                 'SELECT id, code, title, moodle_url, recommended_for, questionnaire_id, min_score, max_score '
                 . 'FROM course_catalogue '
-                . 'WHERE recommended_for = ? AND min_score <= ? AND max_score >= ? '
+                . 'WHERE recommended_for = ? AND min_score <= ? AND max_score >= ? AND is_active = 1 '
                 . 'AND (questionnaire_id = ? OR questionnaire_id IS NULL) '
                 . 'ORDER BY questionnaire_id IS NULL ASC, min_score ASC, title ASC'
             );
@@ -97,7 +109,7 @@ function find_course_matches(PDO $pdo, string $workFunction, int $score, ?int $q
         $stmt = $pdo->prepare(
             'SELECT id, code, title, moodle_url, recommended_for, questionnaire_id, min_score, max_score '
             . 'FROM course_catalogue '
-            . 'WHERE recommended_for = ? AND min_score <= ? AND max_score >= ? '
+            . 'WHERE recommended_for = ? AND min_score <= ? AND max_score >= ? AND is_active = 1 '
             . 'AND questionnaire_id IS NULL '
             . 'ORDER BY min_score ASC, title ASC'
         );


### PR DESCRIPTION
### Motivation
- Allow administrators to control which course mappings participate in recommendations and to adjust score bands after creation. 

### Description
- Add `is_active` column to the `course_catalogue` schema for both SQLite and MySQL and include safe `ALTER TABLE` fallbacks to avoid migration failures. 
- Update `find_course_matches()` to filter out inactive mappings by requiring `is_active = 1` in queries. 
- Extend `admin/course_mappings.php` create flow to persist an `is_active` checkbox and include `is_active` in the `INSERT` statement. 
- Add an `update` action and inline editing UI so admins can edit `min_score`/`max_score` and toggle Active/Inactive for existing mappings from the configured mappings table.

### Testing
- Ran syntax checks with `php -l admin/course_mappings.php` and `php -l lib/course_recommendations.php`, both succeeded. 
- Executed an automated Playwright capture of the admin page which completed and produced a screenshot artifact, but an HTTP request to the local PHP server (`curl`) returned a `500` due to a database connection refusal in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec356712c832d98f71f37769b85f8)