### PR TITLE
Add search filters to department, team, and work role catalogs

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -281,6 +281,10 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
   .md-filter-row { display: flex; gap: .4rem; margin: .35rem 0 .9rem; flex-wrap: wrap; }
   .md-filter-chip { padding: .3rem .65rem; border: 1px solid rgba(0,0,0,.2); border-radius: 999px; text-decoration: none; color: inherit; font-size: .86rem; }
   .md-filter-chip.is-active { background: #1f6feb; color: #fff; border-color: #1f6feb; }
+  .md-search-block { margin-bottom: .8rem; }
+  .md-search-block .md-field { margin: 0; max-width: 360px; }
+  .md-search-empty { display: none; margin: .4rem 0 0; color: #6b7280; font-size: .9rem; }
+  .md-search-empty.is-visible { display: block; }
 </style>
 </head><body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
 <?php include __DIR__ . '/../templates/header.php'; ?>
@@ -304,9 +308,13 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </summary>
       <div class="md-defaults-group-body">
         <form method="post" class="md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="mode" value="department_add"><label class="md-field"><span><?=t($t,'department','Department')?></span><input name="label" required></label><button type="submit" class="md-button md-primary"><?=t($t,'create','Create')?></button></form>
+        <div class="md-search-block">
+          <label class="md-field"><span><?=htmlspecialchars(t($t, 'search_catalog', 'Search this list'), ENT_QUOTES, 'UTF-8')?></span><input type="search" class="js-catalog-search" data-target="department" placeholder="<?=htmlspecialchars(t($t, 'search_department_placeholder', 'Search departments'), ENT_QUOTES, 'UTF-8')?>"></label>
+        </div>
         <?php foreach ($departments as $slug => $record): if (!$matchesStatusFilter($record['archived_at'] ?? null)) continue; ?>
-          <form method="post" class="md-work-function-row md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'department','Department')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="department_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="<?=($record['archived_at'] ?? null) === null ? 'department_archive' : 'department_activate'?>"><?=($record['archived_at'] ?? null) === null ? t($t,'archive','Archive') : t($t,'save','Activate')?></button></form>
+          <form method="post" class="md-work-function-row md-compact-actions" data-search-group="department" data-search-text="<?=htmlspecialchars(strtolower(trim($slug . ' ' . (string)($record['label'] ?? ''))), ENT_QUOTES, 'UTF-8')?>"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'department','Department')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="department_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="<?=($record['archived_at'] ?? null) === null ? 'department_archive' : 'department_activate'?>"><?=($record['archived_at'] ?? null) === null ? t($t,'archive','Archive') : t($t,'save','Activate')?></button></form>
         <?php endforeach; ?>
+        <p class="md-search-empty" data-search-empty="department"><?=htmlspecialchars(t($t, 'search_no_results', 'No matching items found.'), ENT_QUOTES, 'UTF-8')?></p>
       </div>
     </details>
 
@@ -317,9 +325,13 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </summary>
       <div class="md-defaults-group-body">
         <form method="post" class="md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="mode" value="team_add"><label class="md-field"><span><?=t($t,'department','Department')?></span><select name="department_slug" required><?php foreach ($departmentOptions as $depSlug => $depLabel): ?><option value="<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>"><?=htmlspecialchars($depLabel, ENT_QUOTES, 'UTF-8')?></option><?php endforeach; ?></select></label><label class="md-field"><span><?=t($t,'team_catalog_label','Team name')?></span><input name="label" required></label><button type="submit" class="md-button md-primary"><?=t($t,'team_catalog_add','Add team')?></button></form>
+        <div class="md-search-block">
+          <label class="md-field"><span><?=htmlspecialchars(t($t, 'search_catalog', 'Search this list'), ENT_QUOTES, 'UTF-8')?></span><input type="search" class="js-catalog-search" data-target="team" placeholder="<?=htmlspecialchars(t($t, 'search_team_placeholder', 'Search teams'), ENT_QUOTES, 'UTF-8')?>"></label>
+        </div>
         <?php foreach ($teams as $slug => $record): if (!$matchesStatusFilter($record['archived_at'] ?? null)) continue; ?>
-          <form method="post" class="md-work-function-row md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'department','Department')?></span><select name="department_slug" required><?php foreach ($departmentOptions as $depSlug => $depLabel): ?><option value="<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>" <?=$depSlug===($record['department_slug'] ?? '')?'selected':''?>><?=htmlspecialchars($depLabel, ENT_QUOTES, 'UTF-8')?></option><?php endforeach; ?></select></label><label class="md-field"><span><?=t($t,'team_catalog_label','Team name')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="team_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="<?=($record['archived_at'] ?? null) === null ? 'team_archive' : 'team_activate'?>"><?=($record['archived_at'] ?? null) === null ? t($t,'archive','Archive') : t($t,'save','Activate')?></button></form>
+          <form method="post" class="md-work-function-row md-compact-actions" data-search-group="team" data-search-text="<?=htmlspecialchars(strtolower(trim($slug . ' ' . (string)($record['label'] ?? '') . ' ' . (string)($departmentOptions[$record['department_slug'] ?? ''] ?? ''))), ENT_QUOTES, 'UTF-8')?>"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'department','Department')?></span><select name="department_slug" required><?php foreach ($departmentOptions as $depSlug => $depLabel): ?><option value="<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>" <?=$depSlug===($record['department_slug'] ?? '')?'selected':''?>><?=htmlspecialchars($depLabel, ENT_QUOTES, 'UTF-8')?></option><?php endforeach; ?></select></label><label class="md-field"><span><?=t($t,'team_catalog_label','Team name')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="team_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="<?=($record['archived_at'] ?? null) === null ? 'team_archive' : 'team_activate'?>"><?=($record['archived_at'] ?? null) === null ? t($t,'archive','Archive') : t($t,'save','Activate')?></button></form>
         <?php endforeach; ?>
