### PR TITLE
Wire landing hero to configured background and admin landing text

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -312,6 +312,35 @@ body.landing-body {
   align-items: center;
 }
 
+.landing-section--hero-image .landing-hero-panel {
+  background:
+    linear-gradient(135deg, rgba(8, 26, 58, 0.78), rgba(12, 79, 176, 0.58)),
+    radial-gradient(100% 140% at 0% 0%, color-mix(in srgb, var(--landing-accent) 18%, transparent), transparent 70%),
+    radial-gradient(120% 120% at 100% 100%, color-mix(in srgb, var(--landing-primary) 16%, transparent), transparent 75%),
+    var(--landing-hero-image),
+    linear-gradient(135deg, color-mix(in srgb, var(--md-surface) 92%, transparent), color-mix(in srgb, var(--app-primary-soft, #d7e5ff) 38%, transparent));
+  background-size: auto, auto, auto, cover, auto;
+  background-position: center, 0 0, 100% 100%, center, center;
+  overflow: hidden;
+}
+
+.landing-section--hero-image .landing-hero-copy__eyebrow,
+.landing-section--hero-image .landing-hero-copy__title,
+.landing-section--hero-image .landing-hero-copy__subtitle,
+.landing-section--hero-image .landing-hero-badges span {
+  color: #f8fbff;
+}
+
+.landing-section--hero-image .landing-hero-copy__eyebrow,
+.landing-section--hero-image .landing-hero-badges span {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.landing-section--hero-image .landing-hero-copy__subtitle {
+  max-width: 62ch;
+}
+
 .landing-hero-copy__eyebrow {
   margin: 0;
   display: inline-block;

--- a/index.php
+++ b/index.php
@@ -8,6 +8,8 @@ $availableLocales = available_locales();
 $defaultLocale = $availableLocales[0] ?? 'en';
 
 $logoRenderPath = site_logo_url($cfg);
+$landingBackgroundRenderPath = site_landing_background_url($cfg);
+$landingTextRaw = trim((string)($cfg['landing_text'] ?? ''));
 
 $logo = htmlspecialchars($logoRenderPath, ENT_QUOTES, 'UTF-8');
 $logoAlt = htmlspecialchars($cfg['site_name'] ?? 'Logo', ENT_QUOTES, 'UTF-8');
@@ -21,7 +23,27 @@ $loginUrl = htmlspecialchars(url_for('login.php'), ENT_QUOTES, 'UTF-8');
 $primaryCta = htmlspecialchars(t($t, 'sign_in', 'Sign In'), ENT_QUOTES, 'UTF-8');
 $heroEyebrow = htmlspecialchars(t($t, 'hero_eyebrow', 'National performance excellence platform'), ENT_QUOTES, 'UTF-8');
 $heroTitle = htmlspecialchars(t($t, 'hero_title', 'Bring every performance conversation into one vibrant workspace'), ENT_QUOTES, 'UTF-8');
-$heroSubtitle = htmlspecialchars(t($t, 'hero_subtitle', 'From planning to recognition, help teams stay aligned with clear goals, real-time updates, and easy collaboration.'), ENT_QUOTES, 'UTF-8');
+$heroSubtitle = htmlspecialchars(
+    $landingTextRaw !== ''
+        ? $landingTextRaw
+        : t($t, 'hero_subtitle', 'From planning to recognition, help teams stay aligned with clear goals, real-time updates, and easy collaboration.'),
+    ENT_QUOTES,
+    'UTF-8'
+);
+$heroDescription = htmlspecialchars(
+    trim(preg_replace('/\s+/', ' ', strip_tags($landingTextRaw !== '' ? $landingTextRaw : t($t, 'hero_subtitle', 'From planning to recognition, help teams stay aligned with clear goals, real-time updates, and easy collaboration.')))),
+    ENT_QUOTES,
+    'UTF-8'
+);
+$landingHeroClass = 'landing-section landing-section--hero';
+$landingHeroStyle = '';
+if ($landingBackgroundRenderPath !== '') {
+    $landingHeroClass .= ' landing-section--hero-image';
+    $landingHeroStyle = sprintf(
+        "--landing-hero-image: url('%s');",
+        htmlspecialchars($landingBackgroundRenderPath, ENT_QUOTES, 'UTF-8')
+    );
+}
 $heroBadgeOne = htmlspecialchars(t($t, 'hero_badge_one', 'Goal alignment'), ENT_QUOTES, 'UTF-8');
 $heroBadgeTwo = htmlspecialchars(t($t, 'hero_badge_two', '360° feedback'), ENT_QUOTES, 'UTF-8');
 $heroBadgeThree = htmlspecialchars(t($t, 'hero_badge_three', 'Learning insights'), ENT_QUOTES, 'UTF-8');
@@ -87,6 +109,7 @@ $newsCards = [
   <meta charset="utf-8">
   <title><?= $siteName ?></title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="<?= $heroDescription ?>">
   <meta name="app-base-url" content="<?= $baseUrl ?>">
   <link rel="manifest" href="<?= asset_url('manifest.php') ?>">
   <link rel="stylesheet" href="<?= asset_url('assets/css/material.css') ?>">
@@ -109,8 +132,8 @@ $newsCards = [
     </header>
 
     <main class="landing-main" aria-labelledby="features-heading">
-      <section class="landing-section landing-section--hero">
-        <div class="landing-hero-panel">
+      <section class="<?= htmlspecialchars($landingHeroClass, ENT_QUOTES, 'UTF-8') ?>">
+        <div class="landing-hero-panel"<?= $landingHeroStyle !== '' ? ' style="' . $landingHeroStyle . '"' : '' ?>>
           <div class="landing-hero-copy">
             <p class="landing-hero-copy__eyebrow"><?= $heroEyebrow ?></p>
             <h1 class="landing-hero-copy__title"><?= $heroTitle ?></h1>


### PR DESCRIPTION
### Motivation
- The public landing page did not use the background image uploaded in Branding settings and always showed the hardcoded hero copy, so admin changes were not reflected to visitors.
- Improve the landing page's SEO/preview readiness by adding a description meta tag derived from the landing copy.

### Description
- Make `index.php` consume `site_landing_background_url($cfg)` and, when present, apply it as a CSS custom property and switch the hero into an image-backed variant via a computed `$landingHeroClass` and `$landingHeroStyle`.
- Use the admin `landing_text` as the hero copy (fallback to the existing translation when empty) and generate a page description from that text for `<meta name="description">`.
- Add CSS rules in `assets/css/landing.css` for `.landing-section--hero-image` to layer a readability overlay and ensure foreground text/badges remain visible over uploaded images.
- Keep all output escaped via `htmlspecialchars` and sanitize the description (strip tags, collapse whitespace) before emitting.

### Testing
- Ran `php -l index.php` and the file reported no syntax errors (success).
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae30de65c832d959d1ad66311dabf)