### PR TITLE
Make builder toolbar sticky and remove Publish action button

### DIFF
--- a/admin/questionnaire_manage.php
+++ b/admin/questionnaire_manage.php
@@ -2495,9 +2495,11 @@ if ($qbJsVersion) {
           <div class="qb-workspace-head-copy">
             <p class="md-overline"><?=t($t, 'qb_workspace_label', 'Workspace')?></p>
             <h3 class="md-card-title"><?=t($t, 'qb_workspace_title', 'Questionnaire editor')?></h3>
-            <p class="md-hint"><?=t($t, 'qb_workspace_hint', 'Build sections and questions here, then preview and publish when checks are ready.')?></p>
+            <p class="md-hint"><?=t($t, 'qb_workspace_hint', 'Build sections and questions here, then preview when checks are ready.')?></p>
             <p class="md-hint qb-active-questionnaire-label" id="qb-active-questionnaire-label"><?=t($t,'qb_active_questionnaire_none','No questionnaire selected')?></p>
           </div>
+        </div>
+        <div class="qb-workspace-controls">
           <div class="qb-workspace-actions">
             <div class="qb-toolbar" aria-label="<?=htmlspecialchars(t($t, 'qb_workspace_actions', 'Workspace actions'), ENT_QUOTES, 'UTF-8')?>">
               <div class="qb-toolbar-actions qb-toolbar-actions--secondary">
@@ -2513,13 +2515,10 @@ if ($qbJsVersion) {
                 <button class="md-button md-outline md-elev-1" id="qb-preview-questionnaire" type="button"><?=t($t,'qb_preview_label','Preview questionnaire')?></button>
                 <button class="md-button md-outline md-elev-1" id="qb-export-questionnaire"><?=t($t,'export_fhir','Export questionnaire')?></button>
               </div>
-              <div class="qb-toolbar-actions">
-                <button class="md-button md-secondary md-elev-2" id="qb-publish" disabled><?=t($t,'publish','Publish')?></button>
-              </div>
             </div>
           </div>
+          <div class="qb-save-status" id="qb-save-status" aria-live="polite"><?=t($t,'qb_unsaved_changes','Unsaved changes')?></div>
         </div>
-        <div class="qb-save-status" id="qb-save-status" aria-live="polite"><?=t($t,'qb_unsaved_changes','Unsaved changes')?></div>
         <div id="qb-message" class="qb-message" role="status" aria-live="polite"></div>
         <div id="qb-reorder-undo" class="qb-reorder-undo" aria-live="polite" aria-hidden="true">
           <span><?=t($t,'qb_reorder_done','Reorder applied.')?></span>

--- a/assets/css/questionnaire-builder.css
+++ b/assets/css/questionnaire-builder.css
@@ -531,6 +531,15 @@
     align-items: stretch;
   }
 
+  .qb-workspace-controls {
+    position: static;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    backdrop-filter: none;
+  }
+
   .qb-toolbar {
     justify-content: flex-start;
   }
@@ -1883,6 +1892,20 @@ body.qb-preview-open {
   min-width: min(100%, 26rem);
 }
 
+.qb-workspace-controls {
+  position: sticky;
+  top: 0.65rem;
+  z-index: 25;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.55rem;
+  border: 1px solid var(--app-border, rgba(0, 0, 0, 0.1));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--app-surface, #fff) 94%, transparent);
+  backdrop-filter: saturate(140%) blur(2px);
+}
+
 
 .qb-danger-zone {
   border-left: 3px solid var(--app-danger, #b3261e);
@@ -1893,6 +1916,7 @@ body.qb-preview-open {
   color: var(--app-muted, rgba(0, 0, 0, 0.65));
   margin-top: 0;
   line-height: 1.2;
+  text-align: right;
 }
 
 .qb-floating-save {


### PR DESCRIPTION
### Motivation
- Keep top builder actions (collapse/expand, modes, preview, export, jump-to) visible while scrolling through long questionnaires to improve usability.
- Reduce wasted vertical space and surface the save status next to the toolbar so users can see controls and status together.
- Align publishing workflow to the `Status` control rather than a top-level `Publish` button to avoid confusion.

### Description
- Add a new `qb-workspace-controls` wrapper in `admin/questionnaire_manage.php` and move the toolbar into it so controls can be separated from the main header.
- Remove the top-level `Publish` button from the builder toolbar in `admin/questionnaire_manage.php` so publishing is performed via status workflows.
- Move the save-status element (`#qb-save-status`) into the new `qb-workspace-controls` container and right-align it for a compact layout.
- Introduce `.qb-workspace-controls` CSS in `assets/css/questionnaire-builder.css` with a `position: sticky` desktop style and a non-sticky mobile override to preserve responsive behavior.

### Testing
- Ran `php -l admin/questionnaire_manage.php` and it reported no syntax errors.
- Ran `git status --short` to confirm the intended files were modified (local workspace verification succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6755bd614832dbce057ca9b3d0dfc)