+        <p class="md-search-empty" data-search-empty="team"><?=htmlspecialchars(t($t, 'search_no_results', 'No matching items found.'), ENT_QUOTES, 'UTF-8')?></p>
       </div>
     </details>
 
@@ -329,9 +341,13 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeWorkRoleCount : ($statusFilter === 'inactive' ? ($totalWorkRoleCount - $activeWorkRoleCount) : $totalWorkRoleCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
       </summary>
       <div class="md-defaults-group-body">
+        <div class="md-search-block">
+          <label class="md-field"><span><?=htmlspecialchars(t($t, 'search_catalog', 'Search this list'), ENT_QUOTES, 'UTF-8')?></span><input type="search" class="js-catalog-search" data-target="role" placeholder="<?=htmlspecialchars(t($t, 'search_work_role_placeholder', 'Search work roles'), ENT_QUOTES, 'UTF-8')?>"></label>
+        </div>
         <?php foreach ($workRoles as $slug => $record): if (!$matchesStatusFilter($record['archived_at'] ?? null)) continue; ?>
-          <form method="post" class="md-work-function-row md-compact-actions"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'work_function_label_name','Work function name')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="role_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="<?=($record['archived_at'] ?? null) === null ? 'role_archive' : 'role_activate'?>" <?=($record['archived_at'] ?? null) === null ? "onclick=\"return confirm('<?=htmlspecialchars(t($t,'work_function_archive_confirm','Archive this work function? Existing assignments will be removed.'), ENT_QUOTES, 'UTF-8')?>');\"" : ''?>><?=($record['archived_at'] ?? null) === null ? t($t,'work_function_archive','Archive') : t($t,'save','Activate')?></button></form>
+          <form method="post" class="md-work-function-row md-compact-actions" data-search-group="role" data-search-text="<?=htmlspecialchars(strtolower(trim($slug . ' ' . (string)($record['label'] ?? ''))), ENT_QUOTES, 'UTF-8')?>"><input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="slug" value="<?=htmlspecialchars($slug, ENT_QUOTES, 'UTF-8')?>"><label class="md-field"><span><?=t($t,'work_function_label_name','Work function name')?></span><input name="label" value="<?=htmlspecialchars((string)($record['label'] ?? ''), ENT_QUOTES, 'UTF-8')?>"></label><button type="submit" class="md-button md-primary" name="mode" value="role_update"><?=t($t,'save','Save Changes')?></button><button type="submit" class="md-button md-outline" name="mode" value="<?=($record['archived_at'] ?? null) === null ? 'role_archive' : 'role_activate'?>" <?=($record['archived_at'] ?? null) === null ? "onclick=\"return confirm('<?=htmlspecialchars(t($t,'work_function_archive_confirm','Archive this work function? Existing assignments will be removed.'), ENT_QUOTES, 'UTF-8')?>');\"" : ''?>><?=($record['archived_at'] ?? null) === null ? t($t,'work_function_archive','Archive') : t($t,'save','Activate')?></button></form>
         <?php endforeach; ?>
+        <p class="md-search-empty" data-search-empty="role"><?=htmlspecialchars(t($t, 'search_no_results', 'No matching items found.'), ENT_QUOTES, 'UTF-8')?></p>
       </div>
     </details>
 
@@ -360,4 +376,29 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
   </div>
 </section>
 <?php include __DIR__ . '/../templates/footer.php'; ?>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var searchInputs = document.querySelectorAll('.js-catalog-search');
