### PR TITLE
Simplify landing hero background and add overlay for image variant

### DIFF
--- a/assets/css/landing.css
+++ b/assets/css/landing.css
@@ -313,15 +313,30 @@ body.landing-body {
 }
 
 .landing-section--hero-image .landing-hero-panel {
-  background:
-    linear-gradient(135deg, rgba(3, 18, 42, 0.9), rgba(10, 60, 132, 0.72)),
-    radial-gradient(100% 140% at 0% 0%, color-mix(in srgb, var(--landing-accent) 18%, transparent), transparent 70%),
-    radial-gradient(120% 120% at 100% 100%, color-mix(in srgb, var(--landing-primary) 16%, transparent), transparent 75%),
-    var(--landing-hero-image),
-    linear-gradient(135deg, color-mix(in srgb, var(--md-surface) 92%, transparent), color-mix(in srgb, var(--app-primary-soft, #d7e5ff) 38%, transparent));
-  background-size: auto, auto, auto, cover, auto;
-  background-position: center, 0 0, 100% 100%, center, center;
+  position: relative;
+  background-color: #123d75;
+  background-image: var(--landing-hero-image);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
   overflow: hidden;
+}
+
+.landing-section--hero-image .landing-hero-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, rgba(3, 18, 42, 0.42), rgba(10, 60, 132, 0.34)),
+    radial-gradient(100% 140% at 0% 0%, rgba(43, 167, 255, 0.12), rgba(43, 167, 255, 0) 70%),
+    radial-gradient(120% 120% at 100% 100%, rgba(13, 99, 217, 0.1), rgba(13, 99, 217, 0) 75%);
+  pointer-events: none;
+}
+
+.landing-section--hero-image .landing-hero-copy,
+.landing-section--hero-image .landing-hero-badges {
+  position: relative;
+  z-index: 1;
 }
 
 .landing-section--hero-image .landing-hero-copy__eyebrow,


### PR DESCRIPTION
### Motivation

- Make the hero panel background easier to reason about and more robust when a hero image is present.  
- Improve legibility of text on top of hero images by introducing a consistent translucent overlay.  
- Replace fragile multi-layer background positioning with a single-cover image and controlled tinting.

### Description

- Replace the previous multi-layer `background` declaration for `.landing-section--hero-image .landing-hero-panel` with a single `background-image: var(--landing-hero-image)` plus `background-size: cover`, `background-position: center`, `background-repeat: no-repeat`, and a fallback `background-color: #123d75`.  
- Introduce a positioned pseudo-element `::before` on the panel that applies the linear and radial gradient tints to provide the darkening/accent overlay while preserving the underlying image.  
- Set the panel to `position: relative` and bring `.landing-hero-copy` and `.landing-hero-badges` above the overlay with `position: relative` and `z-index: 1`, and keep `overflow: hidden` to contain the overlay; remove the previous multi-value background-size/position rules.

### Testing

- Ran stylesheet linting with `stylelint` and the linter passed.  
- Built the frontend assets with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5a147ef2c832d900f02432c5eefea)