### PR TITLE
Questionnaire Builder: import workspace, reorder mode with undo, and responsive UI improvements

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -2371,6 +2371,13 @@ if ($qbJsVersion) {
   <?php if ($msg): ?>
     <div class="md-alert"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div>
   <?php endif; ?>
+  <div class="md-card md-elev-2 qb-mobile-recommendation" id="qb-mobile-recommendation" role="dialog" aria-live="polite" aria-hidden="true" aria-label="<?=htmlspecialchars(t($t,'qb_mobile_recommendation_title','Desktop recommended for Form Builder'), ENT_QUOTES, 'UTF-8')?>">
+    <div class="qb-mobile-recommendation__head">
+      <h2 class="md-card-title"><?=t($t,'qb_mobile_recommendation_title','Desktop recommended for Form Builder')?></h2>
+      <button type="button" class="md-button md-outline md-elev-1" id="qb-mobile-recommendation-close"><?=t($t,'close','Close')?></button>
+    </div>
+    <p class="md-hint"><?=t($t,'qb_mobile_recommendation_body','For reliable editing, use the Form Builder on a larger desktop or laptop screen (recommended minimum width: 1280px).')?></p>
+  </div>
   <?php if ($importPopup): ?>
     <div class="md-upgrade-popup md-import-popup" role="alertdialog" aria-live="assertive" aria-label="<?=htmlspecialchars($importPopup['title'] ?? t($t, 'import_log_title', 'Import log'), ENT_QUOTES, 'UTF-8')?>">
       <div class="md-upgrade-popup__backdrop"></div>
@@ -2400,7 +2407,7 @@ if ($qbJsVersion) {
       });
     </script>
   <?php endif; ?>
-  <div class="qb-start-grid">
+  <div class="qb-start-grid" id="qb-start-state" aria-label="<?=htmlspecialchars(t($t,'qb_start_choose_mode','Choose how you want to work'), ENT_QUOTES, 'UTF-8')?>">
     <div class="md-card md-elev-2 qb-start-card">
       <div class="qb-start-card-header">
         <p class="md-overline"><?=t($t,'qb_start_create_label','Start new')?></p>
