### PR TITLE
Remove appbar connectivity button

### DIFF
--- a/assets/css/material.css
+++ b/assets/css/material.css
@@ -52,50 +52,6 @@ body.md-bg {
   gap: 12px;
 }
 
-.md-status-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 14px;
-  border-radius: 999px;
-  background: var(--status-success-soft, rgba(34, 197, 94, 0.22));
-  color: inherit;
-  border: none;
-  cursor: pointer;
-  font: inherit;
-  appearance: none;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  transition: background 0.3s ease, color 0.3s ease;
-}
-
-.md-status-indicator:focus-visible {
-  outline: 2px solid var(--status-info, #f59e0b);
-  outline-offset: 2px;
-}
-
-.md-status-dot {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: var(--status-success);
-  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2);
-  transition: background 0.3s ease, box-shadow 0.3s ease;
-}
-
-.md-status-label {
-  font-size: 0.85rem;
-}
-
-.md-status-indicator.is-offline {
-  background: var(--status-warning-surface, rgba(255, 140, 0, 0.2));
-}
-
-.md-status-indicator.is-offline .md-status-dot {
-  background: var(--status-warning);
-  box-shadow: 0 0 0 2px rgba(255, 140, 0, 0.35);
-}
-
 .md-appbar-button {
   border: none;
   background: rgba(255, 255, 255, 0.18);

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -495,52 +495,6 @@ button,
   border-color: var(--app-primary-soft);
 }
 
-.md-status-indicator {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0 1rem;
-  border-radius: 999px;
-  background: var(--status-success-soft, rgba(34, 197, 94, 0.22));
-  color: inherit;
-  border: none;
-  cursor: pointer;
-  font: inherit;
-  appearance: none;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  transition: background 0.3s ease, color 0.3s ease;
-  min-height: var(--app-button-height);
-}
-
-.md-status-indicator:focus-visible {
-  outline: 2px solid var(--status-info, #f59e0b);
-  outline-offset: 2px;
-}
-
-.md-status-dot {
-  width: 0.9rem;
-  height: 0.9rem;
-  border-radius: 50%;
-  background: var(--status-success);
-  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2);
-  transition: background 0.3s ease, box-shadow 0.3s ease;
-}
-
-.md-status-label {
-  font-size: 0.85rem;
-}
-
-.md-status-indicator.is-offline {
-  background: var(--status-warning-surface, rgba(255, 140, 0, 0.2));
-}
-
-.md-status-indicator.is-offline .md-status-dot {
-  background: var(--status-warning);
-  box-shadow: 0 0 0 2px rgba(255, 140, 0, 0.35);
-}
-
 .md-topnav-link.is-offline .md-status-dot {
   background: var(--status-warning);
   box-shadow: 0 0 0 2px rgba(255, 140, 0, 0.35);
@@ -741,9 +695,6 @@ html.has-js .md-topnav-backdrop.is-visible {
     padding: 0.85rem 1.25rem;
   }
 
-  .md-status-indicator {
-    padding: 0 1.25rem;
-  }
 }
 
 .md-drawer {

--- a/templates/header.php
+++ b/templates/header.php
@@ -117,23 +117,6 @@ if ($profileInitials === '') {
     <span><?=$siteTitle?></span>
   </div>
   <div class="md-appbar-actions">
-    <button
-      type="button"
-      class="md-appbar-link md-appbar-theme-toggle md-appbar-connectivity md-status-indicator"
-      data-status-indicator
-      data-online-text="<?=htmlspecialchars(t($t, 'status_online', 'Online'), ENT_QUOTES, 'UTF-8')?>"
-      data-offline-text="<?=htmlspecialchars(t($t, 'status_offline', 'Offline'), ENT_QUOTES, 'UTF-8')?>"
-      role="switch"
-      aria-live="polite"
-      aria-atomic="true"
-      aria-checked="true"
-      data-status="online"
-      aria-label="<?=htmlspecialchars(t($t, 'toggle_offline_mode', 'Toggle offline mode'), ENT_QUOTES, 'UTF-8')?>"
-      title="<?=htmlspecialchars(t($t, 'toggle_offline_mode', 'Toggle offline mode'), ENT_QUOTES, 'UTF-8')?>"
-    >
-      <span class="md-status-dot" aria-hidden="true"></span>
-      <span class="md-status-label visually-hidden"><?=htmlspecialchars(t($t, 'status_online', 'Online'), ENT_QUOTES, 'UTF-8')?></span>
-    </button>
     <a
       href="<?=htmlspecialchars(url_for('set_lang.php?lang=' . $nextLocale), ENT_QUOTES, 'UTF-8')?>"
       class="md-appbar-link md-appbar-language"


### PR DESCRIPTION
### Motivation
- Remove the connectivity toggle control from the shared appbar header to simplify the UI and avoid exposing an inline offline toggle in the global header.
- Clean up the now-unused status indicator CSS rules that were only required for that button.

### Description
- Removed the connectivity toggle button markup from `templates/header.php` so header actions now begin with the language switcher followed by profile and logout controls.
- Deleted the `.md-status-indicator`, `.md-status-dot` and related rules from `assets/css/styles.css` and `assets/css/material.css` to remove unused styling.
- Kept the underlying connectivity API and offline banner logic intact (no changes to `assets/js/app.js` or `AppConnectivity`), so offline handling remains functional without the header toggle.
- Changes committed with message: `Remove appbar connectivity button`.

### Testing
- Ran PHP syntax checks: `php -l templates/header.php` and `php -l config.php`, both returned no syntax errors (success).
- Searched for leftover references with `rg -n "md-status-indicator|md-appbar-connectivity|data-status-indicator"` and confirmed there are no remaining matches in the updated files (success).
- Verified files staged and committed (`templates/header.php`, `assets/css/styles.css`, `assets/css/material.css`) and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bacf03a3e0832da8c9eb98fab91916)