### PR TITLE
Add competency reporting schema, bands, user fields, scoring helpers, tests and docs

### DIFF
--- a/config.php
+++ b/config.php
@@ -627,6 +627,7 @@ function initialize_database_schema(PDO $pdo): void
     ensure_questionnaire_assignment_schema($pdo);
     ensure_annual_performance_periods($pdo);
     ensure_analytics_report_schedule_schema($pdo);
+    ensure_competency_reporting_schema($pdo);
 
     $schemaInitialized = true;
 }
@@ -1076,6 +1077,8 @@ function ensure_users_schema(PDO $pdo): void
         'work_experience_profile' => 'ALTER TABLE users ADD COLUMN work_experience_profile VARCHAR(255) NULL AFTER highest_degree_subject',
         'total_work_experience_band' => 'ALTER TABLE users ADD COLUMN total_work_experience_band VARCHAR(50) NULL AFTER work_experience_profile',
         'epss_work_experience_band' => 'ALTER TABLE users ADD COLUMN epss_work_experience_band VARCHAR(50) NULL AFTER total_work_experience_band',
+        'business_role' => 'ALTER TABLE users ADD COLUMN business_role VARCHAR(100) NULL AFTER profile_role_other',
+        'directorate' => 'ALTER TABLE users ADD COLUMN directorate VARCHAR(150) NULL AFTER department',
     ];
 
     foreach ($changes as $field => $sql) {
@@ -1086,6 +1089,64 @@ function ensure_users_schema(PDO $pdo): void
                 error_log(sprintf('ensure_users_schema add column %s failed: %s', $field, $e->getMessage()));
             }
         }
