### PR TITLE
Add AI integration settings, connection test, and site_config schema

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -94,6 +94,115 @@ if (!function_exists('settings_apply_sql_file')) {
     }
 }
 
+if (!function_exists('settings_ai_test_connection')) {
+    /**
+     * @return array{ok:bool,message:string,response:string}
+     */
+    function settings_ai_test_connection(string $baseUrl, string $apiKey, string $model, int $timeoutSeconds = 20): array
+    {
+        $baseUrl = trim($baseUrl);
+        $model = trim($model);
+        if ($baseUrl === '') {
+            return ['ok' => false, 'message' => 'AI Base URL is required for connection testing.', 'response' => ''];
+        }
+        if ($model === '') {
+            return ['ok' => false, 'message' => 'Chat model is required for connection testing.', 'response' => ''];
+        }
+
+        $normalizedBase = rtrim($baseUrl, '/');
+        $basePath = strtolower(rtrim((string)parse_url($normalizedBase, PHP_URL_PATH), '/'));
+        $endpoint = ($basePath !== '' && str_ends_with($basePath, '/api'))
+            ? $normalizedBase . '/generate'
+            : $normalizedBase . '/api/generate';
+
+        $payload = json_encode([
+            'model' => $model,
+            'prompt' => 'Reply with: OK',
+            'stream' => false,
+            'options' => ['temperature' => 0],
+        ]);
+        if ($payload === false) {
+            return ['ok' => false, 'message' => 'Unable to encode AI test payload.', 'response' => ''];
+        }
+
+        $headers = [
+            'Content-Type: application/json',
+            'Accept: application/json',
+        ];
+        if ($apiKey !== '') {
+            $headers[] = 'Authorization: Bearer ' . $apiKey;
+            $headers[] = 'X-API-Key: ' . $apiKey;
+        }
+
+        $responseBody = '';
+        $statusCode = 0;
+        $errorMessage = '';
+
+        if (function_exists('curl_init')) {
+            $ch = curl_init($endpoint);
+            if ($ch === false) {
+                return ['ok' => false, 'message' => 'Unable to initialize cURL for AI test.', 'response' => ''];
+            }
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_POST, true);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, max(3, min(60, $timeoutSeconds)));
+            curl_setopt($ch, CURLOPT_TIMEOUT, max(5, min(120, $timeoutSeconds)));
+            $raw = curl_exec($ch);
+            if ($raw === false) {
+                $errorMessage = (string)curl_error($ch);
+            } else {
+                $responseBody = (string)$raw;
+            }
+            $statusCode = (int)curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+            curl_close($ch);
+        } else {
+            $context = stream_context_create([
+                'http' => [
+                    'method' => 'POST',
+                    'header' => implode("\r\n", $headers),
+                    'content' => $payload,
+                    'ignore_errors' => true,
+                    'timeout' => max(5, min(120, $timeoutSeconds)),
+                ],
+            ]);
+            $raw = @file_get_contents($endpoint, false, $context);
+            if ($raw === false) {
+                $errorMessage = 'Unable to reach AI endpoint.';
+            } else {
+                $responseBody = (string)$raw;
+            }
+            if (isset($http_response_header) && is_array($http_response_header)) {
+                foreach ($http_response_header as $headerLine) {
+                    if (preg_match('/^HTTP\/\S+\s+(\d{3})/i', $headerLine, $matches)) {
+                        $statusCode = (int)$matches[1];
+                        break;
+                    }
+                }
+            }
+        }
+
+        if ($errorMessage !== '') {
+            return ['ok' => false, 'message' => 'AI test failed: ' . $errorMessage, 'response' => ''];
+        }
+
+        $decoded = json_decode($responseBody, true);
+        $modelReply = '';
+        if (is_array($decoded)) {
+            $modelReply = trim((string)($decoded['response'] ?? $decoded['message']['content'] ?? ''));
+        }
+        $preview = $modelReply !== '' ? $modelReply : substr(trim($responseBody), 0, 240);
+
+        if ($statusCode >= 200 && $statusCode < 300 && $preview !== '') {
+            return ['ok' => true, 'message' => 'AI connection test succeeded.', 'response' => $preview];
+        }
+
+        $statusText = $statusCode > 0 ? ('HTTP ' . $statusCode) : 'no HTTP status';
+        return ['ok' => false, 'message' => 'AI test failed (' . $statusText . ').', 'response' => $preview];
+    }
+}
+
 try {
     require_once __DIR__ . '/../config.php';
     auth_required(['admin']);
@@ -130,6 +239,7 @@ try {
         csrf_check();
 
         $demoDatasetAction = trim((string)($_POST['demo_dataset_action'] ?? ''));
+        $aiConnectionAction = trim((string)($_POST['ai_connection_action'] ?? ''));
         if (in_array($demoDatasetAction, ['enable', 'disable'], true)) {
             try {
                 $pdo->beginTransaction();
@@ -182,6 +292,36 @@ try {
             $smtp_timeout = 20;
         }
 
+        $ai_enabled = isset($_POST['ai_enabled']) ? 1 : 0;
+        $ai_provider = strtolower(trim((string)($_POST['ai_provider'] ?? 'ollama')));
+        if (!in_array($ai_provider, ['ollama'], true)) {
+            $ai_provider = 'ollama';
+        }
+        $ai_base_url = trim((string)($_POST['ai_base_url'] ?? ''));
+        $ai_api_key_input = trim((string)($_POST['ai_api_key'] ?? ''));
+        $ai_api_key = $ai_api_key_input !== '' ? $ai_api_key_input : (string)($cfg['ai_api_key'] ?? '');
+        $ai_model_chat = trim((string)($_POST['ai_model_chat'] ?? ''));
+        $ai_model_fast = trim((string)($_POST['ai_model_fast'] ?? ''));
+        $ai_model_fallback = trim((string)($_POST['ai_model_fallback'] ?? ''));
+
+        $ai_feature_summary_enabled = isset($_POST['ai_feature_summary_enabled']) ? 1 : 0;
+        $ai_feature_devplan_enabled = isset($_POST['ai_feature_devplan_enabled']) ? 1 : 0;
+        $ai_feature_course_rationale_enabled = isset($_POST['ai_feature_course_rationale_enabled']) ? 1 : 0;
+        $ai_placement_supervisor_review = isset($_POST['ai_placement_supervisor_review']) ? 1 : 0;
+        $ai_placement_admin_analytics = isset($_POST['ai_placement_admin_analytics']) ? 1 : 0;
+
+        $ai_timeout_seconds = max(5, min(120, (int)($_POST['ai_timeout_seconds'] ?? 20)));
+        $ai_max_output_tokens = max(100, min(4000, (int)($_POST['ai_max_output_tokens'] ?? 700)));
+        $ai_temperature = (float)($_POST['ai_temperature'] ?? 0.2);
+        if (!is_finite($ai_temperature)) {
+            $ai_temperature = 0.2;
+        }
+        $ai_temperature = max(0.0, min(1.0, $ai_temperature));
+        $ai_retry_count = max(0, min(2, (int)($_POST['ai_retry_count'] ?? 1)));
+        $ai_require_human_approval = isset($_POST['ai_require_human_approval']) ? 1 : 0;
+        $ai_show_generated_badge = isset($_POST['ai_show_generated_badge']) ? 1 : 0;
+        $ai_pii_redaction_enabled = isset($_POST['ai_pii_redaction_enabled']) ? 1 : 0;
+
         $enabledLocalesInput = $_POST['enabled_locales'] ?? [];
         if (!is_array($enabledLocalesInput)) {
             $enabledLocalesInput = [];
@@ -189,6 +329,27 @@ try {
         $selectedLocales = sanitize_locale_selection($enabledLocalesInput);
         if (!array_intersect($selectedLocales, ['en', 'fr'])) {
             $errors[] = t($t, 'language_required_notice', 'At least English or French must remain enabled.');
+        }
+
+        $aiFeaturesSelected = $ai_feature_summary_enabled === 1
+            || $ai_feature_devplan_enabled === 1
+            || $ai_feature_course_rationale_enabled === 1;
+        if ($aiConnectionAction !== 'test') {
+            if ($ai_enabled === 1) {
+                if ($ai_base_url === '') {
+                    $errors[] = t($t, 'ai_base_url_required', 'AI Base URL is required when AI features are enabled.');
+                } else {
+                    $scheme = strtolower((string)parse_url($ai_base_url, PHP_URL_SCHEME));
+                    if (!in_array($scheme, ['http', 'https'], true)) {
+                        $errors[] = t($t, 'ai_base_url_invalid', 'AI Base URL must start with http:// or https://.');
+                    }
+                }
+                if (!$aiFeaturesSelected) {
+                    $errors[] = t($t, 'ai_feature_required', 'Enable at least one AI feature when AI is enabled.');
+                }
+            } elseif ($aiFeaturesSelected) {
+                $errors[] = t($t, 'ai_enable_required', 'Enable AI before turning on AI features.');
+            }
         }
 
         $emailTemplatesInput = $_POST['email_templates'] ?? [];
@@ -231,66 +392,96 @@ try {
             'review_enabled' => $review_enabled,
             'qb_danger_zone_enabled' => $qb_danger_zone_enabled,
             'email_templates' => encode_email_templates($emailTemplates),
+            'ai_enabled' => $ai_enabled,
+            'ai_provider' => $ai_provider,
+            'ai_base_url' => $ai_base_url !== '' ? $ai_base_url : null,
+            'ai_api_key' => $ai_api_key !== '' ? $ai_api_key : null,
+            'ai_model_chat' => $ai_model_chat !== '' ? $ai_model_chat : null,
+            'ai_model_fast' => $ai_model_fast !== '' ? $ai_model_fast : null,
+            'ai_model_fallback' => $ai_model_fallback !== '' ? $ai_model_fallback : null,
+            'ai_feature_summary_enabled' => $ai_feature_summary_enabled,
+            'ai_feature_devplan_enabled' => $ai_feature_devplan_enabled,
+            'ai_feature_course_rationale_enabled' => $ai_feature_course_rationale_enabled,
+            'ai_placement_supervisor_review' => $ai_placement_supervisor_review,
+            'ai_placement_admin_analytics' => $ai_placement_admin_analytics,
+            'ai_timeout_seconds' => $ai_timeout_seconds,
+            'ai_max_output_tokens' => $ai_max_output_tokens,
+            'ai_temperature' => number_format($ai_temperature, 2, '.', ''),
+            'ai_retry_count' => $ai_retry_count,
+            'ai_require_human_approval' => $ai_require_human_approval,
+            'ai_show_generated_badge' => $ai_show_generated_badge,
+            'ai_pii_redaction_enabled' => $ai_pii_redaction_enabled,
         ];
 
-        $siteConfigColumns = site_config_available_columns($pdo);
-        $reviewColumnAvailable = isset($siteConfigColumns['review_enabled']);
-        if (!$reviewColumnAvailable) {
+        if ($aiConnectionAction === 'test') {
+            $testResult = settings_ai_test_connection($ai_base_url, $ai_api_key, $ai_model_chat, $ai_timeout_seconds);
+            if ($testResult['ok']) {
+                $msg = t($t, 'ai_connection_test_success', 'AI connection test succeeded.') . ' ' . sprintf(
+                    t($t, 'ai_connection_test_response', 'Sample response: %s'),
+                    $testResult['response']
+                );
+            } else {
+                $errors[] = $testResult['message'] . ($testResult['response'] !== '' ? ' ' . $testResult['response'] : '');
+            }
+            $cfg = array_merge($cfg, $fields);
+            $enabledLocales = enforce_locale_requirements($selectedLocales);
+            $emailTemplates = normalize_email_templates($emailTemplates);
+        } else {
             ensure_site_config_schema($pdo);
             $siteConfigColumns = site_config_available_columns($pdo, true);
             $reviewColumnAvailable = isset($siteConfigColumns['review_enabled']);
-        }
 
-        foreach (array_keys($fields) as $column) {
-            if (!isset($siteConfigColumns[$column])) {
-                if ($column === 'review_enabled') {
-                    $errors[] = t($t, 'review_column_missing_notice', 'The review workflow setting could not be saved because the database is missing the required column. Please run the latest upgrade script and try again.');
-                }
-                unset($fields[$column]);
-            }
-        }
-
-        if ($fields === []) {
-            $errors[] = t($t, 'settings_missing_columns_notice', 'Settings could not be saved because the configuration table is missing required columns.');
-        }
-
-        if ($errors === []) {
-            $enabledLocales = enforce_locale_requirements($selectedLocales);
-            $fields['enabled_locales'] = encode_enabled_locales($enabledLocales);
-
-            $values = [];
-            foreach ($fields as $column => $value) {
-                $values[] = ($value !== '') ? $value : null;
-            }
-
-            $columns = array_keys($fields);
-            $placeholders = implode(', ', array_fill(0, count($columns), '?'));
-            $updates = [];
-            foreach ($columns as $column) {
-                $updates[] = "$column=VALUES($column)";
-            }
-
-            $sql = 'INSERT INTO site_config (id, ' . implode(', ', $columns) . ') VALUES (1, ' . $placeholders . ') ON DUPLICATE KEY UPDATE ' . implode(', ', $updates);
-            $stm = $pdo->prepare($sql);
-            $stm->execute($values);
-            $autoApproveNotice = '';
-            if ($reviewColumnAvailable && $previousReviewEnabled && $review_enabled === 0) {
-                try {
-                    $autoApproved = $pdo->exec("UPDATE questionnaire_response SET status='approved', reviewed_by=NULL, reviewed_at=NOW(), review_comment=NULL WHERE status='submitted'");
-                    if (is_int($autoApproved) && $autoApproved > 0) {
-                        $autoApproveNotice = ' ' . t($t, 'auto_approve_notice', 'Pending submissions were automatically approved.');
+            foreach (array_keys($fields) as $column) {
+                if (!isset($siteConfigColumns[$column])) {
+                    if ($column === 'review_enabled') {
+                        $errors[] = t($t, 'review_column_missing_notice', 'The review workflow setting could not be saved because the database is missing the required column. Please run the latest upgrade script and try again.');
                     }
-                } catch (PDOException $e) {
-                    error_log('auto-approve pending submissions failed: ' . $e->getMessage());
-                    $errors[] = t($t, 'auto_approve_failed', 'Settings saved, but pending submissions could not be finalized automatically.');
+                    unset($fields[$column]);
                 }
             }
-            if ($errors === []) {
-                $msg = t($t, 'settings_updated', 'Settings updated successfully.') . $autoApproveNotice;
+
+            if ($fields === []) {
+                $errors[] = t($t, 'settings_missing_columns_notice', 'Settings could not be saved because the configuration table is missing required columns.');
             }
-            $cfg = get_site_config($pdo);
-            $enabledLocales = site_enabled_locales($cfg);
-            $emailTemplates = normalize_email_templates($cfg['email_templates'] ?? []);
+
+            if ($errors === []) {
+                $enabledLocales = enforce_locale_requirements($selectedLocales);
+                $fields['enabled_locales'] = encode_enabled_locales($enabledLocales);
+
+                $values = [];
+                foreach ($fields as $column => $value) {
+                    $values[] = ($value !== '') ? $value : null;
+                }
+
+                $columns = array_keys($fields);
+                $placeholders = implode(', ', array_fill(0, count($columns), '?'));
+                $updates = [];
+                foreach ($columns as $column) {
+                    $updates[] = "$column=VALUES($column)";
+                }
+
+                $sql = 'INSERT INTO site_config (id, ' . implode(', ', $columns) . ') VALUES (1, ' . $placeholders . ') ON DUPLICATE KEY UPDATE ' . implode(', ', $updates);
+                $stm = $pdo->prepare($sql);
+                $stm->execute($values);
+                $autoApproveNotice = '';
+                if ($reviewColumnAvailable && $previousReviewEnabled && $review_enabled === 0) {
+                    try {
+                        $autoApproved = $pdo->exec("UPDATE questionnaire_response SET status='approved', reviewed_by=NULL, reviewed_at=NOW(), review_comment=NULL WHERE status='submitted'");
+                        if (is_int($autoApproved) && $autoApproved > 0) {
+                            $autoApproveNotice = ' ' . t($t, 'auto_approve_notice', 'Pending submissions were automatically approved.');
+                        }
+                    } catch (PDOException $e) {
+                        error_log('auto-approve pending submissions failed: ' . $e->getMessage());
+                        $errors[] = t($t, 'auto_approve_failed', 'Settings saved, but pending submissions could not be finalized automatically.');
+                    }
+                }
+                if ($errors === []) {
+                    $msg = t($t, 'settings_updated', 'Settings updated successfully.') . $autoApproveNotice;
+                }
+                $cfg = get_site_config($pdo);
+                $enabledLocales = site_enabled_locales($cfg);
+                $emailTemplates = normalize_email_templates($cfg['email_templates'] ?? []);
+            }
         }
         if ($errors !== []) {
             $enabledLocales = $selectedLocales;
@@ -458,6 +649,85 @@ $pageHelpKey = 'admin.settings';
       <label class="md-field"><span><?=t($t,'smtp_from_email','From Email')?></span><input name="smtp_from_email" value="<?=htmlspecialchars($cfg['smtp_from_email'] ?? '')?>"></label>
       <label class="md-field"><span><?=t($t,'smtp_from_name','From Name')?></span><input name="smtp_from_name" value="<?=htmlspecialchars($cfg['smtp_from_name'] ?? '')?>"></label>
       <label class="md-field"><span><?=t($t,'smtp_timeout','Connection Timeout (seconds)')?></span><input type="number" name="smtp_timeout" min="5" value="<?=htmlspecialchars((string)($cfg['smtp_timeout'] ?? 20))?>"></label>
+      <h3 class="md-subhead">
+        <?=t($t,'ai_settings_heading','AI Integration')?>
+        <?=render_help_icon(t($t,'ai_settings_hint','Connect an AI provider and control which AI capabilities are available in each part of the platform.'))?>
+      </h3>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_enabled" value="1" <?=((int)($cfg['ai_enabled'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_enable_master','Enable AI features')?></span>
+        </label>
+      </div>
+      <label class="md-field"><span><?=t($t,'ai_provider','AI Provider')?></span>
+        <?php $aiProvider = strtolower((string)($cfg['ai_provider'] ?? 'ollama')); ?>
+        <select name="ai_provider">
+          <option value="ollama" <?=$aiProvider==='ollama'?'selected':''?>>Ollama</option>
+        </select>
+      </label>
+      <label class="md-field"><span><?=t($t,'ai_base_url','AI Base URL')?></span><input name="ai_base_url" placeholder="https://ai.example.com" value="<?=htmlspecialchars((string)($cfg['ai_base_url'] ?? ''))?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_api_key','AI API Key')?></span><input type="password" name="ai_api_key" placeholder="<?=htmlspecialchars(t($t,'leave_blank_keep_password','Leave blank to keep current password.'), ENT_QUOTES, 'UTF-8')?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_model_chat','Chat Model')?></span><input name="ai_model_chat" placeholder="llama3.1:8b" value="<?=htmlspecialchars((string)($cfg['ai_model_chat'] ?? ''))?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_model_fast','Fast Model')?></span><input name="ai_model_fast" placeholder="phi3:mini" value="<?=htmlspecialchars((string)($cfg['ai_model_fast'] ?? ''))?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_model_fallback','Fallback Model')?></span><input name="ai_model_fallback" placeholder="llama3.2:3b" value="<?=htmlspecialchars((string)($cfg['ai_model_fallback'] ?? ''))?>"></label>
+      <h4 class="md-subhead"><?=t($t,'ai_features_heading','AI Features')?></h4>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_feature_summary_enabled" value="1" <?=((int)($cfg['ai_feature_summary_enabled'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_feature_summary','Assessment response summary')?></span>
+        </label>
+      </div>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_feature_devplan_enabled" value="1" <?=((int)($cfg['ai_feature_devplan_enabled'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_feature_devplan','Draft development plan')?></span>
+        </label>
+      </div>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_feature_course_rationale_enabled" value="1" <?=((int)($cfg['ai_feature_course_rationale_enabled'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_feature_course_rationale','Training recommendation rationale')?></span>
+        </label>
+      </div>
+      <h4 class="md-subhead"><?=t($t,'ai_placements_heading','AI Placements')?></h4>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_placement_supervisor_review" value="1" <?=((int)($cfg['ai_placement_supervisor_review'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_placement_supervisor_review','Supervisor review pages')?></span>
+        </label>
+      </div>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_placement_admin_analytics" value="1" <?=((int)($cfg['ai_placement_admin_analytics'] ?? 0) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_placement_admin_analytics','Admin analytics pages')?></span>
+        </label>
+      </div>
+      <h4 class="md-subhead"><?=t($t,'ai_runtime_heading','AI Runtime & Safety')?></h4>
+      <label class="md-field"><span><?=t($t,'ai_timeout_seconds','Timeout (seconds)')?></span><input type="number" name="ai_timeout_seconds" min="5" max="120" value="<?=htmlspecialchars((string)($cfg['ai_timeout_seconds'] ?? 20))?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_max_output_tokens','Max output tokens')?></span><input type="number" name="ai_max_output_tokens" min="100" max="4000" value="<?=htmlspecialchars((string)($cfg['ai_max_output_tokens'] ?? 700))?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_temperature','Temperature')?></span><input type="number" name="ai_temperature" min="0" max="1" step="0.01" value="<?=htmlspecialchars((string)($cfg['ai_temperature'] ?? '0.20'))?>"></label>
+      <label class="md-field"><span><?=t($t,'ai_retry_count','Retry count')?></span><input type="number" name="ai_retry_count" min="0" max="2" value="<?=htmlspecialchars((string)($cfg['ai_retry_count'] ?? 1))?>"></label>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_require_human_approval" value="1" <?=((int)($cfg['ai_require_human_approval'] ?? 1) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_require_human_approval','Require human approval for AI-generated output')?></span>
+        </label>
+      </div>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_show_generated_badge" value="1" <?=((int)($cfg['ai_show_generated_badge'] ?? 1) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_show_generated_badge','Display "AI-generated" indicator in the UI')?></span>
+        </label>
+      </div>
+      <div class="md-control">
+        <label>
+          <input type="checkbox" name="ai_pii_redaction_enabled" value="1" <?=((int)($cfg['ai_pii_redaction_enabled'] ?? 1) === 1) ? 'checked' : ''?>>
+          <span><?=t($t,'ai_pii_redaction_enabled','Enable PII redaction before model requests')?></span>
+        </label>
+      </div>
+      <div class="md-form-actions" style="justify-content:flex-start;">
+        <button class="md-button md-secondary" type="submit" name="ai_connection_action" value="test"><?=t($t,'ai_test_connection','Test AI Connection')?></button>
+      </div>
       <h3 class="md-subhead"><?=t($t,'email_template_settings','Email Templates')?></h3>
       <p class="md-help-note"><?=t($t,'email_template_settings_hint','Customize the subject and HTML content for outgoing notification emails. You can use hyperlinks and the placeholders listed for each template.')?></p>
       <?php foreach ($emailTemplateDefinitions as $key => $meta): ?>

--- a/config.php
+++ b/config.php
@@ -546,7 +546,26 @@ function ensure_site_config_schema(PDO $pdo): void {
         'upgrade_repo' => 'ALTER TABLE site_config ADD COLUMN upgrade_repo VARCHAR(255) NULL',
         'review_enabled' => 'ALTER TABLE site_config ADD COLUMN review_enabled TINYINT(1) NOT NULL DEFAULT 1',
         'qb_danger_zone_enabled' => 'ALTER TABLE site_config ADD COLUMN qb_danger_zone_enabled TINYINT(1) NOT NULL DEFAULT 1',
-        'email_templates' => 'ALTER TABLE site_config ADD COLUMN email_templates LONGTEXT NULL'
+        'email_templates' => 'ALTER TABLE site_config ADD COLUMN email_templates LONGTEXT NULL',
+        'ai_enabled' => 'ALTER TABLE site_config ADD COLUMN ai_enabled TINYINT(1) NOT NULL DEFAULT 0',
+        'ai_provider' => "ALTER TABLE site_config ADD COLUMN ai_provider VARCHAR(50) NOT NULL DEFAULT 'ollama'",
+        'ai_base_url' => 'ALTER TABLE site_config ADD COLUMN ai_base_url VARCHAR(255) NULL',
+        'ai_api_key' => 'ALTER TABLE site_config ADD COLUMN ai_api_key VARCHAR(255) NULL',
+        'ai_model_chat' => 'ALTER TABLE site_config ADD COLUMN ai_model_chat VARCHAR(128) NULL',
+        'ai_model_fast' => 'ALTER TABLE site_config ADD COLUMN ai_model_fast VARCHAR(128) NULL',
+        'ai_model_fallback' => 'ALTER TABLE site_config ADD COLUMN ai_model_fallback VARCHAR(128) NULL',
+        'ai_feature_summary_enabled' => 'ALTER TABLE site_config ADD COLUMN ai_feature_summary_enabled TINYINT(1) NOT NULL DEFAULT 0',
+        'ai_feature_devplan_enabled' => 'ALTER TABLE site_config ADD COLUMN ai_feature_devplan_enabled TINYINT(1) NOT NULL DEFAULT 0',
+        'ai_feature_course_rationale_enabled' => 'ALTER TABLE site_config ADD COLUMN ai_feature_course_rationale_enabled TINYINT(1) NOT NULL DEFAULT 0',
+        'ai_placement_supervisor_review' => 'ALTER TABLE site_config ADD COLUMN ai_placement_supervisor_review TINYINT(1) NOT NULL DEFAULT 0',
+        'ai_placement_admin_analytics' => 'ALTER TABLE site_config ADD COLUMN ai_placement_admin_analytics TINYINT(1) NOT NULL DEFAULT 0',
+        'ai_timeout_seconds' => 'ALTER TABLE site_config ADD COLUMN ai_timeout_seconds INT NOT NULL DEFAULT 20',
+        'ai_max_output_tokens' => 'ALTER TABLE site_config ADD COLUMN ai_max_output_tokens INT NOT NULL DEFAULT 700',
+        'ai_temperature' => 'ALTER TABLE site_config ADD COLUMN ai_temperature DECIMAL(3,2) NOT NULL DEFAULT 0.20',
+        'ai_retry_count' => 'ALTER TABLE site_config ADD COLUMN ai_retry_count INT NOT NULL DEFAULT 1',
+        'ai_require_human_approval' => 'ALTER TABLE site_config ADD COLUMN ai_require_human_approval TINYINT(1) NOT NULL DEFAULT 1',
+        'ai_show_generated_badge' => 'ALTER TABLE site_config ADD COLUMN ai_show_generated_badge TINYINT(1) NOT NULL DEFAULT 1',
+        'ai_pii_redaction_enabled' => 'ALTER TABLE site_config ADD COLUMN ai_pii_redaction_enabled TINYINT(1) NOT NULL DEFAULT 1'
     ];
 
     foreach ($schema as $field => $sql) {
@@ -736,6 +755,25 @@ function site_config_defaults(): array
         'review_enabled' => 1,
         'qb_danger_zone_enabled' => 1,
         'email_templates' => default_email_templates(),
+        'ai_enabled' => 0,
+        'ai_provider' => 'ollama',
+        'ai_base_url' => null,
+        'ai_api_key' => null,
+        'ai_model_chat' => null,
+        'ai_model_fast' => null,
+        'ai_model_fallback' => null,
+        'ai_feature_summary_enabled' => 0,
+        'ai_feature_devplan_enabled' => 0,
+        'ai_feature_course_rationale_enabled' => 0,
+        'ai_placement_supervisor_review' => 0,
+        'ai_placement_admin_analytics' => 0,
+        'ai_timeout_seconds' => 20,
+        'ai_max_output_tokens' => 700,
+        'ai_temperature' => '0.20',
+        'ai_retry_count' => 1,
+        'ai_require_human_approval' => 1,
+        'ai_show_generated_badge' => 1,
+        'ai_pii_redaction_enabled' => 1,
     ];
 }
 


### PR DESCRIPTION
### Motivation

- Introduce configurable AI integration so administrators can enable AI features, configure provider/model/runtime options, and test connectivity from the admin settings UI.

### Description

- Add a helper `settings_ai_test_connection` that posts a minimal test payload to an Ollama-compatible endpoint using `curl` or `file_get_contents` and returns a structured result for the UI.
- Extend `admin/settings.php` to expose numerous AI settings in the settings form, validate user input, support a dedicated `ai_connection_action=test` flow, and persist AI fields into `site_config` when saving.
- Update configuration helpers by adding AI schema changes to `ensure_site_config_schema`, new `site_config_defaults` entries for all `ai_*` columns, and include the new columns in available-columns checks before saving.
- Add UI controls for provider, base URL, API key, model selections, feature toggles, placements, runtime/safety parameters, and a `Test AI Connection` button in the settings page.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8fb872eac832d8f5ddc98ddd6c254)