### PR TITLE
Remove top bar online/offline status control

### DIFF
--- a/templates/header.php
+++ b/templates/header.php
@@ -119,23 +119,6 @@ if ($profileInitials === '') {
   <div class="md-appbar-actions">
     <button
       type="button"
-      class="md-appbar-link md-appbar-theme-toggle md-appbar-connectivity md-status-indicator"
-      data-status-indicator
-      data-online-text="<?=htmlspecialchars(t($t, 'status_online', 'Online'), ENT_QUOTES, 'UTF-8')?>"
-      data-offline-text="<?=htmlspecialchars(t($t, 'status_offline', 'Offline'), ENT_QUOTES, 'UTF-8')?>"
-      role="switch"
-      aria-live="polite"
-      aria-atomic="true"
-      aria-checked="true"
-      data-status="online"
-      aria-label="<?=htmlspecialchars(t($t, 'toggle_offline_mode', 'Toggle offline mode'), ENT_QUOTES, 'UTF-8')?>"
-      title="<?=htmlspecialchars(t($t, 'toggle_offline_mode', 'Toggle offline mode'), ENT_QUOTES, 'UTF-8')?>"
-    >
-      <span class="md-status-dot" aria-hidden="true"></span>
-      <span class="md-status-label visually-hidden"><?=htmlspecialchars(t($t, 'status_online', 'Online'), ENT_QUOTES, 'UTF-8')?></span>
-    </button>
-    <button
-      type="button"
       class="md-appbar-link md-appbar-theme-toggle"
       data-theme-toggle
       aria-label="<?=htmlspecialchars(t($t, 'theme_switch_to_dark', 'Switch to dark theme'), ENT_QUOTES, 'UTF-8')?>"
@@ -279,46 +262,6 @@ if ($profileInitials === '') {
     window.AppConnectivity = globalConnectivity;
 
     var onReady = function () {
-      var indicator = document.querySelector('[data-status-indicator]');
-      if (indicator) {
-        var label = indicator.querySelector('.md-status-label');
-        var onlineText = indicator.getAttribute('data-online-text') || 'Online';
-        var offlineText = indicator.getAttribute('data-offline-text') || 'Offline';
-
-        var applyState = function (state) {
-          var isOnline = state && typeof state.online === 'boolean' ? state.online : globalConnectivity.isOnline();
-          var forced = state && typeof state.forcedOffline === 'boolean' ? state.forcedOffline : globalConnectivity.isForcedOffline();
-          indicator.classList.toggle('is-offline', !isOnline);
-          indicator.setAttribute('data-status', isOnline ? 'online' : 'offline');
-          indicator.setAttribute('aria-checked', isOnline ? 'true' : 'false');
-          if (forced) {
-            indicator.setAttribute('data-mode', 'manual');
-          } else {
-            indicator.removeAttribute('data-mode');
-          }
-          if (label) {
-            label.textContent = isOnline ? onlineText : offlineText;
-          }
-        };
-
-        if (globalConnectivity && typeof globalConnectivity.subscribe === 'function') {
-          globalConnectivity.subscribe(applyState);
-        } else {
-          var updateStatus = function () {
-            applyState({ online: navigator.onLine, forcedOffline: false });
-          };
-          window.addEventListener('online', updateStatus);
-          window.addEventListener('offline', updateStatus);
-          updateStatus();
-        }
-
-        indicator.addEventListener('click', function () {
-          if (globalConnectivity && typeof globalConnectivity.toggleForcedOffline === 'function') {
-            globalConnectivity.toggleForcedOffline();
-          }
-        });
-      }
-
       var reloadButton = document.getElementById('appbar-reload-btn');
       if (reloadButton) {
         var performReload = function () {


### PR DESCRIPTION
### Motivation
- The top-bar online/offline status toggle was removed to simplify the header UI and avoid exposing a manual connectivity toggle in the app bar.

### Description
- Deleted the online/offline status button markup and its `data-status-indicator` attributes from `templates/header.php`.
- Removed the inline initialization/subscription and click-handler code that updated the status indicator, while keeping the global `window.AppConnectivity` API intact for other consumers.
- Kept theme, language, profile, and logout controls unchanged.

### Testing
- Ran `php -l templates/header.php` and it reported no syntax errors (success).
- Launched the local PHP dev server to smoke-test rendering; the server started but requests returned HTTP 500 due to missing DB configuration in the environment (observed during validation).
- Executed a Playwright script to capture a screenshot of the header after the change and produced an artifact showing the status button is no longer present (screenshot captured despite the page returning a DB-related 500 error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b821f6d164832daddfa6a4a7dcb60c)