### PR TITLE
Support questionnaire family_key; avoid accidental deactivation of published/answered content

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -486,6 +486,7 @@ function qb_fetch_questionnaires(PDO $pdo): array
             'title' => $row['title'],
             'description' => $row['description'],
             'status' => strtolower((string)($row['status'] ?? 'draft')),
+            'family_key' => trim((string)($row['family_key'] ?? '')) !== '' ? (string)$row['family_key'] : 'questionnaire-' . $qid,
             'created_at' => $row['created_at'],
             'sections' => $sections,
             'items' => $itemsByQuestionnaire[$qid] ?? [],
@@ -763,6 +764,7 @@ if ($action === 'save' || $action === 'publish') {
     $supportsOptionCorrect = false;
     $supportsOptionOrder = false;
     $supportsQuestionnaireStatus = false;
+    $supportsQuestionnaireFamilyKey = false;
     try {
         $questionnaireColumnsStmt = $pdo->query('SHOW COLUMNS FROM questionnaire');
         $questionnaireColumns = [];
@@ -775,6 +777,7 @@ if ($action === 'save' || $action === 'publish') {
             }
         }
         $supportsQuestionnaireStatus = isset($questionnaireColumns['status']);
+        $supportsQuestionnaireFamilyKey = isset($questionnaireColumns['family_key']);
     } catch (PDOException $columnError) {
         error_log('questionnaire_manage questionnaire columns fetch failed: ' . $columnError->getMessage());
     }
