### PR TITLE
Questionnaire builder: add workspace/start/import view states, mobile guidance, and responsive layout fixes

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -2371,6 +2371,13 @@ if ($qbJsVersion) {
   <?php if ($msg): ?>
     <div class="md-alert"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div>
   <?php endif; ?>
+  <div class="md-card md-elev-2 qb-mobile-recommendation" id="qb-mobile-recommendation" role="dialog" aria-live="polite" aria-hidden="true" aria-label="<?=htmlspecialchars(t($t,'qb_mobile_recommendation_title','Desktop recommended for Form Builder'), ENT_QUOTES, 'UTF-8')?>">
+    <div class="qb-mobile-recommendation__head">
+      <h2 class="md-card-title"><?=t($t,'qb_mobile_recommendation_title','Desktop recommended for Form Builder')?></h2>
+      <button type="button" class="md-button md-outline md-elev-1" id="qb-mobile-recommendation-close"><?=t($t,'close','Close')?></button>
+    </div>
+    <p class="md-hint"><?=t($t,'qb_mobile_recommendation_body','For reliable editing, use the Form Builder on a larger desktop or laptop screen (recommended minimum width: 1280px).')?></p>
+  </div>
   <?php if ($importPopup): ?>
     <div class="md-upgrade-popup md-import-popup" role="alertdialog" aria-live="assertive" aria-label="<?=htmlspecialchars($importPopup['title'] ?? t($t, 'import_log_title', 'Import log'), ENT_QUOTES, 'UTF-8')?>">
       <div class="md-upgrade-popup__backdrop"></div>
@@ -2400,7 +2407,7 @@ if ($qbJsVersion) {
       });
     </script>
   <?php endif; ?>
-  <div class="qb-start-grid">
+  <div class="qb-start-grid" id="qb-start-state" aria-label="<?=htmlspecialchars(t($t,'qb_start_choose_mode','Choose how you want to work'), ENT_QUOTES, 'UTF-8')?>">
     <div class="md-card md-elev-2 qb-start-card">
       <div class="qb-start-card-header">
         <p class="md-overline"><?=t($t,'qb_start_create_label','Start new')?></p>
