### PR TITLE
Admin toggle for demo dataset + SQL helpers and cleanup scripts

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -2,6 +2,98 @@
 $fatalError = null;
 $fatalDebugDetails = null;
 
+
+if (!function_exists('settings_sanitize_sql')) {
+    function settings_sanitize_sql(string $sql): string
+    {
+        $sql = preg_replace('/\/\*.*?\*\//s', '', $sql) ?? $sql;
+        $lines = preg_split('/\r\n|\r|\n/', $sql) ?: [];
+        $clean = [];
+        foreach ($lines as $line) {
+            $trimmed = ltrim($line);
+            if (str_starts_with($trimmed, '--') || str_starts_with($trimmed, '#')) {
+                continue;
+            }
+            $clean[] = $line;
+        }
+        return implode("\n", $clean);
+    }
+}
+
+if (!function_exists('settings_split_sql_statements')) {
+    function settings_split_sql_statements(string $sql): array
+    {
+        $statements = [];
+        $buffer = '';
+        $inString = false;
+        $stringChar = '';
+        $len = strlen($sql);
+
+        for ($i = 0; $i < $len; $i++) {
+            $char = $sql[$i];
+            if ($inString) {
+                if ($char === $stringChar) {
+                    $escaped = $i > 0 && $sql[$i - 1] === '\\';
+                    if (!$escaped) {
+                        $inString = false;
+                        $stringChar = '';
+                    }
+                }
+                $buffer .= $char;
+                continue;
+            }
+
+            if ($char === '\'' || $char === '"') {
+                $inString = true;
+                $stringChar = $char;
+                $buffer .= $char;
+                continue;
+            }
+
+            if ($char === ';') {
+                $trimmed = trim($buffer);
+                if ($trimmed !== '') {
+                    $statements[] = $trimmed;
+                }
+                $buffer = '';
+                continue;
+            }
+
+            $buffer .= $char;
+        }
+
+        $trimmed = trim($buffer);
+        if ($trimmed !== '') {
+            $statements[] = $trimmed;
+        }
+
+        return $statements;
+    }
+}
+
+if (!function_exists('settings_apply_sql_file')) {
+    function settings_apply_sql_file(PDO $pdo, string $path): int
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            throw new RuntimeException('SQL seed file not found: ' . $path);
+        }
+
+        $sql = file_get_contents($path);
+        if ($sql === false) {
+            throw new RuntimeException('Unable to read SQL seed file: ' . $path);
+        }
+
+        $statements = settings_split_sql_statements(settings_sanitize_sql($sql));
+        $count = 0;
+        foreach ($statements as $statement) {
+            $pdo->exec($statement);
+            $count++;
+        }
+
+        return $count;
+    }
+}
+
 try {
     require_once __DIR__ . '/../config.php';
     auth_required(['admin']);
@@ -37,6 +129,28 @@ try {
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         csrf_check();
 
+        $demoDatasetAction = trim((string)($_POST['demo_dataset_action'] ?? ''));
+        if (in_array($demoDatasetAction, ['enable', 'disable'], true)) {
+            try {
+                $pdo->beginTransaction();
+                if ($demoDatasetAction === 'enable') {
+                    $executed = settings_apply_sql_file($pdo, __DIR__ . '/../dummy_data.sql');
+                    $msg = t($t, 'demo_dataset_enabled', 'Demo dataset has been enabled.') . ' ' . sprintf(t($t, 'demo_dataset_statements_executed', '%d SQL statements executed.'), $executed);
+                } else {
+                    $executed = settings_apply_sql_file($pdo, __DIR__ . '/../dummy_data_cleanup.sql');
+                    $msg = t($t, 'demo_dataset_disabled', 'Demo dataset has been disabled and cleaned up.') . ' ' . sprintf(t($t, 'demo_dataset_statements_executed', '%d SQL statements executed.'), $executed);
+                }
+                $pdo->commit();
+            } catch (Throwable $datasetException) {
+                if ($pdo->inTransaction()) {
+                    $pdo->rollBack();
+                }
+                $errors[] = t($t, 'demo_dataset_toggle_failed', 'Unable to toggle demo dataset right now.') . ' ' . $datasetException->getMessage();
+            }
+            $cfg = get_site_config($pdo);
+            $enabledLocales = site_enabled_locales($cfg);
+            $emailTemplates = normalize_email_templates($cfg['email_templates'] ?? []);
+        } else {
         $review_enabled = isset($_POST['review_enabled']) ? 1 : 0;
         $local_login_enabled = isset($_POST['local_login_enabled']) ? 1 : 0;
         $google_oauth_enabled = isset($_POST['google_oauth_enabled']) ? 1 : 0;
@@ -178,6 +292,7 @@ try {
         }
         if ($errors !== []) {
             $enabledLocales = $selectedLocales;
+        }
         }
     }
 } catch (Throwable $e) {
@@ -333,6 +448,15 @@ $pageHelpKey = 'admin.settings';
           <label class="md-field md-field-textarea"><span><?=t($t,'email_html_body','HTML Body')?></span><textarea name="email_templates[<?=$key?>][html]" rows="8"><?=htmlspecialchars($emailTemplates[$key]['html'] ?? '')?></textarea></label>
         </div>
       <?php endforeach; ?>
+      <h3 class="md-subhead">
+        <?=t($t,'demo_dataset_heading','Demo Dataset')?>
+        <?=render_help_icon(t($t,'demo_dataset_hint','Load sample users, assessments, analytics history, and training recommendations for demonstrations. Disable to remove the seeded demo records.'))?>
+      </h3>
+      <p class="md-help-note"><?=t($t,'demo_dataset_note','These actions only affect records created by the demo seed files (demo_* users and EPSA-* training mappings).')?></p>
+      <div class="md-form-actions" style="justify-content:flex-start; gap:10px;">
+        <button class="md-button md-secondary" type="submit" name="demo_dataset_action" value="enable"><?=t($t,'demo_dataset_enable','Enable Demo Dataset')?></button>
+        <button class="md-button" type="submit" name="demo_dataset_action" value="disable"><?=t($t,'demo_dataset_disable','Disable Demo Dataset')?></button>
+      </div>
       <div class="md-form-actions">
         <button class="md-button md-primary md-elev-2"><?=t($t,'save','Save Changes')?></button>
       </div>

--- a/docs/dummy-data-seeding.md
+++ b/docs/dummy-data-seeding.md
@@ -29,3 +29,11 @@ Before running, ensure your `.env` has valid `DB_HOST`, `DB_PORT`, `DB_NAME`, `D
 ## Cleanup
 
 Use `dummy_data_cleanup.sql` to remove seeded dummy-user submissions when needed.
+
+
+## Admin toggle
+
+Administrators can now enable or disable the full demo dataset directly from **Admin → Settings**:
+
+- **Enable Demo Dataset** executes `dummy_data.sql` (full demo users, questionnaires, responses, analytics history, and training recommendation mappings).
+- **Disable Demo Dataset** executes `dummy_data_cleanup.sql` (removes demo records and EPSA demo course mappings).

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -586,7 +586,7 @@ INSERT INTO analytics_report_schedule (recipients, frequency, next_run_at, last_
 VALUES
 ('demo.people.lead@example.com,demo.supply.lead@example.com', 'weekly', DATE_ADD(NOW(), INTERVAL 3 DAY), DATE_SUB(NOW(), INTERVAL 4 DAY), @demo_admin_id, @demo_qid, 1, 1),
 ('executive.board@example.com', 'monthly', DATE_ADD(NOW(), INTERVAL 12 DAY), DATE_SUB(NOW(), INTERVAL 26 DAY), @demo_admin_id, @demo_qid, 0, 1),
-('regional.leads@example.com', 'quarterly', DATE_ADD(NOW(), INTERVAL 35 DAY), DATE_SUB(NOW(), INTERVAL 96 DAY), @demo_admin_id, @demo_qid, 1, 1);
+('regional.leads@example.com', 'monthly', DATE_ADD(NOW(), INTERVAL 35 DAY), DATE_SUB(NOW(), INTERVAL 96 DAY), @demo_admin_id, @demo_qid, 1, 1);
 
 -- Additional logs capturing submission activities --------------------------------
 INSERT INTO logs (user_id, action, meta)

--- a/dummy_data_cleanup.sql
+++ b/dummy_data_cleanup.sql
@@ -1,3 +1,48 @@
--- dummy_data_cleanup.sql: remove seeded demo users and their submissions
-DELETE qr FROM questionnaire_response qr JOIN users u ON u.id = qr.user_id WHERE u.username LIKE 'demo_%';
+-- dummy_data_cleanup.sql: remove seeded demo dataset records
+DROP TEMPORARY TABLE IF EXISTS tmp_demo_questionnaires;
+CREATE TEMPORARY TABLE tmp_demo_questionnaires (id INT PRIMARY KEY) ENGINE=Memory;
+INSERT INTO tmp_demo_questionnaires (id)
+SELECT id
+FROM questionnaire
+WHERE title IN ('EPSA Annual Performance Review 360', 'EPSA Leadership Confidence Pulse');
+
+DELETE tr
+FROM training_recommendation tr
+JOIN questionnaire_response qr ON qr.id = tr.questionnaire_response_id
+JOIN users u ON u.id = qr.user_id
+WHERE u.username LIKE 'demo_%';
+
+DELETE qri
+FROM questionnaire_response_item qri
+JOIN questionnaire_response qr ON qr.id = qri.response_id
+JOIN users u ON u.id = qr.user_id
+WHERE u.username LIKE 'demo_%';
+
+DELETE FROM questionnaire_response
+WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires)
+   OR user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
+DELETE FROM questionnaire_assignment
+WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires)
+   OR staff_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
+DELETE FROM questionnaire_work_function WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
+
+DELETE qio
+FROM questionnaire_item_option qio
+JOIN questionnaire_item qi ON qi.id = qio.questionnaire_item_id
+WHERE qi.questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
+
+DELETE FROM questionnaire_item WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
+DELETE FROM questionnaire_section WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
+DELETE FROM questionnaire WHERE id IN (SELECT id FROM tmp_demo_questionnaires);
+DROP TEMPORARY TABLE IF EXISTS tmp_demo_questionnaires;
+
+DELETE FROM analytics_report_schedule
+WHERE created_by IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
+DELETE FROM logs WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+
+DELETE FROM course_catalogue WHERE code LIKE 'EPSA-%';
+
 DELETE FROM users WHERE username LIKE 'demo_%';


### PR DESCRIPTION
### Motivation

- Provide administrators an easy way to seed and remove a realistic demo dataset from the Admin → Settings UI for demonstrations and testing.
- Ensure SQL seed/cleanup files can be parsed and executed safely from PHP by handling comments, string literals, and statement boundaries.
- Improve the demo cleanup to remove seeded questionnaires, responses, training mappings, logs, analytics schedules, and EPSA course catalogue entries introduced by the demo seed.

### Description

- Added SQL helper functions `settings_sanitize_sql`, `settings_split_sql_statements`, and `settings_apply_sql_file` to `admin/settings.php` to strip comments, split statements safely, and execute SQL seed/cleanup files via a `PDO` instance.
- Implemented POST handling in `admin/settings.php` for `demo_dataset_action` with transactional execution of `dummy_data.sql` (enable) and `dummy_data_cleanup.sql` (disable), including success/error messaging and rollback on failure.
- Added UI elements and help text to the Settings page to let admins `Enable Demo Dataset` or `Disable Demo Dataset` and updated `docs/dummy-data-seeding.md` to document the new admin toggle option.
- Updated `dummy_data_cleanup.sql` to perform a comprehensive removal of demo-related data (questionnaires, items, responses, assignments, training recommendations, logs, analytics schedules, EPSA course entries, and demo users) and adjusted a minor schedule frequency value in `dummy_data.sql`.

### Testing

- Ran PHP syntax checks with `php -l` on modified PHP files and there were no syntax errors.
- Performed a local smoke test by applying `dummy_data.sql` and then `dummy_data_cleanup.sql` against a disposable test database to confirm the seed and cleanup statements execute and remove demo records successfully.
- No new unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b05aaef554832d84e32d78134333db)