+    searchInputs.forEach(function (input) {
+      input.addEventListener('input', function () {
+        var group = input.getAttribute('data-target');
+        var query = (input.value || '').toLowerCase().trim();
+        var rows = document.querySelectorAll('[data-search-group="' + group + '"]');
+        var matchCount = 0;
+        rows.forEach(function (row) {
+          var haystack = (row.getAttribute('data-search-text') || '').toLowerCase();
+          var isMatch = query === '' || haystack.indexOf(query) !== -1;
+          row.style.display = isMatch ? '' : 'none';
+          if (isMatch) {
+            matchCount += 1;
+          }
+        });
+        var emptyState = document.querySelector('[data-search-empty="' + group + '"]');
+        if (emptyState) {
+          emptyState.classList.toggle('is-visible', matchCount === 0);
+        }
+      });
+    });
+  });
+</script>
 </body></html>

--- a/lang/am.json
+++ b/lang/am.json
@@ -746,5 +746,10 @@
   "your_trend": "የእርስዎ አዝማሚያ",
   "password_policy_invalid": "የይለፍ ቃል ቢያንስ 8 ቁምፊዎች እና ቢያንስ አንድ ቁጥር ወይም ምልክት ሊኖረው ይገባል።",
   "password_policy_title": "የይለፍ ቃል መስፈርቶች አልተሟሉም",
-  "password_policy_body": "ቢያንስ 8 ቁምፊዎች ይጠቀሙ እና ቢያንስ አንድ ቁጥር ወይም ምልክት ያካትቱ።"
+  "password_policy_body": "ቢያንስ 8 ቁምፊዎች ይጠቀሙ እና ቢያንስ አንድ ቁጥር ወይም ምልክት ያካትቱ።",
+  "search_catalog": "በዚህ ዝርዝር ውስጥ ፈልግ",
+  "search_department_placeholder": "መምሪያዎችን ፈልግ",
+  "search_team_placeholder": "ቡድኖችን ፈልግ",
+  "search_work_role_placeholder": "የስራ ሚናዎችን ፈልግ",
+  "search_no_results": "ተመሳሳይ ውጤት አልተገኘም።"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -769,5 +769,10 @@
   "invalid_department": "Select a valid department.",
   "password_policy_invalid": "Password must be at least 8 characters and include at least one number or symbol.",
   "password_policy_title": "Password requirements not met",
-  "password_policy_body": "Use at least 8 characters and include at least one number or symbol."
+  "password_policy_body": "Use at least 8 characters and include at least one number or symbol.",
+  "search_catalog": "Search this list",
+  "search_department_placeholder": "Search departments",
+  "search_team_placeholder": "Search teams",
+  "search_work_role_placeholder": "Search work roles",
+  "search_no_results": "No matching items found."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -746,5 +746,10 @@
   "your_trend": "Votre tendance",
   "password_policy_invalid": "Le mot de passe doit contenir au moins 8 caractères et inclure au moins un chiffre ou symbole.",
   "password_policy_title": "Exigences du mot de passe non respectées",
-  "password_policy_body": "Utilisez au moins 8 caractères et incluez au moins un chiffre ou symbole."
+  "password_policy_body": "Utilisez au moins 8 caractères et incluez au moins un chiffre ou symbole.",
+  "search_catalog": "Rechercher dans cette liste",
+  "search_department_placeholder": "Rechercher des départements",
+  "search_team_placeholder": "Rechercher des équipes",
+  "search_work_role_placeholder": "Rechercher des rôles de travail",
+  "search_no_results": "Aucun élément correspondant trouvé."
 }


### PR DESCRIPTION
### Motivation
- Improve manageability of the Department / Teams / Work Roles lists on the Work Function Defaults admin page by enabling quick, per-section filtering without a page reload. 

### Description
- Added a small search UI and CSS (`.md-search-block`, `.md-search-empty`) and per-section search inputs to `admin/work_function_defaults.php` to allow users to search Departments, Teams, and Work Roles independently. 
- Tagged each catalog row with `data-search-group` and `data-search-text` attributes so client-side filtering can match against slug/label/department text. 
- Implemented a lightweight client-side script that listens on `.js-catalog-search` inputs, hides non-matching rows, and toggles a per-section empty-state message. 
- Added localized strings for the new search labels/placeholders and empty-state in English, French, and Amharic (`lang/en.json`, `lang/fr.json`, `lang/am.json`).

### Testing
- Ran `php -l admin/work_function_defaults.php` to validate PHP syntax, which completed successfully. 
- Validated JSON localization files by running a small Python `json.load` check over `lang/en.json`, `lang/fr.json`, and `lang/am.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba076758b8832d89a837dcde9a025c)