### PR TITLE
Use 'Competency' terminology and update scoring level labels

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1084,11 +1084,11 @@ $formatScore = static function ($score, int $precision = 1): string {
     return number_format((float)$score, $precision);
 };
 
-$formatProficiencyLevel = static function ($score) use ($t): string {
+$formatCompetencyLevel = static function ($score) use ($t): string {
     if ($score === null) {
         return '—';
     }
-    $level = questionnaire_proficiency_level((float)$score);
+    $level = questionnaire_competency_level((float)$score);
     return $level !== '' ? $level : t($t, 'not_available', 'N/A');
 };
 
@@ -1654,7 +1654,7 @@ $pageHelpKey = 'team.analytics';
             <th><?=t($t, 'status_draft', 'Draft')?></th>
             <th><?=t($t, 'status_rejected', 'Rejected')?></th>
             <th><?=t($t, 'average_score', 'Average score (%)')?></th>
-            <th><?=t($t, 'proficiency_level', 'Proficiency level')?></th>
+            <th><?=t($t, 'proficiency_level', 'Competency level')?></th>
           </tr>
         </thead>
         <tbody>
@@ -1672,7 +1672,7 @@ $pageHelpKey = 'team.analytics';
               <td><?= (int)$row['draft_count'] ?></td>
               <td><?= (int)$row['rejected_count'] ?></td>
               <td><?= $formatScore($row['avg_score'] ?? null) ?></td>
-              <td><?=htmlspecialchars($formatProficiencyLevel($row['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
+              <td><?=htmlspecialchars($formatCompetencyLevel($row['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
             </tr>
           <?php endforeach; ?>
         </tbody>
@@ -1701,7 +1701,7 @@ $pageHelpKey = 'team.analytics';
         <p class="md-upgrade-meta">
           <?=t($t, 'selected_summary', 'Average score: ')?>
           <?=$formatScore($selectedAverage)?> ·
-          <?=t($t, 'proficiency_level', 'Proficiency level')?>: <?=htmlspecialchars($formatProficiencyLevel($selectedAverage), ENT_QUOTES, 'UTF-8')?> ·
+          <?=t($t, 'proficiency_level', 'Competency level')?>: <?=htmlspecialchars($formatCompetencyLevel($selectedAverage), ENT_QUOTES, 'UTF-8')?> ·
           <?=t($t, 'approved_responses', 'Approved responses')?>: <?=$selectedAggregate['approved']?> ·
           <?=t($t, 'status_submitted', 'Submitted')?>: <?=$selectedAggregate['submitted']?> ·
           <?=t($t, 'status_draft', 'Draft')?>: <?=$selectedAggregate['draft']?> ·
@@ -1714,7 +1714,7 @@ $pageHelpKey = 'team.analytics';
               <th><?=t($t, 'performance_period', 'Asessment Period')?></th>
               <th><?=t($t, 'status', 'Status')?></th>
               <th><?=t($t, 'score', 'Score (%)')?></th>
-              <th><?=t($t, 'proficiency_level', 'Proficiency level')?></th>
+              <th><?=t($t, 'proficiency_level', 'Competency level')?></th>
               <th><?=t($t, 'date', 'Submitted on')?></th>
               <th><?=t($t, 'review_comment', 'Review comment')?></th>
               <th><?=t($t, 'view', 'View')?></th>
@@ -1733,7 +1733,7 @@ $pageHelpKey = 'team.analytics';
                 <td><?=htmlspecialchars($row['period_label'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars($statusLabels[$statusKey] ?? ucfirst((string)$statusKey), ENT_QUOTES, 'UTF-8')?></td>
                 <td><?= isset($row['score']) && $row['score'] !== null ? (int)$row['score'] : '—' ?></td>
-                <td><?=htmlspecialchars($formatProficiencyLevel($row['score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($formatCompetencyLevel($row['score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars($row['created_at'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars($row['review_comment'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
                 <td><a class="md-button" href="<?=htmlspecialchars(url_for('admin/view_submission.php?id=' . (int)$row['id']), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'open', 'Open')?></a></td>
@@ -1824,7 +1824,7 @@ $pageHelpKey = 'team.analytics';
               <th><?=t($t, 'count', 'Responses')?></th>
               <th><?=t($t, 'approved', 'Approved')?></th>
               <th><?=t($t, 'average_score', 'Average score (%)')?></th>
-              <th><?=t($t, 'proficiency_level', 'Proficiency level')?></th>
+              <th><?=t($t, 'proficiency_level', 'Competency level')?></th>
             </tr>
           </thead>
           <tbody>
@@ -1843,7 +1843,7 @@ $pageHelpKey = 'team.analytics';
                 <td><?= (int)$row['total_responses'] ?></td>
                 <td><?= (int)$row['approved_count'] ?></td>
                 <td><?= $formatScore($row['avg_score'] ?? null) ?></td>
-                <td><?=htmlspecialchars($formatProficiencyLevel($row['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($formatCompetencyLevel($row['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
               </tr>
             <?php endforeach; ?>
           </tbody>

--- a/lang/am.json
+++ b/lang/am.json
@@ -528,7 +528,7 @@
   "prefer_not_say": "ለመናገር አልፈልግም",
   "preferred_language": "የሚመርጡት ቋንቋ",
   "primary_navigation": "ዋና አሰሳ",
-  "proficiency_level": "Proficiency level",
+  "proficiency_level": "Competency level",
   "profile": "መገለጫ",
   "profile_complete": "መገለጫ ተሟል?",
   "profile_information": "የመገለጫ መረጃ",

--- a/lang/en.json
+++ b/lang/en.json
@@ -528,7 +528,7 @@
   "prefer_not_say": "Prefer not to say",
   "preferred_language": "Preferred Language",
   "primary_navigation": "Primary navigation",
-  "proficiency_level": "Proficiency level",
+  "proficiency_level": "Competency level",
   "profile": "Profile",
   "profile_complete": "Profile Complete?",
   "profile_information": "Profile Information",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -528,7 +528,7 @@
   "prefer_not_say": "Je préfère ne pas répondre",
   "preferred_language": "Langue préférée",
   "primary_navigation": "Navigation principale",
-  "proficiency_level": "Proficiency level",
+  "proficiency_level": "Competency level",
   "profile": "Profil",
   "profile_complete": "Profil complet ?",
   "profile_information": "Informations du profil",

--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -363,7 +363,7 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
         ['Draft', analytics_report_format_number($summary['draft_count'] ?? 0)],
         ['Rejected', analytics_report_format_number($summary['rejected_count'] ?? 0)],
         ['Average score', analytics_report_format_score($summary['avg_score'])],
-        ['Average proficiency', questionnaire_proficiency_level(isset($summary['avg_score']) ? (float)$summary['avg_score'] : null) ?: '—'],
+        ['Average competency', questionnaire_competency_level(isset($summary['avg_score']) ? (float)$summary['avg_score'] : null) ?: '—'],
         ['Latest submission', analytics_report_format_date($summary['latest_at'])],
         ['Unique participants', analytics_report_format_number($snapshot['total_participants'] ?? 0)],
     ];
@@ -382,13 +382,13 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
             analytics_report_format_number($row['draft_count'] ?? 0),
             analytics_report_format_number($row['rejected_count'] ?? 0),
             analytics_report_format_score($row['avg_score'] ?? null),
-            questionnaire_proficiency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
+            questionnaire_competency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
         ];
     }
 
     if ($questionnaireRows) {
         $pdf->addTable(
-            ['Questionnaire', 'Total', 'Approved', 'Submitted', 'Draft', 'Rejected', 'Avg', 'Proficiency'],
+            ['Questionnaire', 'Total', 'Approved', 'Submitted', 'Draft', 'Rejected', 'Avg', 'Competency'],
             $questionnaireRows,
             [34, 7, 9, 10, 8, 9, 7, 16]
         );
@@ -404,13 +404,13 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
                 analytics_report_format_number($row['total_responses'] ?? 0),
                 analytics_report_format_number($row['approved_count'] ?? 0),
                 analytics_report_format_score($row['avg_score'] ?? null),
-                questionnaire_proficiency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
+                questionnaire_competency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
             ];
         }
         if ($workRows) {
             $pdf->addSubheading('Performance by work function');
             $pdf->addTable(
-                ['Work function', 'Responses', 'Approved', 'Avg', 'Proficiency'],
+                ['Work function', 'Responses', 'Approved', 'Avg', 'Competency'],
                 $workRows,
                 [30, 12, 12, 10, 14]
             );
@@ -549,11 +549,11 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
                 analytics_report_format_number($row['total_responses'] ?? 0),
                 analytics_report_format_number($row['approved_count'] ?? 0),
                 analytics_report_format_score($row['avg_score'] ?? null),
-                questionnaire_proficiency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
+                questionnaire_competency_level(isset($row['avg_score']) ? (float)$row['avg_score'] : null) ?: '—',
             ];
         }
         $pdf->addTable(
-            ['User', 'Work function', 'Responses', 'Approved', 'Avg score', 'Proficiency'],
+            ['User', 'Work function', 'Responses', 'Approved', 'Avg score', 'Competency'],
             $detailRows,
             [24, 16, 10, 10, 10, 14]
         );

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -213,56 +213,49 @@ function questionnaire_answer_is_correct(array $answerSet, string $correctValue)
 }
 
 /**
- * Resolve a proficiency level label from a score percentage.
+ * Resolve a competency level label from a score percentage.
  */
-function questionnaire_proficiency_level(?float $score): string
+function questionnaire_competency_level(?float $score): string
 {
     if ($score === null) {
         return '';
     }
     if ($score >= 85.0) {
-        return 'Expert';
+        return 'Strategic';
     }
     if ($score >= 70.0) {
-        return 'Strong Proficiency';
-    }
-    if ($score >= 60.0) {
-        return 'Intermediate';
+        return 'Advanced';
     }
     if ($score >= 50.0) {
-        return 'Basic';
+        return 'Essential';
     }
-    return 'Not Proficient';
+    return 'Introductory';
 }
 
 /**
- * Resolve proficiency level and interpretation details for a score percentage.
+ * Resolve competency level and interpretation details for a score percentage.
  *
  * @return array{level:string, interpretation:string}
  */
-function questionnaire_proficiency_details(?float $score): array
+function questionnaire_competency_details(?float $score): array
 {
-    $level = questionnaire_proficiency_level($score);
+    $level = questionnaire_competency_level($score);
     return match ($level) {
-        'Expert' => [
-            'level' => 'Expert',
-            'interpretation' => 'Exceptional mastery; capable of leading complex assignments and mentoring others.',
+        'Strategic' => [
+            'level' => 'Strategic',
+            'interpretation' => 'Shapes direction, drives outcomes, and mentors others in complex scenarios.',
         ],
-        'Strong Proficiency' => [
-            'level' => 'Strong Proficiency',
-            'interpretation' => 'Fully meets expectations; operates independently at the expected level.',
+        'Advanced' => [
+            'level' => 'Advanced',
+            'interpretation' => 'Performs independently and consistently meets role expectations.',
         ],
-        'Intermediate' => [
-            'level' => 'Intermediate',
-            'interpretation' => 'Partial mastery; requires targeted development to reach full proficiency.',
+        'Essential' => [
+            'level' => 'Essential',
+            'interpretation' => 'Demonstrates core capability with some support and targeted development.',
         ],
-        'Basic' => [
-            'level' => 'Basic',
-            'interpretation' => 'Limited understanding; requires close supervision and structured learning.',
-        ],
-        'Not Proficient' => [
-            'level' => 'Not Proficient',
-            'interpretation' => 'Does not meet minimum expectations; needs foundational skill development.',
+        'Introductory' => [
+            'level' => 'Introductory',
+            'interpretation' => 'Building foundational capability and requires structured guidance.',
         ],
         default => [
             'level' => '',

--- a/my_performance.php
+++ b/my_performance.php
@@ -207,11 +207,11 @@ $statusLabels = [
     'rejected' => t($t, 'status_rejected', 'Rejected'),
 ];
 
-$formatProficiencyLevel = static function ($score): string {
+$formatCompetencyLevel = static function ($score): string {
     if ($score === null) {
         return '—';
     }
-    $level = questionnaire_proficiency_level((float)$score);
+    $level = questionnaire_competency_level((float)$score);
     return $level !== '' ? $level : 'N/A';
 };
 
@@ -302,7 +302,7 @@ $pageHelpKey = 'workspace.my_performance';
       <p><?=t($t,'no_trend_data','Submit assessments to generate your performance trend.')?></p>
     <?php endif; ?>
     <table class="md-table">
-      <thead><tr><th><?=t($t,'date','Date')?></th><th><?=t($t,'questionnaire','Questionnaire')?></th><th><?=t($t,'performance_period','Asessment Period')?></th><th><?=t($t,'score','Score (%)')?></th><th><?=t($t,'proficiency_level','Proficiency level')?></th><th><?=t($t,'status','Status')?></th><th><?=t($t,'actions','Actions')?></th></tr></thead>
+      <thead><tr><th><?=t($t,'date','Date')?></th><th><?=t($t,'questionnaire','Questionnaire')?></th><th><?=t($t,'performance_period','Asessment Period')?></th><th><?=t($t,'score','Score (%)')?></th><th><?=t($t,'proficiency_level','Competency level')?></th><th><?=t($t,'status','Status')?></th><th><?=t($t,'actions','Actions')?></th></tr></thead>
       <tbody>
       <?php foreach ($responses as $r): ?>
         <?php
@@ -314,7 +314,7 @@ $pageHelpKey = 'workspace.my_performance';
           <td><?=htmlspecialchars($r['title'])?></td>
           <td><?=htmlspecialchars($r['period_label'])?></td>
           <td><?= is_null($r['score']) ? '-' : (int)$r['score']?></td>
-          <td><?=htmlspecialchars($formatProficiencyLevel($r['score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
+          <td><?=htmlspecialchars($formatCompetencyLevel($r['score'] ?? null), ENT_QUOTES, 'UTF-8')?></td>
           <td><?=htmlspecialchars($statusLabel)?></td>
           <td><span class="md-muted">—</span></td>
         </tr>

--- a/my_performance_download.php
+++ b/my_performance_download.php
@@ -182,8 +182,8 @@ $summaryRows = [
 if ($averageScore !== null) {
     $summaryRows[] = [t($t, 'average_score', 'Average score (%)'), number_format($averageScore, 1)];
     $summaryRows[] = [
-        t($t, 'proficiency_level', 'Proficiency level'),
-        questionnaire_proficiency_level((float) $averageScore),
+        t($t, 'proficiency_level', 'Competency level'),
+        questionnaire_competency_level((float) $averageScore),
     ];
 }
 if ($nextAssessmentDisplay !== '') {
@@ -256,7 +256,7 @@ if ($rows) {
             (string) ($row['title'] ?? ''),
             (string) ($row['period_label'] ?? ''),
             $scoreValue !== null ? number_format($scoreValue, 0) . '%' : '—',
-            $scoreValue !== null ? questionnaire_proficiency_level($scoreValue) : '—',
+            $scoreValue !== null ? questionnaire_competency_level($scoreValue) : '—',
             t($t, 'status_' . ($row['status'] ?? 'submitted'), ucfirst((string) ($row['status'] ?? 'submitted'))),
         ];
     }
@@ -265,7 +265,7 @@ if ($rows) {
         t($t, 'questionnaire', 'Questionnaire'),
         t($t, 'performance_period', 'Asessment Period'),
         t($t, 'score', 'Score (%)'),
-        t($t, 'proficiency_level', 'Proficiency level'),
+        t($t, 'proficiency_level', 'Competency level'),
         t($t, 'status', 'Status'),
     ], $responseRows, [18, 52, 52, 20, 28, 30]);
 } else {


### PR DESCRIPTION
### Motivation
- Replace the term "Proficiency" with "Competency" across analytics, reports and UI to align terminology.
- Update scoring level names and their interpretations to a new competency-based wording.
- Ensure exported PDFs and language files reflect the updated label.

### Description
- Renamed scoring functions and helpers from `questionnaire_proficiency_level`/`questionnaire_proficiency_details` to `questionnaire_competency_level`/`questionnaire_competency_details` and updated their return labels and interpretation text.
- Replaced usages and helper variables (`$formatProficiencyLevel` -> `$formatCompetencyLevel`) across `admin/analytics.php`, `my_performance.php`, `my_performance_download.php`, and `lib/analytics_report.php` so UI tables, summaries and PDFs show the new terminology and values.
- Updated PDF table headers and metric labels in `lib/analytics_report.php` to use "Competency" instead of "Proficiency".
- Adjusted language resource strings in `lang/en.json`, `lang/fr.json`, and `lang/am.json` to change the `proficiency_level` entry value to "Competency level".

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd18769f1c832dbafe90fc5c342cb3)