### PR TITLE
Match check-for-upgrade button shading with install button

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -672,7 +672,7 @@ $pageHelpKey = 'admin.dashboard';
           <form method="post">
             <input type="hidden" name="csrf" value="<?=csrf_token()?>">
             <input type="hidden" name="action" value="check_upgrade">
-            <button type="submit" class="md-button md-elev-1 md-upgrade-action-button"><?=t($t,'check_for_upgrade','Check for Upgrade')?></button>
+            <button type="submit" class="md-button md-primary md-elev-2 md-upgrade-action-button"><?=t($t,'check_for_upgrade','Check for Upgrade')?></button>
           </form>
           <form method="post" data-upgrade-progress-trigger data-upgrade-progress-message="<?=htmlspecialchars(t($t, 'upgrade_progress_install', 'Installing update. Please keep this page open until the process completes.'), ENT_QUOTES, 'UTF-8')?>">
             <input type="hidden" name="csrf" value="<?=csrf_token()?>">


### PR DESCRIPTION
### Motivation
- Ensure the "Check for Upgrade" action has the same visual weight and shading as the "Install Upgrade" button for a consistent admin UI.

### Description
- Updated `admin/dashboard.php` to change the `Check for Upgrade` button classes from `md-button md-elev-1 md-upgrade-action-button` to `md-button md-primary md-elev-2 md-upgrade-action-button` so it matches the `Install Upgrade` button.

### Testing
- Ran `php -l admin/dashboard.php` and there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c686e039b8832db8e2d3e2f379d690)