@@ -2432,24 +2439,12 @@ if ($qbJsVersion) {
         <h2 class="md-card-title"><?=t($t,'qb_start_import_title','Import or align a questionnaire')?></h2>
         <p class="md-hint"><?=t($t,'qb_start_import_hint','Upload a questionnaire XML file or download our template to mirror other survey tools.')?></p>
       </div>
-      <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
-        <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-        <div class="qb-import-inline">
-          <label class="md-field md-field--compact"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
-          <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
-        </div>
-        <div class="qb-start-actions">
-          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
-            <?=t($t,'download_xml_template','Download XML template')?>
-          </a>
-          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
-            <?=t($t,'download_import_guide','Download Import Guide')?>
-          </a>
-        </div>
-      </form>
+      <div class="qb-start-actions">
+        <button class="md-button md-elev-2" id="qb-open-import-workspace" type="button"><?=t($t,'qb_open_import_workspace','Open import tools')?></button>
+      </div>
     </div>
   </div>
-  <div class="qb-manager-layout">
+  <div class="qb-manager-layout" id="qb-workspace-state" aria-hidden="true">
     <aside class="qb-manager-sidebar" aria-labelledby="qb-navigation-title">
       <button class="md-button md-outline qb-nav-toggle" id="qb-toggle-nav" type="button" aria-expanded="true">
         <span class="qb-nav-toggle-icon" aria-hidden="true">⇤</span>
@@ -2463,6 +2458,32 @@ if ($qbJsVersion) {
       </div>
     </aside>
     <div class="qb-manager-main">
+      <div class="qb-workspace-modebar">
+        <button type="button" class="md-button md-outline md-elev-1" id="qb-back-to-start"><?=t($t,'qb_back_to_start','Back to start')?></button>
+        <p class="md-hint qb-workspace-mode-label" id="qb-workspace-mode-label"><?=t($t,'qb_workspace_mode_default','Workspace')?></p>
+      </div>
+      <div class="md-card md-elev-2 qb-import-workspace" id="qb-import-workspace" aria-live="polite">
+        <div class="qb-start-card-header">
+          <p class="md-overline"><?=t($t,'qb_start_import_label','Import')?></p>
+          <h3 class="md-card-title"><?=t($t,'qb_workspace_import_title','Import questionnaire package')?></h3>
+          <p class="md-hint"><?=t($t,'qb_workspace_import_hint','Upload your questionnaire XML file or download templates and guidance first.')?></p>
+        </div>
+        <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
+          <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+          <div class="qb-import-inline">
+            <label class="md-field md-field--compact"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
+            <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
+          </div>
+          <div class="qb-start-actions">
+            <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
+              <?=t($t,'download_xml_template','Download XML template')?>
+            </a>
+            <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
+              <?=t($t,'download_import_guide','Download Import Guide')?>
+            </a>
+          </div>
+        </form>
+      </div>
       <button type="button" class="md-button md-secondary md-elev-2 qb-scroll-top" id="qb-scroll-top" aria-label="<?=t($t,'qb_scroll_to_top','Back to top')?>" aria-hidden="true" tabindex="-1">
         <span class="qb-scroll-top-icon" aria-hidden="true">⇧</span>
         <span class="qb-scroll-top-label"><?=t($t,'qb_scroll_to_top','Back to top')?></span>
@@ -2473,6 +2494,7 @@ if ($qbJsVersion) {
             <p class="md-overline"><?=t($t, 'qb_workspace_label', 'Workspace')?></p>
             <h3 class="md-card-title"><?=t($t, 'qb_workspace_title', 'Questionnaire editor')?></h3>
             <p class="md-hint"><?=t($t, 'qb_workspace_hint', 'Build sections and questions here, then preview and publish when checks are ready.')?></p>
+            <p class="md-hint qb-active-questionnaire-label" id="qb-active-questionnaire-label"><?=t($t,'qb_active_questionnaire_none','No questionnaire selected')?></p>
           </div>
           <div class="qb-workspace-actions">
             <div class="qb-toolbar" aria-label="<?=htmlspecialchars(t($t, 'qb_workspace_actions', 'Workspace actions'), ENT_QUOTES, 'UTF-8')?>">

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -54,7 +54,7 @@
 
 .qb-select-input {
   min-height: 2.75rem;
-  min-width: 240px;
+  min-width: 0;
   color: var(--app-on-surface, inherit);
   background: var(--app-surface);
   border-color: var(--app-border, rgba(0, 0, 0, 0.1));
@@ -63,7 +63,7 @@
 .qb-select,
 .qb-select-input {
   width: 100%;
-  min-width: 240px;
+  min-width: 0;
   padding: 0.55rem 0.65rem;
   border-radius: 6px;
   border: 1px solid var(--app-border, rgba(0, 0, 0, 0.1));
@@ -104,12 +104,17 @@
   margin: 0;
 }
 
+.qb-active-questionnaire-label {
+  font-weight: 600;
+  color: var(--app-on-surface, inherit);
+}
+
 .qb-start-grid {
   display: grid;
-  gap: 0.4rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  margin-bottom: 0.6rem;
-  align-items: start;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(320px, 1fr));
+  margin-bottom: 0.9rem;
+  align-items: stretch;
 }
 
 .qb-start-card {
@@ -118,6 +123,7 @@
   gap: 0.35rem;
   justify-content: flex-start;
   padding: 0.75rem 0.9rem;
+  height: 100%;
 }
 
 .qb-start-card > * + * {
@@ -157,7 +163,7 @@
 .qb-manager-layout {
   position: relative;
   display: grid;
-  grid-template-columns: clamp(260px, 24vw, 320px) minmax(0, 1fr);
+  grid-template-columns: minmax(280px, 23vw) minmax(0, 1fr);
   gap: 1.25rem;
   align-items: flex-start;
 }
@@ -187,6 +193,60 @@
 .qb-manager-main {
   min-width: 0;
   position: relative;
+}
+
+.qb-mobile-recommendation {
+  display: none;
+  margin-bottom: 0.8rem;
+  padding: 0.7rem 0.9rem;
+}
+
+.qb-mobile-recommendation__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.qb-mobile-recommendation[aria-hidden="false"] {
+  display: block;
+}
+
+.qb-start-grid[aria-hidden="true"] {
+  display: none;
+}
+
+#qb-workspace-state[aria-hidden="true"] {
+  display: none;
+}
+
+.qb-workspace-modebar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.qb-workspace-mode-label {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.qb-import-workspace {
+  display: none;
+  margin-bottom: 0.75rem;
+  padding: 0.8rem 0.9rem;
+}
+
+.qb-manager-layout.is-import-mode .qb-manager-sidebar,
+.qb-manager-layout.is-import-mode .qb-builder-card,
+.qb-manager-layout.is-import-mode .qb-scroll-top {
+  display: none;
+}
+
+.qb-manager-layout.is-import-mode .qb-import-workspace {
+  display: block;
 }
 
 
@@ -746,6 +806,7 @@
   display: flex;
   gap: 0.45rem;
   align-items: center;
+  min-width: 0;
 }
 
 .qb-questionnaire-header {
@@ -776,7 +837,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  min-width: 160px;
+  min-width: 0;
   align-items: flex-start;
 }
 
@@ -867,7 +928,7 @@
 }
 
 .qb-section-summary {
-  min-width: 160px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   padding-top: 1.05rem;
@@ -878,7 +939,7 @@
 }
 
 .qb-section-main {
-  flex: 1 1 600px;
+  flex: 1 1 420px;
   display: grid;
   grid-template-columns: minmax(220px, 1fr) minmax(260px, 1fr) auto auto;
   gap: 0.45rem;
@@ -886,6 +947,10 @@
   max-height: 1000px;
   opacity: 1;
   transition: max-height 0.22s ease, opacity 0.2s ease;
+}
+
+.qb-section-main > * {
+  min-width: 0;
 }
 
 .qb-items,
@@ -1059,6 +1124,7 @@
   gap: 0.55rem;
   border-bottom: 1px solid var(--app-border, rgba(0, 0, 0, 0.12));
   padding-bottom: 0.45rem;
+  min-width: 0;
 }
 
 .qb-item-drag-handle {
@@ -1087,9 +1153,9 @@
 
 .qb-item-summary-copy strong,
 .qb-item-summary-copy small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
 }
 
 .qb-item-summary-copy small {
@@ -1180,6 +1246,7 @@
 
 .qb-item-main {
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
@@ -1381,7 +1448,17 @@
   min-width: 0;
 }
 
-@media (max-width: 920px) {
+@media (max-width: 1400px) {
+  .qb-header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .qb-questionnaire-header,
+  .qb-section-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .qb-section-main,
   .qb-item-main-grid,
   .qb-item-config-row,

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -39,6 +39,14 @@ const Builder = (() => {
     selector: '#qb-selector',
     sectionNav: '#qb-section-nav',
     navToggleButton: '#qb-toggle-nav',
+    startState: '#qb-start-state',
+    workspaceState: '#qb-workspace-state',
+    backToStartButton: '#qb-back-to-start',
+    openImportWorkspaceButton: '#qb-open-import-workspace',
+    workspaceModeLabel: '#qb-workspace-mode-label',
+    activeQuestionnaireLabel: '#qb-active-questionnaire-label',
+    mobileRecommendation: '#qb-mobile-recommendation',
+    mobileRecommendationClose: '#qb-mobile-recommendation-close',
     saveStatus: '#qb-save-status',
     floatingSaveLabel: '#qb-save-floating-label',
     metaCsrf: 'meta[name="csrf-token"]',
@@ -77,6 +85,7 @@ const Builder = (() => {
     collapsedItems: 'hrassess:qb:collapsed-items',
     collapsedSections: 'hrassess:qb:collapsed-sections',
     compactMode: 'hrassess:qb:compact-mode',
+    mobileRecommendationDismissed: 'hrassess:qb:mobile-recommendation-dismissed',
   };
 
   const STRINGS = window.QB_STRINGS || {
@@ -168,6 +177,7 @@ const Builder = (() => {
     collapsedItems: {},
     collapsedSections: {},
     compactMode: false,
+    viewMode: 'start',
   };
 
   let initialActiveId = window.QB_INITIAL_ACTIVE_ID || null;
@@ -354,6 +364,8 @@ const Builder = (() => {
     attachStaticListeners();
     primeFromBootstrap();
     fetchData({ silent: true });
+    setViewMode('start');
+    renderMobileRecommendation();
   }
 
   function primeFromBootstrap() {
@@ -380,6 +392,9 @@ const Builder = (() => {
     const destroyBtn = document.querySelector(selectors.destroyButton);
     const openBtn = document.querySelector(selectors.openButton);
     const navToggleBtn = document.querySelector(selectors.navToggleButton);
+    const backToStartBtn = document.querySelector(selectors.backToStartButton);
+    const openImportWorkspaceBtn = document.querySelector(selectors.openImportWorkspaceButton);
+    const mobileRecommendationCloseBtn = document.querySelector(selectors.mobileRecommendationClose);
     const selector = document.querySelector(selectors.selector);
     const list = document.querySelector(selectors.list);
     const tabs = document.querySelector(selectors.tabs);
@@ -387,6 +402,7 @@ const Builder = (() => {
 
     addBtn?.addEventListener('click', () => {
       addQuestionnaire();
+      setViewMode('create');
     });
 
     saveBtn?.addEventListener('click', () => saveAll(false));
@@ -411,7 +427,18 @@ const Builder = (() => {
       const key = selector?.value;
       if (!key) return;
       setActive(key);
+      setViewMode('edit');
       document.querySelector(selectors.list)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+    openImportWorkspaceBtn?.addEventListener('click', () => {
+      setViewMode('import');
+    });
+    backToStartBtn?.addEventListener('click', () => {
+      setViewMode('start');
+    });
+    mobileRecommendationCloseBtn?.addEventListener('click', () => {
+      rememberSet(STORAGE_KEYS.mobileRecommendationDismissed, '1');
+      renderMobileRecommendation();
     });
     scrollTopBtn?.addEventListener('click', handleScrollToTop);
     quickJumpSelect?.addEventListener('change', (event) => {
@@ -449,6 +476,15 @@ const Builder = (() => {
       window.addEventListener('scroll', toggleScrollTopVisibility, { passive: true });
       toggleScrollTopVisibility();
     }
+    window.addEventListener('resize', renderMobileRecommendation, { passive: true });
+  }
+
+  function renderMobileRecommendation() {
+    const panel = document.querySelector(selectors.mobileRecommendation);
+    if (!panel) return;
+    const dismissed = rememberGet(STORAGE_KEYS.mobileRecommendationDismissed) === '1';
+    const smallViewport = window.matchMedia('(max-width: 1279px)').matches;
+    panel.setAttribute('aria-hidden', dismissed || !smallViewport ? 'true' : 'false');
   }
 
   function openPreview() {
@@ -474,6 +510,20 @@ const Builder = (() => {
     previewWindow.document.open();
     previewWindow.document.write(buildPreviewPage(active));
     previewWindow.document.close();
+  }
+
+  function setViewMode(mode) {
+    state.viewMode = ['start', 'create', 'edit', 'import'].includes(mode) ? mode : 'start';
+    const startState = document.querySelector(selectors.startState);
+    const workspaceState = document.querySelector(selectors.workspaceState);
+    if (startState) {
+      startState.setAttribute('aria-hidden', state.viewMode === 'start' ? 'false' : 'true');
+    }
+    if (workspaceState) {
+      workspaceState.setAttribute('aria-hidden', state.viewMode === 'start' ? 'true' : 'false');
+      workspaceState.classList.toggle('is-import-mode', state.viewMode === 'import');
+    }
+    renderWorkspaceContext();
   }
 
   function buildPreviewPage(questionnaire) {
@@ -892,7 +942,35 @@ const Builder = (() => {
     } else {
       rememberRemove(STORAGE_KEYS.active);
     }
+    renderWorkspaceContext();
     render();
+  }
+
+  function getActiveQuestionnaire() {
+    return state.questionnaires.find((q) => q.clientId === state.activeKey) || null;
+  }
+
+  function getActiveQuestionnaireTitle() {
+    const active = getActiveQuestionnaire();
+    const title = String(active?.title || '').trim();
+    return title || 'Untitled questionnaire';
+  }
+
+  function renderWorkspaceContext() {
+    const modeLabel = document.querySelector(selectors.workspaceModeLabel);
+    const activeLabel = document.querySelector(selectors.activeQuestionnaireLabel);
+    const hasActive = Boolean(getActiveQuestionnaire());
+    const activeTitle = getActiveQuestionnaireTitle();
+
+    if (modeLabel) {
+      if (state.viewMode === 'create') modeLabel.textContent = `Mode: Create questionnaire (${activeTitle})`;
+      else if (state.viewMode === 'edit') modeLabel.textContent = `Mode: Edit questionnaire (${activeTitle})`;
+      else if (state.viewMode === 'import') modeLabel.textContent = 'Mode: Import questionnaire';
+      else modeLabel.textContent = 'Workspace';
+    }
+    if (activeLabel) {
+      activeLabel.textContent = hasActive ? `Editing: ${activeTitle}` : 'No questionnaire selected';
+    }
   }
 
   function normalizeStatusValue(value) {
@@ -1110,6 +1188,7 @@ const Builder = (() => {
     applyFocusMode();
     renderDeleteButton();
     renderDestroyButton();
+    renderWorkspaceContext();
     toggleSaveButtons();
     if (!state.dirty && state.lastSavedAt) {
       updateSaveStatus(STRINGS.saveStatusLastSaved || 'Last saved just now');
@@ -1838,6 +1917,7 @@ const Builder = (() => {
         renderTabs();
         renderSelector();
         renderSectionNav();
+        renderWorkspaceContext();
         break;
       case 'q-description':
         questionnaire.description = event.target.value;


### PR DESCRIPTION
### Motivation
- Introduce explicit UI states for the questionnaire builder so users can switch between the start screen, workspace, and import tools without reloading the page.  
- Improve responsiveness and layout stability so long labels and compact controls wrap correctly on narrower viewports.  
- Surface an optional mobile recommendation prompt advising users to use a desktop for the form builder and allow users to dismiss it persistently.

### Description
- Template updates: added a mobile recommendation dialog and new structural containers (`#qb-start-state`, `#qb-workspace-state`) in `admin/questionnaire_manage.php`, moved the import form into an import workspace area, and added ARIA attributes and labels.  
- CSS changes: updated `assets/css/questionnaire-builder.css` to relax many `min-width` constraints, adjust the start-card grid sizing, add styles for the mobile recommendation, workspace modebar, import workspace visibility, and broaden responsive breakpoint rules.  
- JS changes: enhanced `assets/js/questionnaire-builder.js` with new selectors and state (`viewMode`), `setViewMode`, `renderWorkspaceContext`, and `renderMobileRecommendation` functions, wired open/import/back actions and mobile-dismiss persistence, and updated event handlers to keep workspace context in sync when changing active questionnaire.  
- Accessibility and persistence: added ARIA attributes for the new states and used localStorage keys to remember the mobile recommendation dismissal and persist UI choices where appropriate.

### Testing
- No automated tests were executed for these UI-centric changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd59a39264832d8f5d0969318fe288)