@@ -2432,24 +2439,12 @@ if ($qbJsVersion) {
         <h2 class="md-card-title"><?=t($t,'qb_start_import_title','Import or align a questionnaire')?></h2>
         <p class="md-hint"><?=t($t,'qb_start_import_hint','Upload a questionnaire XML file or download our template to mirror other survey tools.')?></p>
       </div>
-      <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
-        <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-        <div class="qb-import-inline">
-          <label class="md-field md-field--compact"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
-          <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
-        </div>
-        <div class="qb-start-actions">
-          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
-            <?=t($t,'download_xml_template','Download XML template')?>
-          </a>
-          <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
-            <?=t($t,'download_import_guide','Download Import Guide')?>
-          </a>
-        </div>
-      </form>
+      <div class="qb-start-actions">
+        <button class="md-button md-elev-2" id="qb-open-import-workspace" type="button"><?=t($t,'qb_open_import_workspace','Open import tools')?></button>
+      </div>
     </div>
   </div>
-  <div class="qb-manager-layout">
+  <div class="qb-manager-layout" id="qb-workspace-state" aria-hidden="true">
     <aside class="qb-manager-sidebar" aria-labelledby="qb-navigation-title">
       <button class="md-button md-outline qb-nav-toggle" id="qb-toggle-nav" type="button" aria-expanded="true">
         <span class="qb-nav-toggle-icon" aria-hidden="true">⇤</span>
@@ -2463,6 +2458,32 @@ if ($qbJsVersion) {
       </div>
     </aside>
     <div class="qb-manager-main">
+      <div class="qb-workspace-modebar">
+        <button type="button" class="md-button md-outline md-elev-1" id="qb-back-to-start"><?=t($t,'qb_back_to_start','Back to start')?></button>
+        <p class="md-hint qb-workspace-mode-label" id="qb-workspace-mode-label"><?=t($t,'qb_workspace_mode_default','Workspace')?></p>
+      </div>
+      <div class="md-card md-elev-2 qb-import-workspace" id="qb-import-workspace" aria-live="polite">
+        <div class="qb-start-card-header">
+          <p class="md-overline"><?=t($t,'qb_start_import_label','Import')?></p>
+          <h3 class="md-card-title"><?=t($t,'qb_workspace_import_title','Import questionnaire package')?></h3>
+          <p class="md-hint"><?=t($t,'qb_workspace_import_hint','Upload your questionnaire XML file or download templates and guidance first.')?></p>
+        </div>
+        <form method="post" enctype="multipart/form-data" class="qb-import-form" action="<?=htmlspecialchars(url_for('admin/questionnaire_manage.php'), ENT_QUOTES, 'UTF-8')?>">
+          <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+          <div class="qb-import-inline">
+            <label class="md-field md-field--compact"><span><?=t($t,'file','File')?></span><input type="file" name="file" required></label>
+            <button class="md-button md-elev-2" name="import"><?=t($t,'import','Import')?></button>
+          </div>
+          <div class="qb-start-actions">
+            <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(url_for('scripts/download_questionnaire_template.php'), ENT_QUOTES, 'UTF-8')?>" download>
+              <?=t($t,'download_xml_template','Download XML template')?>
+            </a>
+            <a class="md-button md-outline md-elev-1" href="<?=htmlspecialchars(asset_url('docs/questionnaire-import-guide.md'), ENT_QUOTES, 'UTF-8')?>" download>
+              <?=t($t,'download_import_guide','Download Import Guide')?>
+            </a>
+          </div>
+        </form>
+      </div>
       <button type="button" class="md-button md-secondary md-elev-2 qb-scroll-top" id="qb-scroll-top" aria-label="<?=t($t,'qb_scroll_to_top','Back to top')?>" aria-hidden="true" tabindex="-1">
         <span class="qb-scroll-top-icon" aria-hidden="true">⇧</span>
         <span class="qb-scroll-top-label"><?=t($t,'qb_scroll_to_top','Back to top')?></span>
@@ -2473,6 +2494,7 @@ if ($qbJsVersion) {
             <p class="md-overline"><?=t($t, 'qb_workspace_label', 'Workspace')?></p>
             <h3 class="md-card-title"><?=t($t, 'qb_workspace_title', 'Questionnaire editor')?></h3>
             <p class="md-hint"><?=t($t, 'qb_workspace_hint', 'Build sections and questions here, then preview and publish when checks are ready.')?></p>
+            <p class="md-hint qb-active-questionnaire-label" id="qb-active-questionnaire-label"><?=t($t,'qb_active_questionnaire_none','No questionnaire selected')?></p>
           </div>
           <div class="qb-workspace-actions">
             <div class="qb-toolbar" aria-label="<?=htmlspecialchars(t($t, 'qb_workspace_actions', 'Workspace actions'), ENT_QUOTES, 'UTF-8')?>">
@@ -2485,6 +2507,7 @@ if ($qbJsVersion) {
                 <button class="md-button md-outline md-elev-1" id="qb-collapse-all-questions" type="button"><?=t($t,'qb_collapse_all_questions','Collapse all questions')?></button>
                 <button class="md-button md-outline md-elev-1" id="qb-compact-mode" type="button"><?=t($t,'qb_compact_mode_on','Compact mode')?></button>
                 <button class="md-button md-outline md-elev-1" id="qb-focus-mode" type="button"><?=t($t,'qb_focus_mode_enter','Focus mode')?></button>
+                <button class="md-button md-outline md-elev-1" id="qb-reorder-mode" type="button"><?=t($t,'qb_reorder_mode_on','Enable reorder mode')?></button>
                 <button class="md-button md-outline md-elev-1" id="qb-preview-questionnaire" type="button"><?=t($t,'qb_preview_label','Preview questionnaire')?></button>
                 <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_fhir','Export questionnaire')?></button>
               </div>
@@ -2496,6 +2519,10 @@ if ($qbJsVersion) {
         </div>
         <div class="qb-save-status" id="qb-save-status" aria-live="polite"><?=t($t,'qb_unsaved_changes','Unsaved changes')?></div>
         <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
+        <div id="qb-reorder-undo" class="qb-reorder-undo" aria-live="polite" aria-hidden="true">
+          <span><?=t($t,'qb_reorder_done','Reorder applied.')?></span>
+          <button type="button" class="md-button md-outline md-elev-1" id="qb-undo-reorder"><?=t($t,'undo','Undo')?></button>
+        </div>
         <div id="qb-list" class="qb-list" aria-live="polite"></div>
       </div>
       <?php if ($showDangerZone): ?>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -54,7 +54,7 @@
 
 .qb-select-input {
   min-height: 2.75rem;
-  min-width: 240px;
+  min-width: 0;
   color: var(--app-on-surface, inherit);
   background: var(--app-surface);
   border-color: var(--app-border, rgba(0, 0, 0, 0.1));
@@ -63,7 +63,7 @@
 .qb-select,
 .qb-select-input {
   width: 100%;
-  min-width: 240px;
+  min-width: 0;
   padding: 0.55rem 0.65rem;
   border-radius: 6px;
   border: 1px solid var(--app-border, rgba(0, 0, 0, 0.1));
@@ -104,12 +104,17 @@
   margin: 0;
 }
 
+.qb-active-questionnaire-label {
+  font-weight: 600;
+  color: var(--app-on-surface, inherit);
+}
+
 .qb-start-grid {
   display: grid;
-  gap: 0.4rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  margin-bottom: 0.6rem;
-  align-items: start;
+  gap: 0.75rem;
+  grid-template-columns: repeat(3, minmax(320px, 1fr));
+  margin-bottom: 0.9rem;
+  align-items: stretch;
 }
 
 .qb-start-card {
@@ -118,6 +123,7 @@
   gap: 0.35rem;
   justify-content: flex-start;
   padding: 0.75rem 0.9rem;
+  height: 100%;
 }
 
 .qb-start-card > * + * {
@@ -157,7 +163,7 @@
 .qb-manager-layout {
   position: relative;
   display: grid;
-  grid-template-columns: clamp(260px, 24vw, 320px) minmax(0, 1fr);
+  grid-template-columns: minmax(280px, 23vw) minmax(0, 1fr);
   gap: 1.25rem;
   align-items: flex-start;
 }
@@ -187,6 +193,60 @@
 .qb-manager-main {
   min-width: 0;
   position: relative;
+}
+
+.qb-mobile-recommendation {
+  display: none;
+  margin-bottom: 0.8rem;
+  padding: 0.7rem 0.9rem;
+}
+
+.qb-mobile-recommendation__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.qb-mobile-recommendation[aria-hidden="false"] {
+  display: block;
+}
+
+.qb-start-grid[aria-hidden="true"] {
+  display: none;
+}
+
+#qb-workspace-state[aria-hidden="true"] {
+  display: none;
+}
+
+.qb-workspace-modebar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.qb-workspace-mode-label {
+  margin: 0;
+  font-size: 0.86rem;
+}
+
+.qb-import-workspace {
+  display: none;
+  margin-bottom: 0.75rem;
+  padding: 0.8rem 0.9rem;
+}
+
+.qb-manager-layout.is-import-mode .qb-manager-sidebar,
+.qb-manager-layout.is-import-mode .qb-builder-card,
+.qb-manager-layout.is-import-mode .qb-scroll-top {
+  display: none;
+}
+
+.qb-manager-layout.is-import-mode .qb-import-workspace {
+  display: block;
 }
 
 
@@ -746,6 +806,7 @@
   display: flex;
   gap: 0.45rem;
   align-items: center;
+  min-width: 0;
 }
 
 .qb-questionnaire-header {
@@ -776,7 +837,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  min-width: 160px;
+  min-width: 0;
   align-items: flex-start;
 }
 
@@ -850,7 +911,7 @@
   cursor: grab;
   user-select: none;
   color: var(--app-muted, rgba(0, 0, 0, 0.6));
-  padding-top: 1.6rem;
+  padding-top: 0.3rem;
   transition: color 0.18s ease, transform 0.18s ease;
 }
 
@@ -861,16 +922,16 @@
   width: 1.9rem;
   height: 1.9rem;
   line-height: 1;
-  margin-top: 1.2rem;
+  margin-top: 0.2rem;
   cursor: pointer;
   transition: border-color 0.18s ease, background-color 0.18s ease, color 0.18s ease;
 }
 
 .qb-section-summary {
-  min-width: 160px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
-  padding-top: 1.05rem;
+  padding-top: 0.15rem;
 }
 
 .qb-section-summary small {
@@ -878,7 +939,7 @@
 }
 
 .qb-section-main {
-  flex: 1 1 600px;
+  flex: 1 1 420px;
   display: grid;
   grid-template-columns: minmax(220px, 1fr) minmax(260px, 1fr) auto auto;
   gap: 0.45rem;
@@ -886,6 +947,10 @@
   max-height: 1000px;
   opacity: 1;
   transition: max-height 0.22s ease, opacity 0.2s ease;
+}
+
+.qb-section-main > * {
+  min-width: 0;
 }
 
 .qb-items,
@@ -1059,6 +1124,7 @@
   gap: 0.55rem;
   border-bottom: 1px solid var(--app-border, rgba(0, 0, 0, 0.12));
   padding-bottom: 0.45rem;
+  min-width: 0;
 }
 
 .qb-item-drag-handle {
@@ -1087,9 +1153,9 @@
 
 .qb-item-summary-copy strong,
 .qb-item-summary-copy small {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: normal;
 }
 
 .qb-item-summary-copy small {
@@ -1131,6 +1197,11 @@
 .qb-item-drag-handle:focus-visible {
   color: var(--app-primary, #205493);
   transform: translateY(-1px);
+}
+
+.qb-manager-layout:not(.is-reorder-mode) .qb-section-drag-handle,
+.qb-manager-layout:not(.is-reorder-mode) .qb-item-drag-handle {
+  opacity: 0.35;
 }
 
 .qb-section-collapse-toggle:hover,
@@ -1180,6 +1251,7 @@
 
 .qb-item-main {
   width: 100%;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
@@ -1381,7 +1453,17 @@
   min-width: 0;
 }
 
-@media (max-width: 920px) {
+@media (max-width: 1400px) {
+  .qb-header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .qb-questionnaire-header,
+  .qb-section-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .qb-section-main,
   .qb-item-main-grid,
   .qb-item-config-row,
@@ -1549,6 +1631,22 @@
 .qb-import-inline .md-field {
   min-width: 240px;
   margin: 0;
+}
+
+.qb-reorder-undo {
+  display: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem;
+  margin-top: 0.45rem;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.16));
+  border-radius: 8px;
+  background: var(--app-surface-alt, rgba(0, 0, 0, 0.03));
+}
+
+.qb-reorder-undo[aria-hidden="false"] {
+  display: flex;
 }
 
 .md-import-popup__list {

--- a/assets/js/questionnaire-builder.js
+++ b/assets/js/questionnaire-builder.js
@@ -28,6 +28,7 @@ const Builder = (() => {
     exportButton: '#qb-export-questionnaire',
     previewButton: '#qb-preview-questionnaire',
     focusModeButton: '#qb-focus-mode',
+    reorderModeButton: '#qb-reorder-mode',
     quickJumpSelect: '#qb-quick-jump',
     collapseAllSectionsButton: '#qb-collapse-all-sections',
     collapseAllQuestionsButton: '#qb-collapse-all-questions',
@@ -39,6 +40,16 @@ const Builder = (() => {
     selector: '#qb-selector',
     sectionNav: '#qb-section-nav',
     navToggleButton: '#qb-toggle-nav',
+    startState: '#qb-start-state',
+    workspaceState: '#qb-workspace-state',
+    backToStartButton: '#qb-back-to-start',
+    openImportWorkspaceButton: '#qb-open-import-workspace',
+    workspaceModeLabel: '#qb-workspace-mode-label',
+    activeQuestionnaireLabel: '#qb-active-questionnaire-label',
+    mobileRecommendation: '#qb-mobile-recommendation',
+    mobileRecommendationClose: '#qb-mobile-recommendation-close',
+    reorderUndo: '#qb-reorder-undo',
+    undoReorderButton: '#qb-undo-reorder',
     saveStatus: '#qb-save-status',
     floatingSaveLabel: '#qb-save-floating-label',
     metaCsrf: 'meta[name="csrf-token"]',
@@ -77,6 +88,8 @@ const Builder = (() => {
     collapsedItems: 'hrassess:qb:collapsed-items',
     collapsedSections: 'hrassess:qb:collapsed-sections',
     compactMode: 'hrassess:qb:compact-mode',
+    mobileRecommendationDismissed: 'hrassess:qb:mobile-recommendation-dismissed',
+    reorderMode: 'hrassess:qb:reorder-mode',
   };
 
   const STRINGS = window.QB_STRINGS || {
@@ -168,6 +181,10 @@ const Builder = (() => {
     collapsedItems: {},
     collapsedSections: {},
     compactMode: false,
+    viewMode: 'start',
+    reorderMode: false,
+    reorderUndo: null,
+    reorderUndoTimer: null,
   };
 
   let initialActiveId = window.QB_INITIAL_ACTIVE_ID || null;
@@ -350,10 +367,13 @@ const Builder = (() => {
     rememberSet(STORAGE_KEYS.collapsedItems, '{}');
     rememberSet(STORAGE_KEYS.collapsedSections, '{}');
     state.compactMode = rememberGet(STORAGE_KEYS.compactMode) === '1';
+    state.reorderMode = rememberGet(STORAGE_KEYS.reorderMode) === '1';
 
     attachStaticListeners();
     primeFromBootstrap();
     fetchData({ silent: true });
+    setViewMode('start');
+    renderMobileRecommendation();
   }
 
   function primeFromBootstrap() {
@@ -372,6 +392,7 @@ const Builder = (() => {
     const exportBtns = document.querySelectorAll(selectors.exportButton);
     const previewBtn = document.querySelector(selectors.previewButton);
     const focusModeBtn = document.querySelector(selectors.focusModeButton);
+    const reorderModeBtn = document.querySelector(selectors.reorderModeButton);
     const quickJumpSelect = document.querySelector(selectors.quickJumpSelect);
     const collapseAllSectionsBtn = document.querySelector(selectors.collapseAllSectionsButton);
     const collapseAllQuestionsBtn = document.querySelector(selectors.collapseAllQuestionsButton);
@@ -380,6 +401,10 @@ const Builder = (() => {
     const destroyBtn = document.querySelector(selectors.destroyButton);
     const openBtn = document.querySelector(selectors.openButton);
     const navToggleBtn = document.querySelector(selectors.navToggleButton);
+    const backToStartBtn = document.querySelector(selectors.backToStartButton);
+    const openImportWorkspaceBtn = document.querySelector(selectors.openImportWorkspaceButton);
+    const mobileRecommendationCloseBtn = document.querySelector(selectors.mobileRecommendationClose);
+    const undoReorderBtn = document.querySelector(selectors.undoReorderButton);
     const selector = document.querySelector(selectors.selector);
     const list = document.querySelector(selectors.list);
     const tabs = document.querySelector(selectors.tabs);
@@ -387,6 +412,7 @@ const Builder = (() => {
 
     addBtn?.addEventListener('click', () => {
       addQuestionnaire();
+      setViewMode('create');
     });
 
     saveBtn?.addEventListener('click', () => saveAll(false));
@@ -395,6 +421,7 @@ const Builder = (() => {
     exportBtns.forEach((btn) => btn.addEventListener('click', handleExport));
     previewBtn?.addEventListener('click', openPreview);
     focusModeBtn?.addEventListener('click', toggleFocusMode);
+    reorderModeBtn?.addEventListener('click', toggleReorderMode);
     collapseAllSectionsBtn?.addEventListener('click', toggleCollapseAllSections);
     collapseAllQuestionsBtn?.addEventListener('click', toggleCollapseAllQuestions);
     compactModeBtn?.addEventListener('click', toggleCompactMode);
@@ -411,8 +438,20 @@ const Builder = (() => {
       const key = selector?.value;
       if (!key) return;
       setActive(key);
+      setViewMode('edit');
       document.querySelector(selectors.list)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
+    openImportWorkspaceBtn?.addEventListener('click', () => {
+      setViewMode('import');
+    });
+    backToStartBtn?.addEventListener('click', () => {
+      setViewMode('start');
+    });
+    mobileRecommendationCloseBtn?.addEventListener('click', () => {
+      rememberSet(STORAGE_KEYS.mobileRecommendationDismissed, '1');
+      renderMobileRecommendation();
+    });
+    undoReorderBtn?.addEventListener('click', undoLastReorder);
     scrollTopBtn?.addEventListener('click', handleScrollToTop);
     quickJumpSelect?.addEventListener('change', (event) => {
       const sectionKey = event.target.value;
@@ -449,6 +488,15 @@ const Builder = (() => {
       window.addEventListener('scroll', toggleScrollTopVisibility, { passive: true });
       toggleScrollTopVisibility();
     }
+    window.addEventListener('resize', renderMobileRecommendation, { passive: true });
+  }
+
+  function renderMobileRecommendation() {
+    const panel = document.querySelector(selectors.mobileRecommendation);
+    if (!panel) return;
+    const dismissed = rememberGet(STORAGE_KEYS.mobileRecommendationDismissed) === '1';
+    const smallViewport = window.matchMedia('(max-width: 1279px)').matches;
+    panel.setAttribute('aria-hidden', dismissed || !smallViewport ? 'true' : 'false');
   }
 
   function openPreview() {
@@ -474,6 +522,20 @@ const Builder = (() => {
     previewWindow.document.open();
     previewWindow.document.write(buildPreviewPage(active));
     previewWindow.document.close();
+  }
+
+  function setViewMode(mode) {
+    state.viewMode = ['start', 'create', 'edit', 'import'].includes(mode) ? mode : 'start';
+    const startState = document.querySelector(selectors.startState);
+    const workspaceState = document.querySelector(selectors.workspaceState);
+    if (startState) {
+      startState.setAttribute('aria-hidden', state.viewMode === 'start' ? 'false' : 'true');
+    }
+    if (workspaceState) {
+      workspaceState.setAttribute('aria-hidden', state.viewMode === 'start' ? 'true' : 'false');
+      workspaceState.classList.toggle('is-import-mode', state.viewMode === 'import');
+    }
+    renderWorkspaceContext();
   }
 
   function buildPreviewPage(questionnaire) {
@@ -892,7 +954,35 @@ const Builder = (() => {
     } else {
       rememberRemove(STORAGE_KEYS.active);
     }
+    renderWorkspaceContext();
     render();
+  }
+
+  function getActiveQuestionnaire() {
+    return state.questionnaires.find((q) => q.clientId === state.activeKey) || null;
+  }
+
+  function getActiveQuestionnaireTitle() {
+    const active = getActiveQuestionnaire();
+    const title = String(active?.title || '').trim();
+    return title || 'Untitled questionnaire';
+  }
+
+  function renderWorkspaceContext() {
+    const modeLabel = document.querySelector(selectors.workspaceModeLabel);
+    const activeLabel = document.querySelector(selectors.activeQuestionnaireLabel);
+    const hasActive = Boolean(getActiveQuestionnaire());
+    const activeTitle = getActiveQuestionnaireTitle();
+
+    if (modeLabel) {
+      if (state.viewMode === 'create') modeLabel.textContent = `Mode: Create questionnaire (${activeTitle})`;
+      else if (state.viewMode === 'edit') modeLabel.textContent = `Mode: Edit questionnaire (${activeTitle})`;
+      else if (state.viewMode === 'import') modeLabel.textContent = 'Mode: Import questionnaire';
+      else modeLabel.textContent = 'Workspace';
+    }
+    if (activeLabel) {
+      activeLabel.textContent = hasActive ? `Editing: ${activeTitle}` : 'No questionnaire selected';
+    }
   }
 
   function normalizeStatusValue(value) {
@@ -1110,6 +1200,8 @@ const Builder = (() => {
     applyFocusMode();
     renderDeleteButton();
     renderDestroyButton();
+    renderWorkspaceContext();
+    renderReorderModeButton();
     toggleSaveButtons();
     if (!state.dirty && state.lastSavedAt) {
       updateSaveStatus(STRINGS.saveStatusLastSaved || 'Last saved just now');
@@ -1118,6 +1210,15 @@ const Builder = (() => {
       pendingImportFocus = false;
       focusActiveQuestionnaire();
     }
+  }
+
+  function renderReorderModeButton() {
+    const button = document.querySelector(selectors.reorderModeButton);
+    const layout = document.querySelector(selectors.workspaceState);
+    if (layout) layout.classList.toggle('is-reorder-mode', state.reorderMode);
+    if (!button) return;
+    button.textContent = state.reorderMode ? 'Disable reorder mode' : 'Enable reorder mode';
+    button.setAttribute('aria-pressed', state.reorderMode ? 'true' : 'false');
   }
 
   function renderSelector() {
@@ -1303,6 +1404,9 @@ const Builder = (() => {
     const sectionActiveLocked = section.hasResponses || publishedLocked;
     const scoringLocked = publishedLocked;
     const removeLocked = section.hasResponses || publishedLocked;
+    const sectionIndex = questionnaire.sections.findIndex((entry) => entry.clientId === section.clientId);
+    const moveSectionUpDisabled = publishedLocked || sectionIndex <= 0;
+    const moveSectionDownDisabled = publishedLocked || sectionIndex === -1 || sectionIndex >= questionnaire.sections.length - 1;
     const items = section.items.map((item) => buildItemRow(questionnaire, section.clientId, item)).join('');
     const collapsed = isSectionCollapsed(questionnaire, section);
     const sectionLabel = section.title?.trim() || 'Untitled section';
@@ -1337,6 +1441,8 @@ const Builder = (() => {
             ${includeInScoringControl}
           </div>
           <div class="qb-actions">
+            <button type="button" class="md-button md-outline" data-role="move-section-up" ${moveSectionUpDisabled ? 'disabled' : ''} ${publishedLocked ? 'title="' + escapeAttr(scoringReason) + '"' : ''}>Move up</button>
+            <button type="button" class="md-button md-outline" data-role="move-section-down" ${moveSectionDownDisabled ? 'disabled' : ''} ${publishedLocked ? 'title="' + escapeAttr(scoringReason) + '"' : ''}>Move down</button>
             <button type="button" class="md-button md-outline" data-role="remove-section" ${removeLocked ? 'disabled' : ''} ${removeLocked ? 'title="' + escapeAttr(removeSectionReason) + '"' : ''}>Remove section</button>
           </div>
           </div>
@@ -1363,6 +1469,12 @@ const Builder = (() => {
     const toggleLocked = publishedLocked;
     const activeLocked = item.hasResponses || publishedLocked;
     const removeLocked = item.hasResponses || publishedLocked;
+    const itemCollection = sectionClientId
+      ? (questionnaire.sections.find((section) => section.clientId === sectionClientId)?.items || [])
+      : questionnaire.items;
+    const itemIndex = itemCollection.findIndex((entry) => entry.clientId === item.clientId);
+    const moveItemUpDisabled = publishedLocked || itemIndex <= 0;
+    const moveItemDownDisabled = publishedLocked || itemIndex === -1 || itemIndex >= itemCollection.length - 1;
     const optionsHtml = ['choice', 'likert'].includes(item.type)
       ? buildOptionsEditor(sectionClientId, item, { publishedLocked, lockReason: publishedReason })
       : '';
@@ -1415,6 +1527,8 @@ const Builder = (() => {
               <label class="qb-chip-toggle" ${activeLocked ? 'title="' + escapeAttr(itemResponseReason) + '"' : ''}><input type="checkbox" data-role="item-active" ${item.is_active ? 'checked' : ''} ${activeLocked ? 'disabled' : ''}> Active</label>
             </div>
             <div class="qb-actions qb-item-actions">
+              <button type="button" class="md-button md-outline" data-role="move-item-up" ${moveItemUpDisabled ? 'disabled' : ''} ${publishedLocked ? 'title="' + escapeAttr(publishedReason) + '"' : ''}>Move up</button>
+              <button type="button" class="md-button md-outline" data-role="move-item-down" ${moveItemDownDisabled ? 'disabled' : ''} ${publishedLocked ? 'title="' + escapeAttr(publishedReason) + '"' : ''}>Move down</button>
               <button type="button" class="md-button md-outline" data-role="remove-item" ${removeLocked ? 'disabled' : ''} ${removeLocked ? 'title="' + escapeAttr(itemResponseReason) + '"' : ''}>Remove</button>
             </div>
           </div>
@@ -1700,6 +1814,12 @@ const Builder = (() => {
     applyCompactMode();
   }
 
+  function toggleReorderMode() {
+    state.reorderMode = !state.reorderMode;
+    rememberSet(STORAGE_KEYS.reorderMode, state.reorderMode ? '1' : '0');
+    render();
+  }
+
   function applyCompactMode() {
     const layout = document.querySelector('.qb-manager-layout');
     const button = document.querySelector(selectors.compactModeButton);
@@ -1838,6 +1958,7 @@ const Builder = (() => {
         renderTabs();
         renderSelector();
         renderSectionNav();
+        renderWorkspaceContext();
         break;
       case 'q-description':
         questionnaire.description = event.target.value;
@@ -1925,6 +2046,16 @@ const Builder = (() => {
         removeSection(questionnaire, sectionId);
         break;
       }
+      case 'move-section-up': {
+        const sectionId = event.target.closest('[data-section]')?.getAttribute('data-section');
+        moveSection(questionnaire, sectionId, -1);
+        break;
+      }
+      case 'move-section-down': {
+        const sectionId = event.target.closest('[data-section]')?.getAttribute('data-section');
+        moveSection(questionnaire, sectionId, 1);
+        break;
+      }
       case 'add-item': {
         const sectionId = event.target.getAttribute('data-section') || null;
         addItem(questionnaire, sectionId);
@@ -1934,6 +2065,18 @@ const Builder = (() => {
         const itemId = event.target.closest('[data-item]')?.getAttribute('data-item');
         const sectionId = event.target.closest('[data-section]')?.getAttribute('data-section') || null;
         removeItem(questionnaire, sectionId, itemId);
+        break;
+      }
+      case 'move-item-up': {
+        const itemId = event.target.closest('[data-item]')?.getAttribute('data-item');
+        const sectionId = event.target.closest('[data-section]')?.getAttribute('data-section') || null;
+        moveItem(questionnaire, sectionId, itemId, -1);
+        break;
+      }
+      case 'move-item-down': {
+        const itemId = event.target.closest('[data-item]')?.getAttribute('data-item');
+        const sectionId = event.target.closest('[data-section]')?.getAttribute('data-section') || null;
+        moveItem(questionnaire, sectionId, itemId, 1);
         break;
       }
       case 'add-option': {
@@ -2073,6 +2216,17 @@ const Builder = (() => {
     questionnaire.sections.splice(index, 1);
   }
 
+  function moveSection(questionnaire, sectionClientId, delta) {
+    if (!Number.isInteger(delta) || delta === 0) return;
+    const index = questionnaire.sections.findIndex((s) => s.clientId === sectionClientId);
+    if (index === -1) return;
+    const targetIndex = index + delta;
+    if (targetIndex < 0 || targetIndex >= questionnaire.sections.length) return;
+    rememberReorderUndo(questionnaire.clientId);
+    const [section] = questionnaire.sections.splice(index, 1);
+    questionnaire.sections.splice(targetIndex, 0, section);
+  }
+
   function addItem(questionnaire, sectionClientId) {
     const target = sectionClientId
       ? questionnaire.sections.find((s) => s.clientId === sectionClientId)?.items
@@ -2102,6 +2256,90 @@ const Builder = (() => {
     if (idx === -1) return;
     if (collection[idx].hasResponses) return;
     collection.splice(idx, 1);
+  }
+
+  function moveItem(questionnaire, sectionClientId, itemClientId, delta) {
+    if (!Number.isInteger(delta) || delta === 0) return;
+    const collection = sectionClientId
+      ? questionnaire.sections.find((s) => s.clientId === sectionClientId)?.items
+      : questionnaire.items;
+    if (!collection) return;
+    const index = collection.findIndex((item) => item.clientId === itemClientId);
+    if (index === -1) return;
+    const targetIndex = index + delta;
+    if (targetIndex < 0 || targetIndex >= collection.length) return;
+    rememberReorderUndo(questionnaire.clientId);
+    const [item] = collection.splice(index, 1);
+    collection.splice(targetIndex, 0, item);
+  }
+
+  function buildOrderSnapshot(questionnaire) {
+    return {
+      sections: questionnaire.sections.map((section) => section.clientId),
+      rootItems: questionnaire.items.map((item) => item.clientId),
+      sectionItems: questionnaire.sections.reduce((acc, section) => {
+        acc[section.clientId] = section.items.map((item) => item.clientId);
+        return acc;
+      }, {}),
+    };
+  }
+
+  function rememberReorderUndo(questionnaireClientId) {
+    const questionnaire = state.questionnaires.find((q) => q.clientId === questionnaireClientId);
+    if (!questionnaire) return;
+    state.reorderUndo = {
+      questionnaireClientId,
+      snapshot: buildOrderSnapshot(questionnaire),
+    };
+    showReorderUndoToast();
+  }
+
+  function applyOrderSnapshot(questionnaire, snapshot) {
+    if (!questionnaire || !snapshot) return;
+    const sectionLookup = new Map(questionnaire.sections.map((section) => [section.clientId, section]));
+    const orderedSections = (snapshot.sections || []).map((id) => sectionLookup.get(id)).filter(Boolean);
+    questionnaire.sections = orderedSections.length ? orderedSections : questionnaire.sections;
+
+    const rootLookup = new Map(questionnaire.items.map((item) => [item.clientId, item]));
+    const orderedRootItems = (snapshot.rootItems || []).map((id) => rootLookup.get(id)).filter(Boolean);
+    questionnaire.items = orderedRootItems.length ? orderedRootItems : questionnaire.items;
+
+    questionnaire.sections.forEach((section) => {
+      const itemLookup = new Map(section.items.map((item) => [item.clientId, item]));
+      const ordered = (snapshot.sectionItems?.[section.clientId] || []).map((id) => itemLookup.get(id)).filter(Boolean);
+      if (ordered.length) section.items = ordered;
+    });
+  }
+
+  function showReorderUndoToast() {
+    const toast = document.querySelector(selectors.reorderUndo);
+    if (!toast) return;
+    toast.setAttribute('aria-hidden', 'false');
+    if (state.reorderUndoTimer) window.clearTimeout(state.reorderUndoTimer);
+    state.reorderUndoTimer = window.setTimeout(() => {
+      toast.setAttribute('aria-hidden', 'true');
+      state.reorderUndoTimer = null;
+    }, 7000);
+  }
+
+  function hideReorderUndoToast() {
+    const toast = document.querySelector(selectors.reorderUndo);
+    if (toast) toast.setAttribute('aria-hidden', 'true');
+    if (state.reorderUndoTimer) {
+      window.clearTimeout(state.reorderUndoTimer);
+      state.reorderUndoTimer = null;
+    }
+  }
+
+  function undoLastReorder() {
+    if (!state.reorderUndo) return;
+    const questionnaire = state.questionnaires.find((q) => q.clientId === state.reorderUndo.questionnaireClientId);
+    if (!questionnaire) return;
+    applyOrderSnapshot(questionnaire, state.reorderUndo.snapshot);
+    state.reorderUndo = null;
+    hideReorderUndoToast();
+    markDirty();
+    render();
   }
 
   function findItem(questionnaire, sectionClientId, itemClientId) {
@@ -2363,7 +2601,9 @@ const Builder = (() => {
       Sortable.create(sectionContainer, {
         animation: 150,
         handle: '.qb-section-drag-handle',
+        disabled: !state.reorderMode,
         onEnd: () => {
+          rememberReorderUndo(state.activeKey);
           reorderSections();
           markDirty();
         },
@@ -2379,6 +2619,7 @@ const Builder = (() => {
         },
         animation: 150,
         handle: '.qb-item-drag-handle',
+        disabled: !state.reorderMode,
         onAdd: (event) => {
           if (!event?.from || !event?.to || event.from === event.to) return;
           if (event.item && event.to instanceof HTMLElement) {
@@ -2386,6 +2627,7 @@ const Builder = (() => {
           }
         },
         onEnd: () => {
+          rememberReorderUndo(state.activeKey);
           reorderItems();
           markDirty();
         },


### PR DESCRIPTION
### Motivation
- Improve the questionnaire builder's UX by separating the start/import/workspace states and exposing an import workspace inside the main UI instead of an inline import form. 
- Add safer drag-and-drop reordering and explicit move controls for sections and questions, with an undo mechanism to recover accidental reorders. 
- Make the builder more responsive and surface a mobile recommendation for smaller viewports.

### Description
- Frontend UI/layout: split start and workspace states via `#qb-start-state` and `#qb-workspace-state`, move the import form into a dedicated `#qb-import-workspace` panel, add a mobile recommendation card `#qb-mobile-recommendation`, and add a workspace mode bar and active-questionnaire label (`#qb-workspace-mode-label`, `#qb-active-questionnaire-label`). (changes in `admin/questionnaire_manage.php` and CSS). 
- Reorder mode: introduce `reorder` view state and persistent `reorderMode` flag (`STORAGE_KEYS.reorderMode`), add `#qb-reorder-mode` button and toggle via `toggleReorderMode`/`renderReorderModeButton`, enable/disable `Sortable` drag handles based on `state.reorderMode`, and add explicit `Move up`/`Move down` buttons for sections and items (JS changes in `assets/js/questionnaire-builder.js` and styling in `assets/css/questionnaire-builder.css`). 
- Undo snapshot: capture pre-reorder snapshots with `rememberReorderUndo`/`buildOrderSnapshot`, show undo toast `#qb-reorder-undo`, and implement `undoLastReorder` / `applyOrderSnapshot` to restore ordering and mark the builder dirty. 
- Additional UX/accessibility tweaks: persist mobile recommendation dismissal, adjust many layout and responsive CSS rules (min-width fixes, grid changes, reduced padding, media query adjustments), set `aria-hidden`/`aria-pressed` states for mode changes, and update labels for clearer workspace modes. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd59a39264832d8f5d0969318fe288)