### PR TITLE
Make 'Check for Upgrade' button use primary styling

### DIFF
--- a/admin/upgrade.php
+++ b/admin/upgrade.php
@@ -670,7 +670,7 @@ $pageHelpKey = 'admin.dashboard';
           <form method="post">
             <input type="hidden" name="csrf" value="<?=csrf_token()?>">
             <input type="hidden" name="action" value="check_upgrade">
-            <button type="submit" class="md-button md-elev-2 md-upgrade-action-button"><?=t($t,'check_for_upgrade','Check for Upgrade')?></button>
+            <button type="submit" class="md-button md-primary md-elev-2 md-upgrade-action-button"><?=t($t,'check_for_upgrade','Check for Upgrade')?></button>
           </form>
           <form method="post" data-upgrade-progress-trigger data-upgrade-progress-message="<?=htmlspecialchars(t($t, 'upgrade_progress_install', 'Installing update. Please keep this page open until the process completes.'), ENT_QUOTES, 'UTF-8')?>">
             <input type="hidden" name="csrf" value="<?=csrf_token()?>">


### PR DESCRIPTION
### Motivation
- Ensure the 'Check for Upgrade' action has the same prominent visual emphasis as the 'Install Upgrade' action for a more consistent and clear admin UI.

### Description
- Add the `md-primary` class to the "Check for Upgrade" submit button in `admin/upgrade.php` so it matches the styling of the install button.

### Testing
- Ran a PHP syntax check with `php -l admin/upgrade.php`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de61e08118832d9e0ed24e4270a466)