+    }
+}
+
+function ensure_competency_reporting_schema(PDO $pdo): void
+{
+    try {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS competency_level_band (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(100) NOT NULL,
+            min_pct DECIMAL(5,2) NOT NULL,
+            max_pct DECIMAL(5,2) NOT NULL,
+            rank_order INT NOT NULL DEFAULT 0,
+            is_system_default TINYINT(1) NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_competency_level_band_name (name),
+            UNIQUE KEY uniq_competency_level_band_rank (rank_order)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS competency_benchmark_policy (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            scope_type ENUM('organization','department','business_role','work_function','competency') NOT NULL DEFAULT 'organization',
+            scope_id VARCHAR(150) NULL,
+            required_pct DECIMAL(5,2) NOT NULL DEFAULT 80.00,
+            effective_from DATE NULL,
+            effective_to DATE NULL,
+            created_by INT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_benchmark_scope (scope_type, scope_id),
+            KEY idx_benchmark_effective (effective_from, effective_to)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        $seedBands = [
+            ['Not Proficient', 0.00, 49.99, 1],
+            ['Basic Proficiency', 50.00, 64.99, 2],
+            ['Intermediate Proficiency', 65.00, 79.99, 3],
+            ['Advanced Proficiency', 80.00, 89.99, 4],
+            ['Expert', 90.00, 100.00, 5],
+        ];
+        $bandStmt = $pdo->prepare(
+            'INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default) '
+            . 'VALUES (?, ?, ?, ?, 1) '
+            . 'ON DUPLICATE KEY UPDATE min_pct = VALUES(min_pct), max_pct = VALUES(max_pct), rank_order = VALUES(rank_order)'
+        );
+        foreach ($seedBands as $band) {
+            $bandStmt->execute($band);
+        }
+
+        $orgBenchmark = $pdo->query("SELECT id FROM competency_benchmark_policy WHERE scope_type='organization' AND (scope_id IS NULL OR scope_id='') LIMIT 1");
+        if (!$orgBenchmark || !$orgBenchmark->fetch(PDO::FETCH_ASSOC)) {
+            $insertBenchmark = $pdo->prepare(
+                "INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct, effective_from, effective_to, created_by) VALUES ('organization', NULL, 80.00, NULL, NULL, NULL)"
+            );
+            $insertBenchmark->execute();
+        }
+    } catch (PDOException $e) {
+        error_log('ensure_competency_reporting_schema: ' . $e->getMessage());
     }
 }
 

--- a/docs/analytics_reporting_role_based_change_plan.md
+++ b/docs/analytics_reporting_role_based_change_plan.md
@@ -1,0 +1,206 @@
+# Analytics Reporting Change Plan (Role-Based)
+
+## 1) Current-state analysis from CAS codebase
+
+The current analytics implementation already provides:
+
+- Aggregate response metrics and score averages from `questionnaire_response`.
+- Work-role (`work_function`) and department-level rollups.
+- Heatmap-style charts for questionnaire and work-role performance.
+- PDF export support and analytics download endpoints.
+
+However, the current implementation is not yet aligned to the full reporting template requested (Executive Summary + role-hierarchical views + benchmark-driven gap prioritization + lock/finalization workflow). In particular, role taxonomy used by users (`admin`, `supervisor`, `staff`) differs from template roles (Director, Manager, Team Leader, Staff, Hub level), and analytics classification bands are not centrally defined as a governance object.
+
+## 2) Target reporting model (mapped to requested template)
+
+Implement reporting as **three layers**:
+
+1. **Global Organizational Layer**
+   - Executive Summary, organization averages, top strengths, top gaps.
+   - Competency level bands (system-controlled and immutable by non-admin users).
+
+2. **Dimensional Drill-down Layer**
+   - Department/directorate analysis.
+   - Role-based analysis (Director, Manager, Team Leader, Staff, Hub).
+   - Work-role analysis (existing `work_function`) retained as a cross-cut dimension.
+
+3. **Entity Layer**
+   - Individual profile cards.
+   - Benchmark comparison against required target (default 80%, configurable).
+   - Action recommendation and follow-up tracking.
+
+## 3) Required data-model and schema updates
+
+### 3.1 Role taxonomy harmonization
+
+Add normalized fields to map user access role from business reporting role:
+
+- `users.access_role` (existing semantics: admin/supervisor/staff).
+- `users.business_role` (new: director, manager, team_leader, staff, hub).
+- `users.directorate` (new optional text or FK table).
+
+This avoids breaking authorization while enabling the requested role-based reporting.
+
+### 3.2 Competency-level configuration table
+
+Create `competency_level_band`:
+
+- `name` (Not Proficient, Basic, Intermediate, Advanced, Expert)
+- `min_pct`, `max_pct`
+- `rank_order`
+- `is_system_default`
+
+Rules:
+
+- Only admin may edit.
+- Every report snapshot stores the band definitions used at generation time.
+
+### 3.3 Benchmark and gap policies
+
+Create `competency_benchmark_policy`:
+
+- `scope_type` (organization/department/business_role/work_function/competency)
+- `scope_id` (nullable)
+- `required_pct`
+- `effective_from`, `effective_to`
+
+Gap formula should support both policies already described in the template:
+
+- `gap = 100 - actual`
+- `gap = required - actual`
+
+## 4) Reporting computation changes
+
+### 4.1 Snapshot architecture
+
+Introduce `analytics_report_snapshot_v2` and detail tables:
+
+- Store immutable, timestamped report runs.
+- Include assessment period, participant counts, score aggregates, and generated insights.
+- Lock snapshot after finalization to satisfy “Lock report after submission”.
+
+### 4.2 Auto-generated sections (template conformance)
+
+Generate and persist sections 1–13 from the requested template:
+
+- Executive summary with top 3 strengths/gaps.
+- Methodology block (constant text + mapping metadata).
+- Participant overview by role, department, gender.
+- Org dashboard and department/role tables with level and gap.
+- Critical gaps ranking (threshold <60 and below benchmark).
+- Benchmark comparison matrices.
+- Strategic recommendations with deterministic rules:
+  - `<60`: training
+  - `60–75`: coaching
+  - `>85`: mentorship candidate
+
+### 4.3 Duplicate prevention alignment
+
+Reinforce duplicate-submission protections in report eligibility logic:
+
+- Exclude duplicate/invalid submissions from analytics aggregates.
+- Add report diagnostics section listing excluded rows count for auditability.
+
+## 5) Role-based access and visibility matrix
+
+Define explicit scope filters by viewer role:
+
+- **Admin**: full organization + all drill-down filters.
+- **Supervisor/Directorate lead**: only assigned directorate/department and subordinate business roles.
+- **Manager/Team Leader**: own teams/work roles + anonymized peer comparison.
+- **Staff**: individual profile + department average benchmark only.
+
+Apply this matrix consistently to:
+
+- On-screen analytics views.
+- PDF/Excel exports.
+- API endpoints used for dashboard queries.
+
+## 6) UI/UX and export changes
+
+### 6.1 Filter panel
+
+Extend analytics filters to include:
+
+- Role (business_role)
+- Work Role (`work_function`)
+- Directorate
+- Department
+- Individual
+- Assessment period
+
+### 6.2 Visualizations
+
+Add/upgrade:
+
+- Department heatmap (score and gap shading).
+- Role comparison bars.
+- Critical-gap priority table with traffic-light severity.
+- Progress tracking trend for follow-up periods.
+
+### 6.3 Export
+
+- PDF and Excel must include filter metadata and snapshot ID.
+- Export should reflect the same row-level access restrictions as UI.
+
+## 7) Implementation phases
+
+### Phase 1 — Foundations (1 sprint)
+
+- Add schema fields/tables (`business_role`, directorate, level bands, benchmark policy).
+- Add migration + seed defaults.
+- Add server-side classification helper service.
+
+### Phase 2 — Computation + snapshot engine (1 sprint)
+
+- Build report snapshot v2 generator.
+- Add gap policy engine and top-N rankings.
+- Add lock/finalize workflow + audit trail.
+
+### Phase 3 — UI + exports (1 sprint)
+
+- Add filter controls and new report sections.
+- Add department/role charts and critical gap panel.
+- Update PDF/Excel renderers.
+
+### Phase 4 — hardening + rollout (1 sprint)
+
+- Role-scope security tests.
+- Data quality checks (null score handling, duplicate suppression).
+- UAT signoff with sample template outputs.
+
+## 8) Testing strategy
+
+1. **Unit tests**
+   - Level-band classification boundaries.
+   - Gap calculation modes.
+   - Recommendation logic thresholds.
+
+2. **Integration tests**
+   - Snapshot generation with seeded data.
+   - Role-filter enforcement per access role.
+   - Export parity (UI totals == PDF/Excel totals).
+
+3. **Regression tests**
+   - Existing analytics heatmaps continue to render.
+   - Legacy admin analytics endpoints remain backward-compatible.
+
+4. **UAT acceptance tests**
+   - Validate each requested section (1–13) against expected sample output.
+
+## 9) Risks and mitigations
+
+- **Role vocabulary mismatch**: keep access role vs business role separate.
+- **Historical comparability drift**: persist level bands and benchmarks per snapshot.
+- **Performance under multi-filter queries**: add covering indexes for period/department/business_role/work_function.
+- **Governance drift**: enforce admin-only control over level/benchmark settings.
+
+## 10) Deliverables checklist
+
+- [ ] DB migration scripts.
+- [ ] Snapshot v2 backend service.
+- [ ] Role-scope authorization matrix implementation.
+- [ ] Updated analytics UI with required filters/charts.
+- [ ] PDF/Excel export updates.
+- [ ] Automated tests + UAT evidence package.
+

--- a/init.sql
+++ b/init.sql
@@ -72,10 +72,12 @@ CREATE TABLE users (
   date_of_birth DATE NULL,
   phone VARCHAR(50) NULL,
   department VARCHAR(150) NULL,
+  directorate VARCHAR(150) NULL,
   cadre VARCHAR(150) NULL,
   work_function VARCHAR(100) DEFAULT NULL,
   profile_role VARCHAR(100) NULL,
   profile_role_other VARCHAR(200) NULL,
+  business_role VARCHAR(100) NULL,
   job_grade VARCHAR(50) NULL,
   education_level VARCHAR(50) NULL,
   highest_degree_subject VARCHAR(200) NULL,
@@ -218,6 +220,33 @@ CREATE TABLE questionnaire_work_function (
   FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE competency_level_band (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  min_pct DECIMAL(5,2) NOT NULL,
+  max_pct DECIMAL(5,2) NOT NULL,
+  rank_order INT NOT NULL DEFAULT 0,
+  is_system_default TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_competency_level_band_name (name),
+  UNIQUE KEY uniq_competency_level_band_rank (rank_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE competency_benchmark_policy (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  scope_type ENUM('organization','department','business_role','work_function','competency') NOT NULL DEFAULT 'organization',
+  scope_id VARCHAR(150) NULL,
+  required_pct DECIMAL(5,2) NOT NULL DEFAULT 80.00,
+  effective_from DATE NULL,
+  effective_to DATE NULL,
+  created_by INT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_benchmark_scope (scope_type, scope_id),
+  KEY idx_benchmark_effective (effective_from, effective_to)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE work_function_catalog (
   slug VARCHAR(100) NOT NULL PRIMARY KEY,
   label VARCHAR(255) NOT NULL,
@@ -245,6 +274,16 @@ INSERT INTO work_function_catalog (slug, label, sort_order) VALUES
   ('security_driver', 'Security & Driver Management', 16),
   ('tmd', 'Training & Mentorship Development', 17),
   ('wim', 'Warehouse & Inventory Management', 18);
+
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default) VALUES
+  ('Not Proficient', 0.00, 49.99, 1, 1),
+  ('Basic Proficiency', 50.00, 64.99, 2, 1),
+  ('Intermediate Proficiency', 65.00, 79.99, 3, 1),
+  ('Advanced Proficiency', 80.00, 89.99, 4, 1),
+  ('Expert', 90.00, 100.00, 5, 1);
+
+INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct, effective_from, effective_to, created_by)
+VALUES ('organization', NULL, 80.00, NULL, NULL, NULL);
 
 CREATE TABLE questionnaire_assignment (
   staff_id INT NOT NULL,

--- a/lib/competency_framework.php
+++ b/lib/competency_framework.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Default competency level bands used when no database override exists.
+ *
+ * @return array<int, array{name:string,min_pct:float,max_pct:float,rank_order:int}>
+ */
+function competency_default_level_bands(): array
+{
+    return [
+        ['name' => 'Not Proficient', 'min_pct' => 0.0, 'max_pct' => 49.99, 'rank_order' => 1],
+        ['name' => 'Basic Proficiency', 'min_pct' => 50.0, 'max_pct' => 64.99, 'rank_order' => 2],
+        ['name' => 'Intermediate Proficiency', 'min_pct' => 65.0, 'max_pct' => 79.99, 'rank_order' => 3],
+        ['name' => 'Advanced Proficiency', 'min_pct' => 80.0, 'max_pct' => 89.99, 'rank_order' => 4],
+        ['name' => 'Expert', 'min_pct' => 90.0, 'max_pct' => 100.0, 'rank_order' => 5],
+    ];
+}
+
+/**
+ * Evaluate a competency level label for a percentage score.
+ *
+ * @param array<int, array{name:string,min_pct:float,max_pct:float}> $bands
+ */
+function competency_level_from_bands(?float $score, array $bands): string
+{
+    if ($score === null) {
+        return '';
+    }
+
+    $normalizedScore = max(0.0, min(100.0, (float)$score));
+    foreach ($bands as $band) {
+        $min = isset($band['min_pct']) ? (float)$band['min_pct'] : 0.0;
+        $max = isset($band['max_pct']) ? (float)$band['max_pct'] : 0.0;
+        if ($normalizedScore >= $min && $normalizedScore <= $max) {
+            return (string)($band['name'] ?? '');
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Compute competency gap.
+ *
+ * When benchmark is null, uses 100 - score.
+ * When benchmark is provided, uses benchmark - score.
+ */
+function competency_gap(?float $score, ?float $benchmark = null): ?float
+{
+    if ($score === null) {
+        return null;
+    }
+
+    $normalizedScore = max(0.0, min(100.0, (float)$score));
+    if ($benchmark === null) {
+        return round(100.0 - $normalizedScore, 1);
+    }
+
+    $normalizedBenchmark = max(0.0, min(100.0, (float)$benchmark));
+    return round($normalizedBenchmark - $normalizedScore, 1);
+}
+
+/**
+ * Rule-based recommendation text from the reporting template.
+ */
+function competency_recommendation(?float $score): string
+{
+    if ($score === null) {
+        return '';
+    }
+    if ($score < 60.0) {
+        return 'Recommend training';
+    }
+    if ($score <= 75.0) {
+        return 'Recommend coaching';
+    }
+    if ($score > 85.0) {
+        return 'Consider mentorship role';
+    }
+    return 'Maintain current development plan';
+}

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -1,4 +1,6 @@
 <?php
+
+require_once __DIR__ . '/competency_framework.php';
 /**
  * Helper functions for questionnaire scoring calculations.
  */
@@ -217,19 +219,7 @@ function questionnaire_answer_is_correct(array $answerSet, string $correctValue)
  */
 function questionnaire_competency_level(?float $score): string
 {
-    if ($score === null) {
-        return '';
-    }
-    if ($score >= 85.0) {
-        return 'Strategic';
-    }
-    if ($score >= 70.0) {
-        return 'Advanced';
-    }
-    if ($score >= 50.0) {
-        return 'Essential';
-    }
-    return 'Introductory';
+    return competency_level_from_bands($score, competency_default_level_bands());
 }
 
 /**
@@ -241,25 +231,39 @@ function questionnaire_competency_details(?float $score): array
 {
     $level = questionnaire_competency_level($score);
     return match ($level) {
-        'Strategic' => [
-            'level' => 'Strategic',
-            'interpretation' => 'Shapes direction, drives outcomes, and mentors others in complex scenarios.',
+        'Expert' => [
+            'level' => 'Expert',
+            'interpretation' => 'Consistently demonstrates mastery and can guide others.',
         ],
-        'Advanced' => [
-            'level' => 'Advanced',
-            'interpretation' => 'Performs independently and consistently meets role expectations.',
+        'Advanced Proficiency' => [
+            'level' => 'Advanced Proficiency',
+            'interpretation' => 'Performs independently and consistently exceeds most role expectations.',
         ],
-        'Essential' => [
-            'level' => 'Essential',
-            'interpretation' => 'Demonstrates core capability with some support and targeted development.',
+        'Intermediate Proficiency' => [
+            'level' => 'Intermediate Proficiency',
+            'interpretation' => 'Shows reliable capability with periodic coaching in complex tasks.',
         ],
-        'Introductory' => [
-            'level' => 'Introductory',
-            'interpretation' => 'Building foundational capability and requires structured guidance.',
+        'Basic Proficiency' => [
+            'level' => 'Basic Proficiency',
+            'interpretation' => 'Has foundational capability and benefits from targeted support.',
+        ],
+        'Not Proficient' => [
+            'level' => 'Not Proficient',
+            'interpretation' => 'Requires substantial development support and structured learning.',
         ],
         default => [
             'level' => '',
             'interpretation' => '',
         ],
     };
+}
+
+function questionnaire_competency_gap(?float $score, ?float $benchmark = null): ?float
+{
+    return competency_gap($score, $benchmark);
+}
+
+function questionnaire_competency_recommendation(?float $score): string
+{
+    return competency_recommendation($score);
 }

--- a/migration.sql
+++ b/migration.sql
@@ -1387,3 +1387,86 @@ SET @qi_condition_value_sql = IF(
 PREPARE stmt FROM @qi_condition_value_sql;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
+
+SET @users_business_role_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND COLUMN_NAME = 'business_role'
+);
+SET @users_business_role_sql = IF(
+  @users_business_role_exists = 0,
+  'ALTER TABLE users ADD COLUMN business_role VARCHAR(100) NULL AFTER profile_role_other',
+  'DO 1'
+);
+PREPARE stmt FROM @users_business_role_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @users_directorate_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND COLUMN_NAME = 'directorate'
+);
+SET @users_directorate_sql = IF(
+  @users_directorate_exists = 0,
+  'ALTER TABLE users ADD COLUMN directorate VARCHAR(150) NULL AFTER department',
+  'DO 1'
+);
+PREPARE stmt FROM @users_directorate_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS competency_level_band (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  min_pct DECIMAL(5,2) NOT NULL,
+  max_pct DECIMAL(5,2) NOT NULL,
+  rank_order INT NOT NULL DEFAULT 0,
+  is_system_default TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_competency_level_band_name (name),
+  UNIQUE KEY uniq_competency_level_band_rank (rank_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS competency_benchmark_policy (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  scope_type ENUM('organization','department','business_role','work_function','competency') NOT NULL DEFAULT 'organization',
+  scope_id VARCHAR(150) NULL,
+  required_pct DECIMAL(5,2) NOT NULL DEFAULT 80.00,
+  effective_from DATE NULL,
+  effective_to DATE NULL,
+  created_by INT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_benchmark_scope (scope_type, scope_id),
+  KEY idx_benchmark_effective (effective_from, effective_to)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Not Proficient', 0.00, 49.99, 1, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Not Proficient');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Basic Proficiency', 50.00, 64.99, 2, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Basic Proficiency');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Intermediate Proficiency', 65.00, 79.99, 3, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Intermediate Proficiency');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Advanced Proficiency', 80.00, 89.99, 4, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Advanced Proficiency');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Expert', 90.00, 100.00, 5, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Expert');
+
+INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct, effective_from, effective_to, created_by)
+SELECT 'organization', NULL, 80.00, NULL, NULL, NULL
+WHERE NOT EXISTS (
+  SELECT 1 FROM competency_benchmark_policy
+  WHERE scope_type = 'organization'
+    AND (scope_id IS NULL OR scope_id = '')
+);

--- a/tests/competency_framework_test.php
+++ b/tests/competency_framework_test.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/competency_framework.php';
+require_once __DIR__ . '/../lib/scoring.php';
+
+$bands = competency_default_level_bands();
+if (count($bands) !== 5) {
+    fwrite(STDERR, "Expected five default competency bands.\n");
+    exit(1);
+}
+
+$cases = [
+    [49.0, 'Not Proficient'],
+    [50.0, 'Basic Proficiency'],
+    [65.0, 'Intermediate Proficiency'],
+    [80.0, 'Advanced Proficiency'],
+    [95.0, 'Expert'],
+];
+
+foreach ($cases as $case) {
+    [$score, $expected] = $case;
+    $actual = questionnaire_competency_level($score);
+    if ($actual !== $expected) {
+        fwrite(STDERR, sprintf("Expected %s for score %.1f but received %s.\n", $expected, $score, $actual));
+        exit(1);
+    }
+}
+
+if (questionnaire_competency_gap(72.0, null) !== 28.0) {
+    fwrite(STDERR, "Expected 100-based gap to equal 28.0.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_gap(72.0, 80.0) !== 8.0) {
+    fwrite(STDERR, "Expected benchmark gap to equal 8.0.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_recommendation(59.0) !== 'Recommend training') {
+    fwrite(STDERR, "Expected training recommendation for low scores.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_recommendation(70.0) !== 'Recommend coaching') {
+    fwrite(STDERR, "Expected coaching recommendation for mid scores.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_recommendation(90.0) !== 'Consider mentorship role') {
+    fwrite(STDERR, "Expected mentorship recommendation for high scores.\n");
+    exit(1);
+}
+
+echo "Competency framework tests passed.\n";


### PR DESCRIPTION
### Motivation

- Introduce a competency reporting foundation to support role-based analytics, benchmarks and level bands required by the new reporting template.
- Add user-level fields to support a business reporting role taxonomy without breaking existing access semantics.

### Description

- Add DB schema and seeding for competency reporting by creating `competency_level_band` and `competency_benchmark_policy` and seeding default bands and an organization benchmark in `init.sql`, `migration.sql`, and runtime via `ensure_competency_reporting_schema` in `config.php`.
- Add new user fields `business_role` and `directorate` to `init.sql`, `migration.sql`, and the runtime schema migration in `ensure_users_schema` to enable role-based filtering.
- Add `lib/competency_framework.php` implementing default bands, level resolution, gap calculation and recommendation rules, and wire it into `lib/scoring.php` to replace hard-coded level logic and expose `questionnaire_competency_gap` and `questionnaire_competency_recommendation` helpers.
- Add a design/implementation plan `docs/analytics_reporting_role_based_change_plan.md` describing the target reporting model, data model, UI and rollout phases.

### Testing

- Ran the competency unit test `php tests/competency_framework_test.php`, which exercises band resolution, gap calculation, and recommendations, and it passed (`Competency framework tests passed.`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6243cab74832d900081637854b55e)