@@ -853,7 +856,26 @@ if ($action === 'save' || $action === 'publish') {
 
     $pdo->beginTransaction();
     try {
-        if ($supportsQuestionnaireStatus) {
+        $generateFamilyKey = static function (?string $candidate = null): string {
+            $normalized = trim((string)$candidate);
+            if ($normalized !== '') {
+                $normalized = preg_replace('/[^a-zA-Z0-9_-]+/', '-', strtolower($normalized));
+                $normalized = trim((string)$normalized, '-');
+            }
+            if ($normalized === '') {
+                try {
+                    $normalized = 'questionnaire-' . bin2hex(random_bytes(8));
+                } catch (Throwable $_) {
+                    $normalized = 'questionnaire-' . uniqid('', true);
+                }
+            }
+            return substr($normalized, 0, 100);
+        };
+
+        if ($supportsQuestionnaireStatus && $supportsQuestionnaireFamilyKey) {
+            $insertQuestionnaireStmt = $pdo->prepare('INSERT INTO questionnaire (title, description, status, family_key) VALUES (?, ?, ?, ?)');
+            $updateQuestionnaireStmt = $pdo->prepare('UPDATE questionnaire SET title=?, description=?, status=?, family_key=? WHERE id=?');
+        } elseif ($supportsQuestionnaireStatus) {
             $insertQuestionnaireStmt = $pdo->prepare('INSERT INTO questionnaire (title, description, status) VALUES (?, ?, ?)');
             $updateQuestionnaireStmt = $pdo->prepare('UPDATE questionnaire SET title=?, description=?, status=? WHERE id=?');
         } else {
@@ -1120,6 +1142,7 @@ if ($action === 'save' || $action === 'publish') {
             $title = trim((string)($qData['title'] ?? ''));
             $description = $qData['description'] ?? null;
             $status = strtolower(trim((string)($qData['status'] ?? '')));
+            $familyKey = trim((string)($qData['family_key'] ?? ''));
             if (!in_array($status, ['draft', 'published', 'inactive'], true)) {
                 $status = 'draft';
             }
@@ -1128,19 +1151,31 @@ if ($action === 'save' || $action === 'publish') {
             } elseif ($qid && isset($questionnaireMap[$qid])) {
                 $existingStatus = strtolower((string)($questionnaireMap[$qid]['status'] ?? 'draft'));
                 if ($existingStatus === 'published' && $status === 'draft') {
-                    $status = 'inactive';
+                    // Keep previously published questionnaires published unless admins
+                    // explicitly switch them to inactive.
+                    $status = 'published';
                 }
             }
+            if ($qid && isset($questionnaireMap[$qid]) && $familyKey === '') {
+                $familyKey = (string)($questionnaireMap[$qid]['family_key'] ?? '');
+            }
+            $familyKey = $generateFamilyKey($familyKey !== '' ? $familyKey : ($title !== '' ? $title : null));
 
             if ($qid && isset($questionnaireMap[$qid])) {
-                if ($supportsQuestionnaireStatus) {
+                if ($supportsQuestionnaireStatus && $supportsQuestionnaireFamilyKey) {
+                    $updateQuestionnaireStmt->execute([$title, $description, $status, $familyKey, $qid]);
+                    $questionnaireMap[$qid]['status'] = $status;
+                    $questionnaireMap[$qid]['family_key'] = $familyKey;
+                } elseif ($supportsQuestionnaireStatus) {
                     $updateQuestionnaireStmt->execute([$title, $description, $status, $qid]);
                     $questionnaireMap[$qid]['status'] = $status;
                 } else {
                     $updateQuestionnaireStmt->execute([$title, $description, $qid]);
                 }
             } else {
-                if ($supportsQuestionnaireStatus) {
+                if ($supportsQuestionnaireStatus && $supportsQuestionnaireFamilyKey) {
+                    $insertQuestionnaireStmt->execute([$title, $description, $status, $familyKey]);
+                } elseif ($supportsQuestionnaireStatus) {
                     $insertQuestionnaireStmt->execute([$title, $description, $status]);
                 } else {
                     $insertQuestionnaireStmt->execute([$title, $description]);
@@ -1154,6 +1189,7 @@ if ($action === 'save' || $action === 'publish') {
                     'title' => $title,
                     'description' => $description,
                     'status' => $status,
+                    'family_key' => $familyKey,
                 ];
             }
             $questionnaireSeen[] = $qid;
@@ -1333,22 +1369,18 @@ if ($action === 'save' || $action === 'publish') {
 
             $itemsToDelete = array_diff(array_keys($existingItems), $itemSeen);
             if ($itemsToDelete) {
-                $itemsToDeactivate = [];
                 $itemsToRemove = [];
                 foreach ($itemsToDelete as $itemId) {
                     $row = $existingItems[$itemId] ?? [];
                     $linkId = isset($row['linkId']) ? (string)$row['linkId'] : '';
                     $hasResponses = $linkId !== '' && !empty($itemResponsePresence[$qid][$linkId] ?? null);
                     if ($hasResponses) {
-                        $itemsToDeactivate[] = $itemId;
-                    } else {
-                        $itemsToRemove[] = $itemId;
+                        // Preserve answered items if they are omitted from payload.
+                        // This prevents accidental mass-deactivation when the client submits
+                        // an incomplete questionnaire graph.
+                        continue;
                     }
-                }
-                if ($itemsToDeactivate && $supportsItemActive) {
-                    $placeholders = implode(',', array_fill(0, count($itemsToDeactivate), '?'));
-                    $stmt = $pdo->prepare("UPDATE questionnaire_item SET is_active=0 WHERE id IN ($placeholders)");
-                    $stmt->execute(array_values($itemsToDeactivate));
+                    $itemsToRemove[] = $itemId;
                 }
                 if ($itemsToRemove) {
                     $placeholders = implode(',', array_fill(0, count($itemsToRemove), '?'));
@@ -1381,7 +1413,6 @@ if ($action === 'save' || $action === 'publish') {
 
         $sectionsToDelete = array_diff(array_keys($existingSections), $sectionSeen);
         if ($sectionsToDelete) {
-            $sectionsToDeactivate = [];
             $sectionsToRemove = [];
             foreach ($sectionsToDelete as $sectionId) {
                 $hasResponses = false;
@@ -1395,21 +1426,10 @@ if ($action === 'save' || $action === 'publish') {
                     }
                 }
                 if ($hasResponses) {
-                    $sectionsToDeactivate[] = $sectionId;
-                } else {
-                    $sectionsToRemove[] = $sectionId;
+                    // Preserve answered sections when omitted from payload.
+                    continue;
                 }
-            }
-            if ($sectionsToDeactivate) {
-                $placeholders = implode(',', array_fill(0, count($sectionsToDeactivate), '?'));
-                if ($supportsSectionActive) {
-                    $stmt = $pdo->prepare("UPDATE questionnaire_section SET is_active=0 WHERE id IN ($placeholders)");
-                    $stmt->execute(array_values($sectionsToDeactivate));
-                }
-                if ($supportsItemActive) {
-                    $stmt = $pdo->prepare("UPDATE questionnaire_item SET is_active=0 WHERE section_id IN ($placeholders)");
-                    $stmt->execute(array_values($sectionsToDeactivate));
-                }
+                $sectionsToRemove[] = $sectionId;
             }
             if ($sectionsToRemove) {
                 $placeholders = implode(',', array_fill(0, count($sectionsToRemove), '?'));

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -192,6 +192,7 @@ const Builder = (() => {
       title: raw.title || 'Untitled Questionnaire',
       description: raw.description || '',
       status: normalizeStatusValue(raw.status),
+      family_key: raw.family_key || '',
       sections,
       items,
       work_functions: Array.isArray(raw.work_functions) ? [...raw.work_functions] : undefined,
@@ -1970,6 +1971,7 @@ const Builder = (() => {
       title: questionnaire.title,
       description: questionnaire.description,
       status: normalizeStatusValue(questionnaire.status),
+      family_key: questionnaire.family_key || undefined,
       sections: questionnaire.sections.map((section, idx) => serializeSection(section, idx + 1)),
       items: questionnaire.items.map((item, idx) => serializeItem(item, idx + 1)),
     };


### PR DESCRIPTION
### Motivation
- Add persistent `family_key` support for questionnaires to allow consistent external identifiers and safer updates across imports/clients.
- Prevent accidental mass-deactivation/removal of previously answered items and sections when clients submit incomplete questionnaire graphs.
- Keep questionnaires that were previously `published` published unless an admin explicitly marks them `inactive` during a save operation.

### Description
- Detects `family_key` column on the `questionnaire` table and includes `family_key` in fetch, insert, and update flows, using a new `generateFamilyKey` helper to normalize or generate a safe value.
- Ensures `qb_fetch_questionnaires` returns a non-empty `family_key` (falls back to `questionnaire-<id>` when missing) and includes `family_key` in the questionnaire payload.
- Updates insert/update prepared statements to include `family_key` conditionally when the column is present in the DB schema and maps the value back into `questionnaireMap` on create/update.
- Adjusts status handling so previously `published` questionnaires are not downgraded to `inactive` when saving a `draft` payload, keeping them `published` unless explicitly set to `inactive`.
- Changes deletion logic to preserve items and sections that have existing responses by skipping removal when those entities are omitted from the incoming payload, and only removing truly orphaned entries.
- Frontend changes include adding `family_key` to the normalized and serialized questionnaire model so the builder will round-trip the field.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0582c0d1c832da8a48454721c1060)