### PR TITLE
Add role-based competency reporting and Analytics Snapshot v2 (schema, backend, UI, export, tests)

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -1474,6 +1474,11 @@ $pageHelpKey = 'team.analytics';
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'analytics_download_reports', 'Download default reports')?></h2>
     <p><?=t($t, 'analytics_download_reports_hint', 'Quickly download PDF snapshots for offline sharing.')?></p>
+    <p>
+      <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics_snapshot_v2.php'), ENT_QUOTES, 'UTF-8')?>">
+        <?=t($t, 'analytics_snapshot_v2_open', 'Open snapshot workspace')?>
+      </a>
+    </p>
     <div class="md-download-grid">
       <?php foreach ($defaultReportDownloads as $download): ?>
         <div class="md-download-card">

--- a/admin/analytics_snapshot_v2.php
+++ b/admin/analytics_snapshot_v2.php
@@ -18,6 +18,11 @@ if (isset($_SESSION['analytics_snapshot_v2_flash']) && is_array($_SESSION['analy
 }
 
 $questionnaireId = isset($_GET['questionnaire_id']) ? max(0, (int)$_GET['questionnaire_id']) : 0;
+$selectedBusinessRole = isset($_GET['business_role']) ? trim((string)$_GET['business_role']) : '';
+$selectedDirectorate = isset($_GET['directorate']) ? trim((string)$_GET['directorate']) : '';
+$selectedWorkFunction = isset($_GET['work_function']) ? trim((string)$_GET['work_function']) : '';
+$selectedUserId = isset($_GET['user_id']) ? max(0, (int)$_GET['user_id']) : 0;
+
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf'] ?? '')) {
         http_response_code(400);
@@ -30,7 +35,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $qid = isset($_POST['questionnaire_id']) ? (int)$_POST['questionnaire_id'] : 0;
             $qid = $qid > 0 ? $qid : null;
             $generatedBy = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : null;
-            $snapshot = analytics_snapshot_v2_generate($pdo, $qid, $generatedBy);
+            $filters = [
+                'business_role' => trim((string)($_POST['business_role'] ?? '')),
+                'directorate' => trim((string)($_POST['directorate'] ?? '')),
+                'work_function' => trim((string)($_POST['work_function'] ?? '')),
+                'user_id' => max(0, (int)($_POST['user_id'] ?? 0)),
+            ];
+            $snapshot = analytics_snapshot_v2_generate($pdo, $qid, $generatedBy, $filters);
             $_SESSION['analytics_snapshot_v2_flash'] = [
                 'ok' => t($t, 'analytics_snapshot_v2_generated', 'Snapshot generated successfully.')
                     . (!empty($snapshot['snapshot_id']) ? ' #' . (int)$snapshot['snapshot_id'] : ''),
@@ -65,9 +76,46 @@ if ($qStmt) {
     $questionnaires = $qStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
 }
 
+$businessRoleOptions = [];
+$directorateOptions = [];
+$workFunctionOptions = [];
+$userOptions = [];
+
+$roleStmt = $pdo->query("SELECT DISTINCT COALESCE(NULLIF(business_role, ''), NULLIF(profile_role, ''), 'Unspecified') AS role_label FROM users ORDER BY role_label ASC");
+if ($roleStmt) {
+    foreach ($roleStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $value = trim((string)($row['role_label'] ?? ''));
+        if ($value !== '') {
+            $businessRoleOptions[] = $value;
+        }
+    }
+}
+$directorateStmt = $pdo->query("SELECT DISTINCT COALESCE(NULLIF(directorate, ''), 'Unknown') AS directorate_label FROM users ORDER BY directorate_label ASC");
+if ($directorateStmt) {
+    foreach ($directorateStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $value = trim((string)($row['directorate_label'] ?? ''));
+        if ($value !== '') {
+            $directorateOptions[] = $value;
+        }
+    }
+}
+$workFunctionStmt = $pdo->query("SELECT DISTINCT COALESCE(NULLIF(work_function, ''), 'Unspecified') AS wf_label FROM users ORDER BY wf_label ASC");
+if ($workFunctionStmt) {
+    foreach ($workFunctionStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $value = trim((string)($row['wf_label'] ?? ''));
+        if ($value !== '') {
+            $workFunctionOptions[] = $value;
+        }
+    }
+}
+$userStmt = $pdo->query("SELECT id, COALESCE(NULLIF(full_name,''), username) AS display_name FROM users ORDER BY display_name ASC LIMIT 500");
+if ($userStmt) {
+    $userOptions = $userStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+}
+
 $snapshots = [];
 if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
-    $sql = 'SELECT id, questionnaire_id, generated_by, status, locked, summary_json, generated_at, finalized_at '
+    $sql = 'SELECT id, questionnaire_id, generated_by, status, locked, filters_json, summary_json, generated_at, finalized_at '
         . 'FROM analytics_report_snapshot_v2 ';
     $params = [];
     if ($questionnaireId > 0) {
@@ -86,8 +134,24 @@ foreach ($questionnaires as $q) {
 }
 
 $csvHref = url_for('admin/analytics_snapshot_v2_export.php');
+$csvParams = [];
 if ($questionnaireId > 0) {
-    $csvHref .= '?questionnaire_id=' . $questionnaireId;
+    $csvParams[] = 'questionnaire_id=' . $questionnaireId;
+}
+if ($selectedBusinessRole !== '') {
+    $csvParams[] = 'business_role=' . rawurlencode($selectedBusinessRole);
+}
+if ($selectedDirectorate !== '') {
+    $csvParams[] = 'directorate=' . rawurlencode($selectedDirectorate);
+}
+if ($selectedWorkFunction !== '') {
+    $csvParams[] = 'work_function=' . rawurlencode($selectedWorkFunction);
+}
+if ($selectedUserId > 0) {
+    $csvParams[] = 'user_id=' . $selectedUserId;
+}
+if ($csvParams) {
+    $csvHref .= '?' . implode('&', $csvParams);
 }
 ?>
 <!doctype html>
@@ -125,6 +189,43 @@ if ($questionnaireId > 0) {
           <?php endforeach; ?>
         </select>
       </label>
+      <label class="md-field">
+        <span><?=t($t, 'role', 'Role')?></span>
+        <select name="business_role">
+          <option value=""><?=t($t, 'all_roles', 'All roles')?></option>
+          <?php foreach ($businessRoleOptions as $value): ?>
+            <option value="<?=htmlspecialchars($value, ENT_QUOTES, 'UTF-8')?>" <?=$selectedBusinessRole === $value ? 'selected' : ''?>><?=htmlspecialchars($value, ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'directorate', 'Directorate')?></span>
+        <select name="directorate">
+          <option value=""><?=t($t, 'all_directorates', 'All directorates')?></option>
+          <?php foreach ($directorateOptions as $value): ?>
+            <option value="<?=htmlspecialchars($value, ENT_QUOTES, 'UTF-8')?>" <?=$selectedDirectorate === $value ? 'selected' : ''?>><?=htmlspecialchars($value, ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'work_function', 'Work Role')?></span>
+        <select name="work_function">
+          <option value=""><?=t($t, 'all_work_roles', 'All work roles')?></option>
+          <?php foreach ($workFunctionOptions as $value): ?>
+            <option value="<?=htmlspecialchars($value, ENT_QUOTES, 'UTF-8')?>" <?=$selectedWorkFunction === $value ? 'selected' : ''?>><?=htmlspecialchars($value, ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'individual', 'Individual')?></span>
+        <select name="user_id">
+          <option value="0"><?=t($t, 'all_individuals', 'All individuals')?></option>
+          <?php foreach ($userOptions as $u): ?>
+            <?php $uid = (int)($u['id'] ?? 0); ?>
+            <option value="<?=$uid?>" <?=$selectedUserId === $uid ? 'selected' : ''?>><?=htmlspecialchars((string)($u['display_name'] ?? ('#' . $uid)), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
       <button class="md-button md-primary md-elev-2"><?=t($t, 'generate_snapshot', 'Generate snapshot')?></button>
       <a class="md-button" href="<?=htmlspecialchars($csvHref, ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'export_csv', 'Export CSV')?></a>
     </form>
@@ -145,6 +246,7 @@ if ($questionnaireId > 0) {
               <th><?=t($t, 'average_score', 'Average score (%)')?></th>
               <th><?=t($t, 'competency_level', 'Competency level')?></th>
               <th><?=t($t, 'generated_at', 'Generated at')?></th>
+              <th><?=t($t, 'filters', 'Filters')?></th>
               <th><?=t($t, 'actions', 'Actions')?></th>
             </tr>
           </thead>
@@ -152,9 +254,15 @@ if ($questionnaireId > 0) {
             <?php foreach ($snapshots as $row): ?>
               <?php
                 $summary = json_decode((string)($row['summary_json'] ?? '{}'), true);
+                $filters = json_decode((string)($row['filters_json'] ?? '{}'), true);
                 $avg = isset($summary['average_score']) ? round((float)$summary['average_score'], 1) : null;
                 $level = (string)($summary['competency_level'] ?? '—');
                 $qid = (int)($row['questionnaire_id'] ?? 0);
+                $filterParts = [];
+                if (!empty($filters['business_role'])) { $filterParts[] = 'Role: ' . (string)$filters['business_role']; }
+                if (!empty($filters['directorate'])) { $filterParts[] = 'Directorate: ' . (string)$filters['directorate']; }
+                if (!empty($filters['work_function'])) { $filterParts[] = 'Work role: ' . (string)$filters['work_function']; }
+                if (!empty($filters['user_id'])) { $filterParts[] = 'User ID: ' . (int)$filters['user_id']; }
               ?>
               <tr>
                 <td><?= (int)($row['id'] ?? 0) ?></td>
@@ -163,6 +271,7 @@ if ($questionnaireId > 0) {
                 <td><?= $avg === null ? '—' : htmlspecialchars((string)$avg, ENT_QUOTES, 'UTF-8') ?></td>
                 <td><?=htmlspecialchars($level !== '' ? $level : '—', ENT_QUOTES, 'UTF-8')?></td>
                 <td><?=htmlspecialchars((string)($row['generated_at'] ?? ''), ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($filterParts ? implode(' · ', $filterParts) : t($t, 'all', 'All'), ENT_QUOTES, 'UTF-8')?></td>
                 <td>
                   <?php if (empty($row['locked'])): ?>
                     <form method="post" style="display:inline;">

--- a/admin/analytics_snapshot_v2.php
+++ b/admin/analytics_snapshot_v2.php
@@ -5,6 +5,9 @@ require_once __DIR__ . '/../lib/analytics_snapshot_v2.php';
 auth_required(['admin', 'supervisor']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);
+$viewer = current_user();
+$viewerRole = (string)($viewer['role'] ?? ($_SESSION['user']['role'] ?? ''));
+$viewerId = (int)($viewer['id'] ?? ($_SESSION['user']['id'] ?? 0));
 
 $locale = ensure_locale();
 $t = load_lang($locale);
@@ -18,10 +21,17 @@ if (isset($_SESSION['analytics_snapshot_v2_flash']) && is_array($_SESSION['analy
 }
 
 $questionnaireId = isset($_GET['questionnaire_id']) ? max(0, (int)$_GET['questionnaire_id']) : 0;
-$selectedBusinessRole = isset($_GET['business_role']) ? trim((string)$_GET['business_role']) : '';
-$selectedDirectorate = isset($_GET['directorate']) ? trim((string)$_GET['directorate']) : '';
-$selectedWorkFunction = isset($_GET['work_function']) ? trim((string)$_GET['work_function']) : '';
-$selectedUserId = isset($_GET['user_id']) ? max(0, (int)$_GET['user_id']) : 0;
+$requestedFilters = analytics_snapshot_v2_normalize_filters([
+    'business_role' => $_GET['business_role'] ?? '',
+    'directorate' => $_GET['directorate'] ?? '',
+    'work_function' => $_GET['work_function'] ?? '',
+    'user_id' => $_GET['user_id'] ?? 0,
+]);
+$effectiveFilters = analytics_snapshot_v2_apply_viewer_scope($viewer, $requestedFilters);
+$selectedBusinessRole = $effectiveFilters['business_role'];
+$selectedDirectorate = $effectiveFilters['directorate'];
+$selectedWorkFunction = $effectiveFilters['work_function'];
+$selectedUserId = $effectiveFilters['user_id'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf'] ?? '')) {
@@ -35,12 +45,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $qid = isset($_POST['questionnaire_id']) ? (int)$_POST['questionnaire_id'] : 0;
             $qid = $qid > 0 ? $qid : null;
             $generatedBy = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : null;
-            $filters = [
+            $requestedPostFilters = [
                 'business_role' => trim((string)($_POST['business_role'] ?? '')),
                 'directorate' => trim((string)($_POST['directorate'] ?? '')),
                 'work_function' => trim((string)($_POST['work_function'] ?? '')),
                 'user_id' => max(0, (int)($_POST['user_id'] ?? 0)),
             ];
+            $filters = analytics_snapshot_v2_apply_viewer_scope($viewer, $requestedPostFilters);
             $snapshot = analytics_snapshot_v2_generate($pdo, $qid, $generatedBy, $filters);
             $_SESSION['analytics_snapshot_v2_flash'] = [
                 'ok' => t($t, 'analytics_snapshot_v2_generated', 'Snapshot generated successfully.')
@@ -112,6 +123,9 @@ $userStmt = $pdo->query("SELECT id, COALESCE(NULLIF(full_name,''), username) AS 
 if ($userStmt) {
     $userOptions = $userStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
 }
+if ($viewerRole === 'supervisor' && $selectedDirectorate !== '') {
+    $directorateOptions = [$selectedDirectorate];
+}
 
 $snapshots = [];
 if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
@@ -125,7 +139,19 @@ if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
     $sql .= 'ORDER BY generated_at DESC, id DESC LIMIT 50';
     $stmt = $pdo->prepare($sql);
     $stmt->execute($params);
-    $snapshots = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    $snapshotRows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+    foreach ($snapshotRows as $row) {
+        if ($viewerRole !== 'supervisor') {
+            $snapshots[] = $row;
+            continue;
+        }
+        $filters = json_decode((string)($row['filters_json'] ?? '{}'), true);
+        $rowDirectorate = trim((string)($filters['directorate'] ?? ''));
+        $generatedBy = (int)($row['generated_by'] ?? 0);
+        if ($generatedBy === $viewerId || ($selectedDirectorate !== '' && $rowDirectorate === $selectedDirectorate)) {
+            $snapshots[] = $row;
+        }
+    }
 }
 
 $questionnaireMap = [];

--- a/admin/analytics_snapshot_v2.php
+++ b/admin/analytics_snapshot_v2.php
@@ -1,0 +1,188 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/analytics_snapshot_v2.php';
+
+auth_required(['admin', 'supervisor']);
+refresh_current_user($pdo);
+require_profile_completion($pdo);
+
+$locale = ensure_locale();
+$t = load_lang($locale);
+$drawerKey = 'team.analytics';
+$pageTitle = t($t, 'analytics_snapshot_v2_title', 'Analytics Snapshot v2');
+
+$flash = ['ok' => '', 'error' => ''];
+if (isset($_SESSION['analytics_snapshot_v2_flash']) && is_array($_SESSION['analytics_snapshot_v2_flash'])) {
+    $flash = array_merge($flash, $_SESSION['analytics_snapshot_v2_flash']);
+    unset($_SESSION['analytics_snapshot_v2_flash']);
+}
+
+$questionnaireId = isset($_GET['questionnaire_id']) ? max(0, (int)$_GET['questionnaire_id']) : 0;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf'] ?? '')) {
+        http_response_code(400);
+        exit('invalid csrf');
+    }
+
+    $action = (string)($_POST['action'] ?? '');
+    try {
+        if ($action === 'generate') {
+            $qid = isset($_POST['questionnaire_id']) ? (int)$_POST['questionnaire_id'] : 0;
+            $qid = $qid > 0 ? $qid : null;
+            $generatedBy = isset($_SESSION['user']['id']) ? (int)$_SESSION['user']['id'] : null;
+            $snapshot = analytics_snapshot_v2_generate($pdo, $qid, $generatedBy);
+            $_SESSION['analytics_snapshot_v2_flash'] = [
+                'ok' => t($t, 'analytics_snapshot_v2_generated', 'Snapshot generated successfully.')
+                    . (!empty($snapshot['snapshot_id']) ? ' #' . (int)$snapshot['snapshot_id'] : ''),
+                'error' => '',
+            ];
+        } elseif ($action === 'finalize') {
+            $snapshotId = isset($_POST['snapshot_id']) ? (int)$_POST['snapshot_id'] : 0;
+            if ($snapshotId <= 0 || !analytics_snapshot_v2_finalize($pdo, $snapshotId)) {
+                throw new RuntimeException(t($t, 'analytics_snapshot_v2_finalize_failed', 'Unable to finalize snapshot.'));
+            }
+            $_SESSION['analytics_snapshot_v2_flash'] = [
+                'ok' => t($t, 'analytics_snapshot_v2_finalized', 'Snapshot finalized and locked.'),
+                'error' => '',
+            ];
+        } else {
+            throw new RuntimeException(t($t, 'invalid_request', 'Invalid request.'));
+        }
+    } catch (Throwable $e) {
+        $_SESSION['analytics_snapshot_v2_flash'] = [
+            'ok' => '',
+            'error' => $e->getMessage(),
+        ];
+    }
+
+    header('Location: ' . url_for('admin/analytics_snapshot_v2.php'));
+    exit;
+}
+
+$questionnaires = [];
+$qStmt = $pdo->query('SELECT id, title FROM questionnaire ORDER BY title ASC');
+if ($qStmt) {
+    $questionnaires = $qStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+}
+
+$snapshots = [];
+if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
+    $sql = 'SELECT id, questionnaire_id, generated_by, status, locked, summary_json, generated_at, finalized_at '
+        . 'FROM analytics_report_snapshot_v2 ';
+    $params = [];
+    if ($questionnaireId > 0) {
+        $sql .= 'WHERE questionnaire_id = ? ';
+        $params[] = $questionnaireId;
+    }
+    $sql .= 'ORDER BY generated_at DESC, id DESC LIMIT 50';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute($params);
+    $snapshots = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+}
+
+$questionnaireMap = [];
+foreach ($questionnaires as $q) {
+    $questionnaireMap[(int)($q['id'] ?? 0)] = (string)($q['title'] ?? '');
+}
+
+$csvHref = url_for('admin/analytics_snapshot_v2_export.php');
+if ($questionnaireId > 0) {
+    $csvHref .= '?questionnaire_id=' . $questionnaireId;
+}
+?>
+<!doctype html>
+<html lang="<?=htmlspecialchars($locale)?>">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><?=htmlspecialchars($pageTitle)?></title>
+  <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
+</head>
+<body class="md-app-shell">
+<?php require_once __DIR__ . '/../templates/header.php'; ?>
+<main class="md-content">
+  <section class="md-card md-elev-2" style="padding:1rem;">
+    <h1 class="md-card-title"><?=htmlspecialchars($pageTitle)?></h1>
+    <p class="md-upgrade-meta"><?=t($t, 'analytics_snapshot_v2_subtitle', 'Generate and lock role-based analytics snapshots.')?></p>
+
+    <?php if ($flash['ok'] !== ''): ?>
+      <p style="color:#156d2f;font-weight:600;"><?=htmlspecialchars($flash['ok'], ENT_QUOTES, 'UTF-8')?></p>
+    <?php endif; ?>
+    <?php if ($flash['error'] !== ''): ?>
+      <p style="color:#b42318;font-weight:600;"><?=htmlspecialchars($flash['error'], ENT_QUOTES, 'UTF-8')?></p>
+    <?php endif; ?>
+
+    <form method="post" style="display:flex;gap:.75rem;align-items:flex-end;flex-wrap:wrap;">
+      <input type="hidden" name="csrf" value="<?=htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8')?>">
+      <input type="hidden" name="action" value="generate">
+      <label class="md-field">
+        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
+        <select name="questionnaire_id">
+          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
+          <?php foreach ($questionnaires as $q): ?>
+            <?php $qid = (int)($q['id'] ?? 0); ?>
+            <option value="<?=$qid?>" <?=$questionnaireId === $qid ? 'selected' : ''?>><?=htmlspecialchars((string)($q['title'] ?? ''), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <button class="md-button md-primary md-elev-2"><?=t($t, 'generate_snapshot', 'Generate snapshot')?></button>
+      <a class="md-button" href="<?=htmlspecialchars($csvHref, ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'export_csv', 'Export CSV')?></a>
+    </form>
+  </section>
+
+  <section class="md-card md-elev-2" style="padding:1rem;margin-top:1rem;">
+    <h2 class="md-card-title"><?=t($t, 'recent_snapshots', 'Recent snapshots')?></h2>
+    <?php if (!$snapshots): ?>
+      <p><?=t($t, 'no_snapshot_data', 'No snapshots available yet.')?></p>
+    <?php else: ?>
+      <div style="overflow:auto;">
+        <table class="md-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th><?=t($t, 'questionnaire', 'Questionnaire')?></th>
+              <th><?=t($t, 'status', 'Status')?></th>
+              <th><?=t($t, 'average_score', 'Average score (%)')?></th>
+              <th><?=t($t, 'competency_level', 'Competency level')?></th>
+              <th><?=t($t, 'generated_at', 'Generated at')?></th>
+              <th><?=t($t, 'actions', 'Actions')?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($snapshots as $row): ?>
+              <?php
+                $summary = json_decode((string)($row['summary_json'] ?? '{}'), true);
+                $avg = isset($summary['average_score']) ? round((float)$summary['average_score'], 1) : null;
+                $level = (string)($summary['competency_level'] ?? '—');
+                $qid = (int)($row['questionnaire_id'] ?? 0);
+              ?>
+              <tr>
+                <td><?= (int)($row['id'] ?? 0) ?></td>
+                <td><?=htmlspecialchars($questionnaireMap[$qid] ?? ($qid > 0 ? '#' . $qid : t($t, 'all_questionnaires', 'All questionnaires')), ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars((string)($row['status'] ?? 'draft'), ENT_QUOTES, 'UTF-8')?><?= !empty($row['locked']) ? ' · ' . t($t, 'locked', 'Locked') : '' ?></td>
+                <td><?= $avg === null ? '—' : htmlspecialchars((string)$avg, ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?=htmlspecialchars($level !== '' ? $level : '—', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars((string)($row['generated_at'] ?? ''), ENT_QUOTES, 'UTF-8')?></td>
+                <td>
+                  <?php if (empty($row['locked'])): ?>
+                    <form method="post" style="display:inline;">
+                      <input type="hidden" name="csrf" value="<?=htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8')?>">
+                      <input type="hidden" name="action" value="finalize">
+                      <input type="hidden" name="snapshot_id" value="<?= (int)($row['id'] ?? 0) ?>">
+                      <button class="md-button" type="submit"><?=t($t, 'finalize', 'Finalize')?></button>
+                    </form>
+                  <?php else: ?>
+                    <span><?=t($t, 'locked', 'Locked')?></span>
+                  <?php endif; ?>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php endif; ?>
+  </section>
+</main>
+<?php require_once __DIR__ . '/../templates/footer.php'; ?>
+</body>
+</html>

--- a/admin/analytics_snapshot_v2_export.php
+++ b/admin/analytics_snapshot_v2_export.php
@@ -1,0 +1,49 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/analytics_snapshot_v2.php';
+
+auth_required(['admin', 'supervisor']);
+refresh_current_user($pdo);
+require_profile_completion($pdo);
+
+$questionnaireId = isset($_GET['questionnaire_id']) ? max(0, (int)$_GET['questionnaire_id']) : 0;
+
+if (!analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
+    http_response_code(404);
+    echo 'Snapshot table not available.';
+    exit;
+}
+
+$sql = 'SELECT id, questionnaire_id, status, locked, summary_json, generated_at, finalized_at FROM analytics_report_snapshot_v2 ';
+$params = [];
+if ($questionnaireId > 0) {
+    $sql .= 'WHERE questionnaire_id = ? ';
+    $params[] = $questionnaireId;
+}
+$sql .= 'ORDER BY generated_at DESC, id DESC';
+
+$stmt = $pdo->prepare($sql);
+$stmt->execute($params);
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+header('Content-Type: text/csv; charset=utf-8');
+header('Content-Disposition: attachment; filename="analytics_snapshot_v2.csv"');
+
+$out = fopen('php://output', 'w');
+fputcsv($out, ['snapshot_id', 'questionnaire_id', 'status', 'locked', 'average_score', 'competency_level', 'gap_pct_required', 'generated_at', 'finalized_at']);
+foreach ($rows as $row) {
+    $summary = json_decode((string)($row['summary_json'] ?? '{}'), true);
+    fputcsv($out, [
+        (int)($row['id'] ?? 0),
+        (int)($row['questionnaire_id'] ?? 0),
+        (string)($row['status'] ?? ''),
+        !empty($row['locked']) ? 1 : 0,
+        isset($summary['average_score']) ? (float)$summary['average_score'] : null,
+        (string)($summary['competency_level'] ?? ''),
+        isset($summary['gap_pct_required']) ? (float)$summary['gap_pct_required'] : null,
+        (string)($row['generated_at'] ?? ''),
+        (string)($row['finalized_at'] ?? ''),
+    ]);
+}
+fclose($out);
+exit;

--- a/admin/analytics_snapshot_v2_export.php
+++ b/admin/analytics_snapshot_v2_export.php
@@ -5,12 +5,25 @@ require_once __DIR__ . '/../lib/analytics_snapshot_v2.php';
 auth_required(['admin', 'supervisor']);
 refresh_current_user($pdo);
 require_profile_completion($pdo);
+$viewer = current_user();
+$viewerRole = (string)($viewer['role'] ?? ($_SESSION['user']['role'] ?? ''));
+$viewerId = (int)($viewer['id'] ?? ($_SESSION['user']['id'] ?? 0));
 
 $questionnaireId = isset($_GET['questionnaire_id']) ? max(0, (int)$_GET['questionnaire_id']) : 0;
 $businessRole = isset($_GET['business_role']) ? trim((string)$_GET['business_role']) : '';
 $directorate = isset($_GET['directorate']) ? trim((string)$_GET['directorate']) : '';
 $workFunction = isset($_GET['work_function']) ? trim((string)$_GET['work_function']) : '';
 $userId = isset($_GET['user_id']) ? max(0, (int)$_GET['user_id']) : 0;
+$effectiveFilters = analytics_snapshot_v2_apply_viewer_scope($viewer, [
+    'business_role' => $businessRole,
+    'directorate' => $directorate,
+    'work_function' => $workFunction,
+    'user_id' => $userId,
+]);
+$businessRole = $effectiveFilters['business_role'];
+$directorate = $effectiveFilters['directorate'];
+$workFunction = $effectiveFilters['work_function'];
+$userId = $effectiveFilters['user_id'];
 
 if (!analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
     http_response_code(404);
@@ -18,7 +31,7 @@ if (!analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
     exit;
 }
 
-$sql = 'SELECT id, questionnaire_id, status, locked, filters_json, summary_json, generated_at, finalized_at FROM analytics_report_snapshot_v2 ';
+$sql = 'SELECT id, questionnaire_id, generated_by, status, locked, filters_json, summary_json, generated_at, finalized_at FROM analytics_report_snapshot_v2 ';
 $params = [];
 $where = [];
 if ($questionnaireId > 0) {
@@ -53,6 +66,13 @@ foreach ($rows as $row) {
     }
     if ($userId > 0 && (int)($filters['user_id'] ?? 0) !== $userId) {
         continue;
+    }
+    if ($viewerRole === 'supervisor') {
+        $rowDirectorate = (string)($filters['directorate'] ?? '');
+        $rowGeneratedBy = (int)($row['generated_by'] ?? 0);
+        if ($rowGeneratedBy !== $viewerId && ($directorate === '' || $rowDirectorate !== $directorate)) {
+            continue;
+        }
     }
     fputcsv($out, [
         (int)($row['id'] ?? 0),

--- a/admin/analytics_snapshot_v2_export.php
+++ b/admin/analytics_snapshot_v2_export.php
@@ -7,6 +7,10 @@ refresh_current_user($pdo);
 require_profile_completion($pdo);
 
 $questionnaireId = isset($_GET['questionnaire_id']) ? max(0, (int)$_GET['questionnaire_id']) : 0;
+$businessRole = isset($_GET['business_role']) ? trim((string)$_GET['business_role']) : '';
+$directorate = isset($_GET['directorate']) ? trim((string)$_GET['directorate']) : '';
+$workFunction = isset($_GET['work_function']) ? trim((string)$_GET['work_function']) : '';
+$userId = isset($_GET['user_id']) ? max(0, (int)$_GET['user_id']) : 0;
 
 if (!analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
     http_response_code(404);
@@ -14,11 +18,15 @@ if (!analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
     exit;
 }
 
-$sql = 'SELECT id, questionnaire_id, status, locked, summary_json, generated_at, finalized_at FROM analytics_report_snapshot_v2 ';
+$sql = 'SELECT id, questionnaire_id, status, locked, filters_json, summary_json, generated_at, finalized_at FROM analytics_report_snapshot_v2 ';
 $params = [];
+$where = [];
 if ($questionnaireId > 0) {
-    $sql .= 'WHERE questionnaire_id = ? ';
+    $where[] = 'questionnaire_id = ?';
     $params[] = $questionnaireId;
+}
+if ($where) {
+    $sql .= 'WHERE ' . implode(' AND ', $where) . ' ';
 }
 $sql .= 'ORDER BY generated_at DESC, id DESC';
 
@@ -30,14 +38,31 @@ header('Content-Type: text/csv; charset=utf-8');
 header('Content-Disposition: attachment; filename="analytics_snapshot_v2.csv"');
 
 $out = fopen('php://output', 'w');
-fputcsv($out, ['snapshot_id', 'questionnaire_id', 'status', 'locked', 'average_score', 'competency_level', 'gap_pct_required', 'generated_at', 'finalized_at']);
+fputcsv($out, ['snapshot_id', 'questionnaire_id', 'status', 'locked', 'business_role', 'directorate', 'work_function', 'user_id', 'average_score', 'competency_level', 'gap_pct_required', 'generated_at', 'finalized_at']);
 foreach ($rows as $row) {
     $summary = json_decode((string)($row['summary_json'] ?? '{}'), true);
+    $filters = json_decode((string)($row['filters_json'] ?? '{}'), true);
+    if ($businessRole !== '' && (string)($filters['business_role'] ?? '') !== $businessRole) {
+        continue;
+    }
+    if ($directorate !== '' && (string)($filters['directorate'] ?? '') !== $directorate) {
+        continue;
+    }
+    if ($workFunction !== '' && (string)($filters['work_function'] ?? '') !== $workFunction) {
+        continue;
+    }
+    if ($userId > 0 && (int)($filters['user_id'] ?? 0) !== $userId) {
+        continue;
+    }
     fputcsv($out, [
         (int)($row['id'] ?? 0),
         (int)($row['questionnaire_id'] ?? 0),
         (string)($row['status'] ?? ''),
         !empty($row['locked']) ? 1 : 0,
+        (string)($filters['business_role'] ?? ''),
+        (string)($filters['directorate'] ?? ''),
+        (string)($filters['work_function'] ?? ''),
+        (int)($filters['user_id'] ?? 0),
         isset($summary['average_score']) ? (float)$summary['average_score'] : null,
         (string)($summary['competency_level'] ?? ''),
         isset($summary['gap_pct_required']) ? (float)$summary['gap_pct_required'] : null,

--- a/config.php
+++ b/config.php
@@ -1128,6 +1128,7 @@ function ensure_competency_reporting_schema(PDO $pdo): void
             generated_by INT NULL,
             status ENUM('draft','finalized') NOT NULL DEFAULT 'draft',
             locked TINYINT(1) NOT NULL DEFAULT 0,
+            filters_json LONGTEXT NULL,
             summary_json LONGTEXT NOT NULL,
             details_json LONGTEXT NOT NULL,
             generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1138,6 +1139,16 @@ function ensure_competency_reporting_schema(PDO $pdo): void
             KEY idx_snapshot_questionnaire (questionnaire_id),
             KEY idx_snapshot_generated_at (generated_at)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+        $snapshotColumnsStmt = $pdo->query('SHOW COLUMNS FROM analytics_report_snapshot_v2');
+        $snapshotColumns = [];
+        if ($snapshotColumnsStmt) {
+            foreach ($snapshotColumnsStmt->fetchAll(PDO::FETCH_ASSOC) as $column) {
+                $snapshotColumns[] = (string)($column['Field'] ?? '');
+            }
+        }
+        if (!in_array('filters_json', $snapshotColumns, true)) {
+            $pdo->exec('ALTER TABLE analytics_report_snapshot_v2 ADD COLUMN filters_json LONGTEXT NULL AFTER locked');
+        }
 
         $seedBands = [
             ['Not Proficient', 0.00, 49.99, 1],

--- a/config.php
+++ b/config.php
@@ -627,6 +627,7 @@ function initialize_database_schema(PDO $pdo): void
     ensure_questionnaire_assignment_schema($pdo);
     ensure_annual_performance_periods($pdo);
     ensure_analytics_report_schedule_schema($pdo);
+    ensure_competency_reporting_schema($pdo);
 
     $schemaInitialized = true;
 }
@@ -1076,6 +1077,8 @@ function ensure_users_schema(PDO $pdo): void
         'work_experience_profile' => 'ALTER TABLE users ADD COLUMN work_experience_profile VARCHAR(255) NULL AFTER highest_degree_subject',
         'total_work_experience_band' => 'ALTER TABLE users ADD COLUMN total_work_experience_band VARCHAR(50) NULL AFTER work_experience_profile',
         'epss_work_experience_band' => 'ALTER TABLE users ADD COLUMN epss_work_experience_band VARCHAR(50) NULL AFTER total_work_experience_band',
+        'business_role' => 'ALTER TABLE users ADD COLUMN business_role VARCHAR(100) NULL AFTER profile_role_other',
+        'directorate' => 'ALTER TABLE users ADD COLUMN directorate VARCHAR(150) NULL AFTER department',
     ];
 
     foreach ($changes as $field => $sql) {
@@ -1086,6 +1089,81 @@ function ensure_users_schema(PDO $pdo): void
                 error_log(sprintf('ensure_users_schema add column %s failed: %s', $field, $e->getMessage()));
             }
         }
+    }
+}
+
+function ensure_competency_reporting_schema(PDO $pdo): void
+{
+    try {
+        $pdo->exec("CREATE TABLE IF NOT EXISTS competency_level_band (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(100) NOT NULL,
+            min_pct DECIMAL(5,2) NOT NULL,
+            max_pct DECIMAL(5,2) NOT NULL,
+            rank_order INT NOT NULL DEFAULT 0,
+            is_system_default TINYINT(1) NOT NULL DEFAULT 1,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            UNIQUE KEY uniq_competency_level_band_name (name),
+            UNIQUE KEY uniq_competency_level_band_rank (rank_order)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS competency_benchmark_policy (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            scope_type ENUM('organization','department','business_role','work_function','competency') NOT NULL DEFAULT 'organization',
+            scope_id VARCHAR(150) NULL,
+            required_pct DECIMAL(5,2) NOT NULL DEFAULT 80.00,
+            effective_from DATE NULL,
+            effective_to DATE NULL,
+            created_by INT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_benchmark_scope (scope_type, scope_id),
+            KEY idx_benchmark_effective (effective_from, effective_to)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        $pdo->exec("CREATE TABLE IF NOT EXISTS analytics_report_snapshot_v2 (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            questionnaire_id INT NULL,
+            generated_by INT NULL,
+            status ENUM('draft','finalized') NOT NULL DEFAULT 'draft',
+            locked TINYINT(1) NOT NULL DEFAULT 0,
+            summary_json LONGTEXT NOT NULL,
+            details_json LONGTEXT NOT NULL,
+            generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            finalized_at DATETIME NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            KEY idx_snapshot_status (status),
+            KEY idx_snapshot_questionnaire (questionnaire_id),
+            KEY idx_snapshot_generated_at (generated_at)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
+
+        $seedBands = [
+            ['Not Proficient', 0.00, 49.99, 1],
+            ['Basic Proficiency', 50.00, 64.99, 2],
+            ['Intermediate Proficiency', 65.00, 79.99, 3],
+            ['Advanced Proficiency', 80.00, 89.99, 4],
+            ['Expert', 90.00, 100.00, 5],
+        ];
+        $bandStmt = $pdo->prepare(
+            'INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default) '
+            . 'VALUES (?, ?, ?, ?, 1) '
+            . 'ON DUPLICATE KEY UPDATE min_pct = VALUES(min_pct), max_pct = VALUES(max_pct), rank_order = VALUES(rank_order)'
+        );
+        foreach ($seedBands as $band) {
+            $bandStmt->execute($band);
+        }
+
+        $orgBenchmark = $pdo->query("SELECT id FROM competency_benchmark_policy WHERE scope_type='organization' AND (scope_id IS NULL OR scope_id='') LIMIT 1");
+        if (!$orgBenchmark || !$orgBenchmark->fetch(PDO::FETCH_ASSOC)) {
+            $insertBenchmark = $pdo->prepare(
+                "INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct, effective_from, effective_to, created_by) VALUES ('organization', NULL, 80.00, NULL, NULL, NULL)"
+            );
+            $insertBenchmark->execute();
+        }
+    } catch (PDOException $e) {
+        error_log('ensure_competency_reporting_schema: ' . $e->getMessage());
     }
 }
 

--- a/docs/analytics_reporting_role_based_change_plan.md
+++ b/docs/analytics_reporting_role_based_change_plan.md
@@ -1,0 +1,206 @@
+# Analytics Reporting Change Plan (Role-Based)
+
+## 1) Current-state analysis from CAS codebase
+
+The current analytics implementation already provides:
+
+- Aggregate response metrics and score averages from `questionnaire_response`.
+- Work-role (`work_function`) and department-level rollups.
+- Heatmap-style charts for questionnaire and work-role performance.
+- PDF export support and analytics download endpoints.
+
+However, the current implementation is not yet aligned to the full reporting template requested (Executive Summary + role-hierarchical views + benchmark-driven gap prioritization + lock/finalization workflow). In particular, role taxonomy used by users (`admin`, `supervisor`, `staff`) differs from template roles (Director, Manager, Team Leader, Staff, Hub level), and analytics classification bands are not centrally defined as a governance object.
+
+## 2) Target reporting model (mapped to requested template)
+
+Implement reporting as **three layers**:
+
+1. **Global Organizational Layer**
+   - Executive Summary, organization averages, top strengths, top gaps.
+   - Competency level bands (system-controlled and immutable by non-admin users).
+
+2. **Dimensional Drill-down Layer**
+   - Department/directorate analysis.
+   - Role-based analysis (Director, Manager, Team Leader, Staff, Hub).
+   - Work-role analysis (existing `work_function`) retained as a cross-cut dimension.
+
+3. **Entity Layer**
+   - Individual profile cards.
+   - Benchmark comparison against required target (default 80%, configurable).
+   - Action recommendation and follow-up tracking.
+
+## 3) Required data-model and schema updates
+
+### 3.1 Role taxonomy harmonization
+
+Add normalized fields to map user access role from business reporting role:
+
+- `users.access_role` (existing semantics: admin/supervisor/staff).
+- `users.business_role` (new: director, manager, team_leader, staff, hub).
+- `users.directorate` (new optional text or FK table).
+
+This avoids breaking authorization while enabling the requested role-based reporting.
+
+### 3.2 Competency-level configuration table
+
+Create `competency_level_band`:
+
+- `name` (Not Proficient, Basic, Intermediate, Advanced, Expert)
+- `min_pct`, `max_pct`
+- `rank_order`
+- `is_system_default`
+
+Rules:
+
+- Only admin may edit.
+- Every report snapshot stores the band definitions used at generation time.
+
+### 3.3 Benchmark and gap policies
+
+Create `competency_benchmark_policy`:
+
+- `scope_type` (organization/department/business_role/work_function/competency)
+- `scope_id` (nullable)
+- `required_pct`
+- `effective_from`, `effective_to`
+
+Gap formula should support both policies already described in the template:
+
+- `gap = 100 - actual`
+- `gap = required - actual`
+
+## 4) Reporting computation changes
+
+### 4.1 Snapshot architecture
+
+Introduce `analytics_report_snapshot_v2` and detail tables:
+
+- Store immutable, timestamped report runs.
+- Include assessment period, participant counts, score aggregates, and generated insights.
+- Lock snapshot after finalization to satisfy “Lock report after submission”.
+
+### 4.2 Auto-generated sections (template conformance)
+
+Generate and persist sections 1–13 from the requested template:
+
+- Executive summary with top 3 strengths/gaps.
+- Methodology block (constant text + mapping metadata).
+- Participant overview by role, department, gender.
+- Org dashboard and department/role tables with level and gap.
+- Critical gaps ranking (threshold <60 and below benchmark).
+- Benchmark comparison matrices.
+- Strategic recommendations with deterministic rules:
+  - `<60`: training
+  - `60–75`: coaching
+  - `>85`: mentorship candidate
+
+### 4.3 Duplicate prevention alignment
+
+Reinforce duplicate-submission protections in report eligibility logic:
+
+- Exclude duplicate/invalid submissions from analytics aggregates.
+- Add report diagnostics section listing excluded rows count for auditability.
+
+## 5) Role-based access and visibility matrix
+
+Define explicit scope filters by viewer role:
+
+- **Admin**: full organization + all drill-down filters.
+- **Supervisor/Directorate lead**: only assigned directorate/department and subordinate business roles.
+- **Manager/Team Leader**: own teams/work roles + anonymized peer comparison.
+- **Staff**: individual profile + department average benchmark only.
+
+Apply this matrix consistently to:
+
+- On-screen analytics views.
+- PDF/Excel exports.
+- API endpoints used for dashboard queries.
+
+## 6) UI/UX and export changes
+
+### 6.1 Filter panel
+
+Extend analytics filters to include:
+
+- Role (business_role)
+- Work Role (`work_function`)
+- Directorate
+- Department
+- Individual
+- Assessment period
+
+### 6.2 Visualizations
+
+Add/upgrade:
+
+- Department heatmap (score and gap shading).
+- Role comparison bars.
+- Critical-gap priority table with traffic-light severity.
+- Progress tracking trend for follow-up periods.
+
+### 6.3 Export
+
+- PDF and Excel must include filter metadata and snapshot ID.
+- Export should reflect the same row-level access restrictions as UI.
+
+## 7) Implementation phases
+
+### Phase 1 — Foundations (1 sprint)
+
+- Add schema fields/tables (`business_role`, directorate, level bands, benchmark policy).
+- Add migration + seed defaults.
+- Add server-side classification helper service.
+
+### Phase 2 — Computation + snapshot engine (1 sprint)
+
+- Build report snapshot v2 generator.
+- Add gap policy engine and top-N rankings.
+- Add lock/finalize workflow + audit trail.
+
+### Phase 3 — UI + exports (1 sprint)
+
+- Add filter controls and new report sections.
+- Add department/role charts and critical gap panel.
+- Update PDF/Excel renderers.
+
+### Phase 4 — hardening + rollout (1 sprint)
+
+- Role-scope security tests.
+- Data quality checks (null score handling, duplicate suppression).
+- UAT signoff with sample template outputs.
+
+## 8) Testing strategy
+
+1. **Unit tests**
+   - Level-band classification boundaries.
+   - Gap calculation modes.
+   - Recommendation logic thresholds.
+
+2. **Integration tests**
+   - Snapshot generation with seeded data.
+   - Role-filter enforcement per access role.
+   - Export parity (UI totals == PDF/Excel totals).
+
+3. **Regression tests**
+   - Existing analytics heatmaps continue to render.
+   - Legacy admin analytics endpoints remain backward-compatible.
+
+4. **UAT acceptance tests**
+   - Validate each requested section (1–13) against expected sample output.
+
+## 9) Risks and mitigations
+
+- **Role vocabulary mismatch**: keep access role vs business role separate.
+- **Historical comparability drift**: persist level bands and benchmarks per snapshot.
+- **Performance under multi-filter queries**: add covering indexes for period/department/business_role/work_function.
+- **Governance drift**: enforce admin-only control over level/benchmark settings.
+
+## 10) Deliverables checklist
+
+- [ ] DB migration scripts.
+- [ ] Snapshot v2 backend service.
+- [ ] Role-scope authorization matrix implementation.
+- [ ] Updated analytics UI with required filters/charts.
+- [ ] PDF/Excel export updates.
+- [ ] Automated tests + UAT evidence package.
+

--- a/init.sql
+++ b/init.sql
@@ -72,10 +72,12 @@ CREATE TABLE users (
   date_of_birth DATE NULL,
   phone VARCHAR(50) NULL,
   department VARCHAR(150) NULL,
+  directorate VARCHAR(150) NULL,
   cadre VARCHAR(150) NULL,
   work_function VARCHAR(100) DEFAULT NULL,
   profile_role VARCHAR(100) NULL,
   profile_role_other VARCHAR(200) NULL,
+  business_role VARCHAR(100) NULL,
   job_grade VARCHAR(50) NULL,
   education_level VARCHAR(50) NULL,
   highest_degree_subject VARCHAR(200) NULL,
@@ -218,6 +220,50 @@ CREATE TABLE questionnaire_work_function (
   FOREIGN KEY (questionnaire_id) REFERENCES questionnaire(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE competency_level_band (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  min_pct DECIMAL(5,2) NOT NULL,
+  max_pct DECIMAL(5,2) NOT NULL,
+  rank_order INT NOT NULL DEFAULT 0,
+  is_system_default TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_competency_level_band_name (name),
+  UNIQUE KEY uniq_competency_level_band_rank (rank_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE competency_benchmark_policy (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  scope_type ENUM('organization','department','business_role','work_function','competency') NOT NULL DEFAULT 'organization',
+  scope_id VARCHAR(150) NULL,
+  required_pct DECIMAL(5,2) NOT NULL DEFAULT 80.00,
+  effective_from DATE NULL,
+  effective_to DATE NULL,
+  created_by INT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_benchmark_scope (scope_type, scope_id),
+  KEY idx_benchmark_effective (effective_from, effective_to)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE analytics_report_snapshot_v2 (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  questionnaire_id INT NULL,
+  generated_by INT NULL,
+  status ENUM('draft','finalized') NOT NULL DEFAULT 'draft',
+  locked TINYINT(1) NOT NULL DEFAULT 0,
+  summary_json LONGTEXT NOT NULL,
+  details_json LONGTEXT NOT NULL,
+  generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  finalized_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_snapshot_status (status),
+  KEY idx_snapshot_questionnaire (questionnaire_id),
+  KEY idx_snapshot_generated_at (generated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE work_function_catalog (
   slug VARCHAR(100) NOT NULL PRIMARY KEY,
   label VARCHAR(255) NOT NULL,
@@ -245,6 +291,16 @@ INSERT INTO work_function_catalog (slug, label, sort_order) VALUES
   ('security_driver', 'Security & Driver Management', 16),
   ('tmd', 'Training & Mentorship Development', 17),
   ('wim', 'Warehouse & Inventory Management', 18);
+
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default) VALUES
+  ('Not Proficient', 0.00, 49.99, 1, 1),
+  ('Basic Proficiency', 50.00, 64.99, 2, 1),
+  ('Intermediate Proficiency', 65.00, 79.99, 3, 1),
+  ('Advanced Proficiency', 80.00, 89.99, 4, 1),
+  ('Expert', 90.00, 100.00, 5, 1);
+
+INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct, effective_from, effective_to, created_by)
+VALUES ('organization', NULL, 80.00, NULL, NULL, NULL);
 
 CREATE TABLE questionnaire_assignment (
   staff_id INT NOT NULL,

--- a/init.sql
+++ b/init.sql
@@ -253,6 +253,7 @@ CREATE TABLE analytics_report_snapshot_v2 (
   generated_by INT NULL,
   status ENUM('draft','finalized') NOT NULL DEFAULT 'draft',
   locked TINYINT(1) NOT NULL DEFAULT 0,
+  filters_json LONGTEXT NULL,
   summary_json LONGTEXT NOT NULL,
   details_json LONGTEXT NOT NULL,
   generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/lib/analytics_snapshot_v2.php
+++ b/lib/analytics_snapshot_v2.php
@@ -26,6 +26,32 @@ function analytics_snapshot_v2_table_exists(PDO $pdo, string $table): bool
     }
 }
 
+function analytics_snapshot_v2_column_exists(PDO $pdo, string $table, string $column): bool
+{
+    try {
+        $driver = (string)$pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $stmt = $pdo->query('PRAGMA table_info(' . $table . ')');
+            $rows = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+            foreach ($rows as $row) {
+                if (strcasecmp((string)($row['name'] ?? ''), $column) === 0) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        $stmt = $pdo->prepare(
+            'SELECT COUNT(1) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?'
+        );
+        $stmt->execute([$table, $column]);
+        return ((int)$stmt->fetchColumn()) > 0;
+    } catch (Throwable $e) {
+        error_log('analytics_snapshot_v2_column_exists failed: ' . $e->getMessage());
+        return false;
+    }
+}
+
 function analytics_snapshot_v2_required_benchmark(PDO $pdo): float
 {
     if (!analytics_snapshot_v2_table_exists($pdo, 'competency_benchmark_policy')) {
@@ -118,20 +144,43 @@ function analytics_snapshot_v2_build_critical_gaps(array $departmentRows, array 
 /**
  * @return array<string, mixed>
  */
-function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, ?int $generatedBy = null): array
+function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, ?int $generatedBy = null, array $filters = []): array
 {
     $params = [];
-    $where = '';
+    $whereClauses = ["qr.status IN ('submitted','approved','approved_late')"];
     if ($questionnaireId !== null && $questionnaireId > 0) {
-        $where = ' WHERE qr.questionnaire_id = ? ';
+        $whereClauses[] = 'qr.questionnaire_id = ?';
         $params[] = $questionnaireId;
     }
+    $normalizedFilters = [
+        'business_role' => trim((string)($filters['business_role'] ?? '')),
+        'directorate' => trim((string)($filters['directorate'] ?? '')),
+        'user_id' => isset($filters['user_id']) ? max(0, (int)$filters['user_id']) : 0,
+        'work_function' => trim((string)($filters['work_function'] ?? '')),
+    ];
+    if ($normalizedFilters['business_role'] !== '') {
+        $whereClauses[] = 'COALESCE(NULLIF(u.business_role, \'\'), NULLIF(u.profile_role, \'\'), \'Unspecified\') = ?';
+        $params[] = $normalizedFilters['business_role'];
+    }
+    if ($normalizedFilters['directorate'] !== '') {
+        $whereClauses[] = 'COALESCE(NULLIF(u.directorate, \'\'), \'Unknown\') = ?';
+        $params[] = $normalizedFilters['directorate'];
+    }
+    if ($normalizedFilters['user_id'] > 0) {
+        $whereClauses[] = 'u.id = ?';
+        $params[] = $normalizedFilters['user_id'];
+    }
+    if ($normalizedFilters['work_function'] !== '') {
+        $whereClauses[] = 'COALESCE(NULLIF(u.work_function, \'\'), \'Unspecified\') = ?';
+        $params[] = $normalizedFilters['work_function'];
+    }
+    $whereSql = 'WHERE ' . implode(' AND ', $whereClauses);
 
     $summaryStmt = $pdo->prepare(
         'SELECT COUNT(*) AS total_responses, COUNT(DISTINCT qr.user_id) AS total_participants, AVG(qr.score) AS average_score '
         . 'FROM questionnaire_response qr '
-        . "WHERE qr.status IN ('submitted','approved','approved_late')"
-        . ($where !== '' ? ' AND qr.questionnaire_id = ?' : '')
+        . 'JOIN users u ON u.id = qr.user_id '
+        . $whereSql
     );
     $summaryStmt->execute($params);
     $summary = $summaryStmt->fetch(PDO::FETCH_ASSOC) ?: [];
@@ -140,8 +189,7 @@ function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, 
         'SELECT COALESCE(NULLIF(u.department, \'\'), \'Unknown\') AS department, COUNT(*) AS total_responses, AVG(qr.score) AS avg_score '
         . 'FROM questionnaire_response qr '
         . 'JOIN users u ON u.id = qr.user_id '
-        . "WHERE qr.status IN ('submitted','approved','approved_late')"
-        . ($where !== '' ? ' AND qr.questionnaire_id = ? ' : ' ')
+        . $whereSql . ' '
         . 'GROUP BY COALESCE(NULLIF(u.department, \'\'), \'Unknown\') '
         . 'ORDER BY avg_score DESC'
     );
@@ -153,8 +201,7 @@ function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, 
         . 'COUNT(*) AS total_responses, AVG(qr.score) AS avg_score '
         . 'FROM questionnaire_response qr '
         . 'JOIN users u ON u.id = qr.user_id '
-        . "WHERE qr.status IN ('submitted','approved','approved_late')"
-        . ($where !== '' ? ' AND qr.questionnaire_id = ? ' : ' ')
+        . $whereSql . ' '
         . 'GROUP BY COALESCE(NULLIF(u.business_role, \'\'), NULLIF(u.profile_role, \'\'), \'Unspecified\') '
         . 'ORDER BY avg_score DESC'
     );
@@ -183,6 +230,7 @@ function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, 
 
     $snapshot = [
         'questionnaire_id' => $questionnaireId,
+        'filters' => $normalizedFilters,
         'summary' => $summaryPayload,
         'department_analysis' => $departmentRows,
         'role_analysis' => $roleRows,
@@ -193,25 +241,49 @@ function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, 
     ];
 
     if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
-        $insert = $pdo->prepare(
-            'INSERT INTO analytics_report_snapshot_v2 (questionnaire_id, generated_by, status, locked, summary_json, details_json, generated_at) '
-            . 'VALUES (:questionnaire_id, :generated_by, :status, :locked, :summary_json, :details_json, :generated_at)'
-        );
-        $insert->execute([
-            ':questionnaire_id' => $questionnaireId,
-            ':generated_by' => $generatedBy,
-            ':status' => 'draft',
-            ':locked' => 0,
-            ':summary_json' => json_encode($summaryPayload),
-            ':details_json' => json_encode([
-                'department_analysis' => $departmentRows,
-                'role_analysis' => $roleRows,
-                'critical_gaps' => $criticalGaps,
-                'top_strengths' => $topStrengths,
-                'top_gaps' => $topGaps,
-            ]),
-            ':generated_at' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
-        ]);
+        $hasFiltersColumn = analytics_snapshot_v2_column_exists($pdo, 'analytics_report_snapshot_v2', 'filters_json');
+        if ($hasFiltersColumn) {
+            $insert = $pdo->prepare(
+                'INSERT INTO analytics_report_snapshot_v2 (questionnaire_id, generated_by, status, locked, filters_json, summary_json, details_json, generated_at) '
+                . 'VALUES (:questionnaire_id, :generated_by, :status, :locked, :filters_json, :summary_json, :details_json, :generated_at)'
+            );
+            $insert->execute([
+                ':questionnaire_id' => $questionnaireId,
+                ':generated_by' => $generatedBy,
+                ':status' => 'draft',
+                ':locked' => 0,
+                ':filters_json' => json_encode($normalizedFilters),
+                ':summary_json' => json_encode($summaryPayload),
+                ':details_json' => json_encode([
+                    'department_analysis' => $departmentRows,
+                    'role_analysis' => $roleRows,
+                    'critical_gaps' => $criticalGaps,
+                    'top_strengths' => $topStrengths,
+                    'top_gaps' => $topGaps,
+                ]),
+                ':generated_at' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+            ]);
+        } else {
+            $insert = $pdo->prepare(
+                'INSERT INTO analytics_report_snapshot_v2 (questionnaire_id, generated_by, status, locked, summary_json, details_json, generated_at) '
+                . 'VALUES (:questionnaire_id, :generated_by, :status, :locked, :summary_json, :details_json, :generated_at)'
+            );
+            $insert->execute([
+                ':questionnaire_id' => $questionnaireId,
+                ':generated_by' => $generatedBy,
+                ':status' => 'draft',
+                ':locked' => 0,
+                ':summary_json' => json_encode($summaryPayload),
+                ':details_json' => json_encode([
+                    'department_analysis' => $departmentRows,
+                    'role_analysis' => $roleRows,
+                    'critical_gaps' => $criticalGaps,
+                    'top_strengths' => $topStrengths,
+                    'top_gaps' => $topGaps,
+                ]),
+                ':generated_at' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+            ]);
+        }
         $snapshot['snapshot_id'] = (int)$pdo->lastInsertId();
     }
 

--- a/lib/analytics_snapshot_v2.php
+++ b/lib/analytics_snapshot_v2.php
@@ -52,6 +52,48 @@ function analytics_snapshot_v2_column_exists(PDO $pdo, string $table, string $co
     }
 }
 
+/**
+ * @param array<string, mixed> $filters
+ * @return array{business_role:string,directorate:string,user_id:int,work_function:string}
+ */
+function analytics_snapshot_v2_normalize_filters(array $filters): array
+{
+    return [
+        'business_role' => trim((string)($filters['business_role'] ?? '')),
+        'directorate' => trim((string)($filters['directorate'] ?? '')),
+        'user_id' => isset($filters['user_id']) ? max(0, (int)$filters['user_id']) : 0,
+        'work_function' => trim((string)($filters['work_function'] ?? '')),
+    ];
+}
+
+/**
+ * Apply row-level guardrails based on the viewer role.
+ *
+ * Supervisors are restricted to their own directorate (or department fallback).
+ *
+ * @param array<string, mixed> $viewer
+ * @param array<string, mixed> $filters
+ * @return array{business_role:string,directorate:string,user_id:int,work_function:string}
+ */
+function analytics_snapshot_v2_apply_viewer_scope(array $viewer, array $filters): array
+{
+    $normalized = analytics_snapshot_v2_normalize_filters($filters);
+    $role = trim((string)($viewer['role'] ?? ''));
+    if ($role !== 'supervisor') {
+        return $normalized;
+    }
+
+    $viewerDirectorate = trim((string)($viewer['directorate'] ?? ''));
+    if ($viewerDirectorate === '') {
+        $viewerDirectorate = trim((string)($viewer['department'] ?? ''));
+    }
+    if ($viewerDirectorate !== '') {
+        $normalized['directorate'] = $viewerDirectorate;
+    }
+
+    return $normalized;
+}
+
 function analytics_snapshot_v2_required_benchmark(PDO $pdo): float
 {
     if (!analytics_snapshot_v2_table_exists($pdo, 'competency_benchmark_policy')) {
@@ -152,12 +194,7 @@ function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, 
         $whereClauses[] = 'qr.questionnaire_id = ?';
         $params[] = $questionnaireId;
     }
-    $normalizedFilters = [
-        'business_role' => trim((string)($filters['business_role'] ?? '')),
-        'directorate' => trim((string)($filters['directorate'] ?? '')),
-        'user_id' => isset($filters['user_id']) ? max(0, (int)$filters['user_id']) : 0,
-        'work_function' => trim((string)($filters['work_function'] ?? '')),
-    ];
+    $normalizedFilters = analytics_snapshot_v2_normalize_filters($filters);
     if ($normalizedFilters['business_role'] !== '') {
         $whereClauses[] = 'COALESCE(NULLIF(u.business_role, \'\'), NULLIF(u.profile_role, \'\'), \'Unspecified\') = ?';
         $params[] = $normalizedFilters['business_role'];

--- a/lib/analytics_snapshot_v2.php
+++ b/lib/analytics_snapshot_v2.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/scoring.php';
+require_once __DIR__ . '/competency_framework.php';
+
+function analytics_snapshot_v2_table_exists(PDO $pdo, string $table): bool
+{
+    try {
+        $driver = (string)$pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver === 'sqlite') {
+            $stmt = $pdo->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = ?");
+            $stmt->execute([$table]);
+            return (bool)$stmt->fetch(PDO::FETCH_ASSOC);
+        }
+
+        $stmt = $pdo->prepare(
+            'SELECT COUNT(1) AS c FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?'
+        );
+        $stmt->execute([$table]);
+        return ((int)$stmt->fetchColumn()) > 0;
+    } catch (Throwable $e) {
+        error_log('analytics_snapshot_v2_table_exists failed: ' . $e->getMessage());
+        return false;
+    }
+}
+
+function analytics_snapshot_v2_required_benchmark(PDO $pdo): float
+{
+    if (!analytics_snapshot_v2_table_exists($pdo, 'competency_benchmark_policy')) {
+        return 80.0;
+    }
+
+    try {
+        $stmt = $pdo->query(
+            "SELECT required_pct FROM competency_benchmark_policy "
+            . "WHERE scope_type = 'organization' AND (scope_id IS NULL OR scope_id = '') "
+            . "ORDER BY id DESC LIMIT 1"
+        );
+        if ($stmt) {
+            $raw = $stmt->fetchColumn();
+            if ($raw !== false) {
+                return max(0.0, min(100.0, (float)$raw));
+            }
+        }
+    } catch (Throwable $e) {
+        error_log('analytics_snapshot_v2_required_benchmark failed: ' . $e->getMessage());
+    }
+
+    return 80.0;
+}
+
+/**
+ * @param array<int, array<string, mixed>> $rows
+ * @return array<int, array<string, mixed>>
+ */
+function analytics_snapshot_v2_enrich_rows(array $rows, float $requiredBenchmark): array
+{
+    $enriched = [];
+    foreach ($rows as $row) {
+        $score = isset($row['avg_score']) && $row['avg_score'] !== null ? (float)$row['avg_score'] : null;
+        $row['competency_level'] = questionnaire_competency_level($score);
+        $row['gap_pct_100'] = questionnaire_competency_gap($score, null);
+        $row['gap_pct_required'] = questionnaire_competency_gap($score, $requiredBenchmark);
+        $row['recommendation'] = questionnaire_competency_recommendation($score);
+        $enriched[] = $row;
+    }
+    return $enriched;
+}
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function analytics_snapshot_v2_build_critical_gaps(array $departmentRows, array $roleRows): array
+{
+    $candidates = [];
+
+    foreach ($departmentRows as $row) {
+        $score = isset($row['avg_score']) ? (float)$row['avg_score'] : null;
+        if ($score === null || $score >= 60.0) {
+            continue;
+        }
+        $candidates[] = [
+            'dimension' => 'department',
+            'name' => (string)($row['department'] ?? 'Unknown'),
+            'score' => $score,
+            'gap_level' => $score < 50.0 ? 'High' : 'Moderate',
+        ];
+    }
+
+    foreach ($roleRows as $row) {
+        $score = isset($row['avg_score']) ? (float)$row['avg_score'] : null;
+        if ($score === null || $score >= 60.0) {
+            continue;
+        }
+        $candidates[] = [
+            'dimension' => 'business_role',
+            'name' => (string)($row['business_role'] ?? 'Unspecified'),
+            'score' => $score,
+            'gap_level' => $score < 50.0 ? 'High' : 'Moderate',
+        ];
+    }
+
+    usort($candidates, static fn(array $a, array $b): int => ($a['score'] <=> $b['score']));
+    $ranked = [];
+    $rank = 1;
+    foreach ($candidates as $candidate) {
+        $candidate['priority_rank'] = $rank++;
+        $ranked[] = $candidate;
+        if (count($ranked) >= 10) {
+            break;
+        }
+    }
+    return $ranked;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function analytics_snapshot_v2_generate(PDO $pdo, ?int $questionnaireId = null, ?int $generatedBy = null): array
+{
+    $params = [];
+    $where = '';
+    if ($questionnaireId !== null && $questionnaireId > 0) {
+        $where = ' WHERE qr.questionnaire_id = ? ';
+        $params[] = $questionnaireId;
+    }
+
+    $summaryStmt = $pdo->prepare(
+        'SELECT COUNT(*) AS total_responses, COUNT(DISTINCT qr.user_id) AS total_participants, AVG(qr.score) AS average_score '
+        . 'FROM questionnaire_response qr '
+        . "WHERE qr.status IN ('submitted','approved','approved_late')"
+        . ($where !== '' ? ' AND qr.questionnaire_id = ?' : '')
+    );
+    $summaryStmt->execute($params);
+    $summary = $summaryStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+
+    $departmentStmt = $pdo->prepare(
+        'SELECT COALESCE(NULLIF(u.department, \'\'), \'Unknown\') AS department, COUNT(*) AS total_responses, AVG(qr.score) AS avg_score '
+        . 'FROM questionnaire_response qr '
+        . 'JOIN users u ON u.id = qr.user_id '
+        . "WHERE qr.status IN ('submitted','approved','approved_late')"
+        . ($where !== '' ? ' AND qr.questionnaire_id = ? ' : ' ')
+        . 'GROUP BY COALESCE(NULLIF(u.department, \'\'), \'Unknown\') '
+        . 'ORDER BY avg_score DESC'
+    );
+    $departmentStmt->execute($params);
+    $departmentRows = $departmentStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+    $roleStmt = $pdo->prepare(
+        'SELECT COALESCE(NULLIF(u.business_role, \'\'), NULLIF(u.profile_role, \'\'), \'Unspecified\') AS business_role, '
+        . 'COUNT(*) AS total_responses, AVG(qr.score) AS avg_score '
+        . 'FROM questionnaire_response qr '
+        . 'JOIN users u ON u.id = qr.user_id '
+        . "WHERE qr.status IN ('submitted','approved','approved_late')"
+        . ($where !== '' ? ' AND qr.questionnaire_id = ? ' : ' ')
+        . 'GROUP BY COALESCE(NULLIF(u.business_role, \'\'), NULLIF(u.profile_role, \'\'), \'Unspecified\') '
+        . 'ORDER BY avg_score DESC'
+    );
+    $roleStmt->execute($params);
+    $roleRows = $roleStmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
+
+    $requiredBenchmark = analytics_snapshot_v2_required_benchmark($pdo);
+    $departmentRows = analytics_snapshot_v2_enrich_rows($departmentRows, $requiredBenchmark);
+    $roleRows = analytics_snapshot_v2_enrich_rows($roleRows, $requiredBenchmark);
+    $criticalGaps = analytics_snapshot_v2_build_critical_gaps($departmentRows, $roleRows);
+
+    $overallScore = isset($summary['average_score']) && $summary['average_score'] !== null ? (float)$summary['average_score'] : null;
+    $summaryPayload = [
+        'total_responses' => (int)($summary['total_responses'] ?? 0),
+        'total_participants' => (int)($summary['total_participants'] ?? 0),
+        'average_score' => $overallScore,
+        'competency_level' => questionnaire_competency_level($overallScore),
+        'gap_pct_100' => questionnaire_competency_gap($overallScore, null),
+        'gap_pct_required' => questionnaire_competency_gap($overallScore, $requiredBenchmark),
+        'recommendation' => questionnaire_competency_recommendation($overallScore),
+        'required_benchmark' => $requiredBenchmark,
+    ];
+
+    $topStrengths = array_slice($departmentRows, 0, 3);
+    $topGaps = array_slice(array_reverse($departmentRows), 0, 3);
+
+    $snapshot = [
+        'questionnaire_id' => $questionnaireId,
+        'summary' => $summaryPayload,
+        'department_analysis' => $departmentRows,
+        'role_analysis' => $roleRows,
+        'critical_gaps' => $criticalGaps,
+        'top_strengths' => $topStrengths,
+        'top_gaps' => $topGaps,
+        'generated_at' => (new DateTimeImmutable('now'))->format(DateTimeInterface::ATOM),
+    ];
+
+    if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
+        $insert = $pdo->prepare(
+            'INSERT INTO analytics_report_snapshot_v2 (questionnaire_id, generated_by, status, locked, summary_json, details_json, generated_at) '
+            . 'VALUES (:questionnaire_id, :generated_by, :status, :locked, :summary_json, :details_json, :generated_at)'
+        );
+        $insert->execute([
+            ':questionnaire_id' => $questionnaireId,
+            ':generated_by' => $generatedBy,
+            ':status' => 'draft',
+            ':locked' => 0,
+            ':summary_json' => json_encode($summaryPayload),
+            ':details_json' => json_encode([
+                'department_analysis' => $departmentRows,
+                'role_analysis' => $roleRows,
+                'critical_gaps' => $criticalGaps,
+                'top_strengths' => $topStrengths,
+                'top_gaps' => $topGaps,
+            ]),
+            ':generated_at' => (new DateTimeImmutable('now'))->format('Y-m-d H:i:s'),
+        ]);
+        $snapshot['snapshot_id'] = (int)$pdo->lastInsertId();
+    }
+
+    return $snapshot;
+}
+
+function analytics_snapshot_v2_finalize(PDO $pdo, int $snapshotId): bool
+{
+    if ($snapshotId <= 0 || !analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
+        return false;
+    }
+    $stmt = $pdo->prepare(
+        "UPDATE analytics_report_snapshot_v2 SET locked = 1, status = 'finalized', finalized_at = CURRENT_TIMESTAMP WHERE id = ? AND locked = 0"
+    );
+    $stmt->execute([$snapshotId]);
+    return $stmt->rowCount() > 0;
+}

--- a/lib/competency_framework.php
+++ b/lib/competency_framework.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Default competency level bands used when no database override exists.
+ *
+ * @return array<int, array{name:string,min_pct:float,max_pct:float,rank_order:int}>
+ */
+function competency_default_level_bands(): array
+{
+    return [
+        ['name' => 'Not Proficient', 'min_pct' => 0.0, 'max_pct' => 49.99, 'rank_order' => 1],
+        ['name' => 'Basic Proficiency', 'min_pct' => 50.0, 'max_pct' => 64.99, 'rank_order' => 2],
+        ['name' => 'Intermediate Proficiency', 'min_pct' => 65.0, 'max_pct' => 79.99, 'rank_order' => 3],
+        ['name' => 'Advanced Proficiency', 'min_pct' => 80.0, 'max_pct' => 89.99, 'rank_order' => 4],
+        ['name' => 'Expert', 'min_pct' => 90.0, 'max_pct' => 100.0, 'rank_order' => 5],
+    ];
+}
+
+/**
+ * Evaluate a competency level label for a percentage score.
+ *
+ * @param array<int, array{name:string,min_pct:float,max_pct:float}> $bands
+ */
+function competency_level_from_bands(?float $score, array $bands): string
+{
+    if ($score === null) {
+        return '';
+    }
+
+    $normalizedScore = max(0.0, min(100.0, (float)$score));
+    foreach ($bands as $band) {
+        $min = isset($band['min_pct']) ? (float)$band['min_pct'] : 0.0;
+        $max = isset($band['max_pct']) ? (float)$band['max_pct'] : 0.0;
+        if ($normalizedScore >= $min && $normalizedScore <= $max) {
+            return (string)($band['name'] ?? '');
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Compute competency gap.
+ *
+ * When benchmark is null, uses 100 - score.
+ * When benchmark is provided, uses benchmark - score.
+ */
+function competency_gap(?float $score, ?float $benchmark = null): ?float
+{
+    if ($score === null) {
+        return null;
+    }
+
+    $normalizedScore = max(0.0, min(100.0, (float)$score));
+    if ($benchmark === null) {
+        return round(100.0 - $normalizedScore, 1);
+    }
+
+    $normalizedBenchmark = max(0.0, min(100.0, (float)$benchmark));
+    return round($normalizedBenchmark - $normalizedScore, 1);
+}
+
+/**
+ * Rule-based recommendation text from the reporting template.
+ */
+function competency_recommendation(?float $score): string
+{
+    if ($score === null) {
+        return '';
+    }
+    if ($score < 60.0) {
+        return 'Recommend training';
+    }
+    if ($score <= 75.0) {
+        return 'Recommend coaching';
+    }
+    if ($score > 85.0) {
+        return 'Consider mentorship role';
+    }
+    return 'Maintain current development plan';
+}

--- a/lib/competency_framework.php
+++ b/lib/competency_framework.php
@@ -19,6 +19,81 @@ function competency_default_level_bands(): array
 }
 
 /**
+ * Resolve competency level bands from runtime configuration when available.
+ *
+ * Falls back to default level bands if no database connection or overrides exist.
+ *
+ * @return array<int, array{name:string,min_pct:float,max_pct:float,rank_order:int}>
+ */
+function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): array
+{
+    static $cache = [];
+
+    if ($pdo === null && isset($GLOBALS['pdo']) && $GLOBALS['pdo'] instanceof PDO) {
+        $pdo = $GLOBALS['pdo'];
+    }
+
+    if (!$pdo instanceof PDO) {
+        return competency_default_level_bands();
+    }
+
+    $cacheKey = spl_object_id($pdo);
+    if (!$forceRefresh && isset($cache[$cacheKey])) {
+        return $cache[$cacheKey];
+    }
+
+    try {
+        $driver = strtolower((string)$pdo->getAttribute(PDO::ATTR_DRIVER_NAME));
+        if ($driver === 'sqlite') {
+            $existsStmt = $pdo->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = 'competency_level_band' LIMIT 1");
+            $existsStmt->execute();
+            if (!$existsStmt->fetch(PDO::FETCH_ASSOC)) {
+                return $cache[$cacheKey] = competency_default_level_bands();
+            }
+        } else {
+            $existsStmt = $pdo->prepare(
+                'SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?'
+            );
+            $existsStmt->execute(['competency_level_band']);
+            if ((int)$existsStmt->fetchColumn() <= 0) {
+                return $cache[$cacheKey] = competency_default_level_bands();
+            }
+        }
+
+        $stmt = $pdo->query(
+            'SELECT name, min_pct, max_pct, rank_order FROM competency_level_band ORDER BY rank_order ASC, id ASC'
+        );
+        $rows = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+        if (!is_array($rows) || $rows === []) {
+            return $cache[$cacheKey] = competency_default_level_bands();
+        }
+
+        $bands = [];
+        foreach ($rows as $row) {
+            $name = trim((string)($row['name'] ?? ''));
+            if ($name === '') {
+                continue;
+            }
+            $bands[] = [
+                'name' => $name,
+                'min_pct' => isset($row['min_pct']) ? (float)$row['min_pct'] : 0.0,
+                'max_pct' => isset($row['max_pct']) ? (float)$row['max_pct'] : 0.0,
+                'rank_order' => isset($row['rank_order']) ? (int)$row['rank_order'] : (count($bands) + 1),
+            ];
+        }
+
+        if ($bands === []) {
+            return $cache[$cacheKey] = competency_default_level_bands();
+        }
+
+        return $cache[$cacheKey] = $bands;
+    } catch (Throwable $e) {
+        error_log('competency_level_bands failed: ' . $e->getMessage());
+        return competency_default_level_bands();
+    }
+}
+
+/**
  * Evaluate a competency level label for a percentage score.
  *
  * @param array<int, array{name:string,min_pct:float,max_pct:float}> $bands

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -219,7 +219,7 @@ function questionnaire_answer_is_correct(array $answerSet, string $correctValue)
  */
 function questionnaire_competency_level(?float $score): string
 {
-    return competency_level_from_bands($score, competency_default_level_bands());
+    return competency_level_from_bands($score, competency_level_bands());
 }
 
 /**

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -1,4 +1,6 @@
 <?php
+
+require_once __DIR__ . '/competency_framework.php';
 /**
  * Helper functions for questionnaire scoring calculations.
  */
@@ -217,19 +219,7 @@ function questionnaire_answer_is_correct(array $answerSet, string $correctValue)
  */
 function questionnaire_competency_level(?float $score): string
 {
-    if ($score === null) {
-        return '';
-    }
-    if ($score >= 85.0) {
-        return 'Strategic';
-    }
-    if ($score >= 70.0) {
-        return 'Advanced';
-    }
-    if ($score >= 50.0) {
-        return 'Essential';
-    }
-    return 'Introductory';
+    return competency_level_from_bands($score, competency_default_level_bands());
 }
 
 /**
@@ -241,25 +231,39 @@ function questionnaire_competency_details(?float $score): array
 {
     $level = questionnaire_competency_level($score);
     return match ($level) {
-        'Strategic' => [
-            'level' => 'Strategic',
-            'interpretation' => 'Shapes direction, drives outcomes, and mentors others in complex scenarios.',
+        'Expert' => [
+            'level' => 'Expert',
+            'interpretation' => 'Consistently demonstrates mastery and can guide others.',
         ],
-        'Advanced' => [
-            'level' => 'Advanced',
-            'interpretation' => 'Performs independently and consistently meets role expectations.',
+        'Advanced Proficiency' => [
+            'level' => 'Advanced Proficiency',
+            'interpretation' => 'Performs independently and consistently exceeds most role expectations.',
         ],
-        'Essential' => [
-            'level' => 'Essential',
-            'interpretation' => 'Demonstrates core capability with some support and targeted development.',
+        'Intermediate Proficiency' => [
+            'level' => 'Intermediate Proficiency',
+            'interpretation' => 'Shows reliable capability with periodic coaching in complex tasks.',
         ],
-        'Introductory' => [
-            'level' => 'Introductory',
-            'interpretation' => 'Building foundational capability and requires structured guidance.',
+        'Basic Proficiency' => [
+            'level' => 'Basic Proficiency',
+            'interpretation' => 'Has foundational capability and benefits from targeted support.',
+        ],
+        'Not Proficient' => [
+            'level' => 'Not Proficient',
+            'interpretation' => 'Requires substantial development support and structured learning.',
         ],
         default => [
             'level' => '',
             'interpretation' => '',
         ],
     };
+}
+
+function questionnaire_competency_gap(?float $score, ?float $benchmark = null): ?float
+{
+    return competency_gap($score, $benchmark);
+}
+
+function questionnaire_competency_recommendation(?float $score): string
+{
+    return competency_recommendation($score);
 }

--- a/migration.sql
+++ b/migration.sql
@@ -1477,6 +1477,7 @@ CREATE TABLE IF NOT EXISTS analytics_report_snapshot_v2 (
   generated_by INT NULL,
   status ENUM('draft','finalized') NOT NULL DEFAULT 'draft',
   locked TINYINT(1) NOT NULL DEFAULT 0,
+  filters_json LONGTEXT NULL,
   summary_json LONGTEXT NOT NULL,
   details_json LONGTEXT NOT NULL,
   generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1487,3 +1488,19 @@ CREATE TABLE IF NOT EXISTS analytics_report_snapshot_v2 (
   KEY idx_snapshot_questionnaire (questionnaire_id),
   KEY idx_snapshot_generated_at (generated_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+SET @snapshot_filters_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'analytics_report_snapshot_v2'
+    AND COLUMN_NAME = 'filters_json'
+);
+SET @snapshot_filters_sql = IF(
+  @snapshot_filters_exists = 0,
+  'ALTER TABLE analytics_report_snapshot_v2 ADD COLUMN filters_json LONGTEXT NULL AFTER locked',
+  'DO 1'
+);
+PREPARE stmt FROM @snapshot_filters_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/migration.sql
+++ b/migration.sql
@@ -1387,3 +1387,103 @@ SET @qi_condition_value_sql = IF(
 PREPARE stmt FROM @qi_condition_value_sql;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
+
+SET @users_business_role_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND COLUMN_NAME = 'business_role'
+);
+SET @users_business_role_sql = IF(
+  @users_business_role_exists = 0,
+  'ALTER TABLE users ADD COLUMN business_role VARCHAR(100) NULL AFTER profile_role_other',
+  'DO 1'
+);
+PREPARE stmt FROM @users_business_role_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @users_directorate_exists = (
+  SELECT COUNT(1)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'users'
+    AND COLUMN_NAME = 'directorate'
+);
+SET @users_directorate_sql = IF(
+  @users_directorate_exists = 0,
+  'ALTER TABLE users ADD COLUMN directorate VARCHAR(150) NULL AFTER department',
+  'DO 1'
+);
+PREPARE stmt FROM @users_directorate_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS competency_level_band (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  min_pct DECIMAL(5,2) NOT NULL,
+  max_pct DECIMAL(5,2) NOT NULL,
+  rank_order INT NOT NULL DEFAULT 0,
+  is_system_default TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_competency_level_band_name (name),
+  UNIQUE KEY uniq_competency_level_band_rank (rank_order)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS competency_benchmark_policy (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  scope_type ENUM('organization','department','business_role','work_function','competency') NOT NULL DEFAULT 'organization',
+  scope_id VARCHAR(150) NULL,
+  required_pct DECIMAL(5,2) NOT NULL DEFAULT 80.00,
+  effective_from DATE NULL,
+  effective_to DATE NULL,
+  created_by INT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_benchmark_scope (scope_type, scope_id),
+  KEY idx_benchmark_effective (effective_from, effective_to)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Not Proficient', 0.00, 49.99, 1, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Not Proficient');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Basic Proficiency', 50.00, 64.99, 2, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Basic Proficiency');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Intermediate Proficiency', 65.00, 79.99, 3, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Intermediate Proficiency');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Advanced Proficiency', 80.00, 89.99, 4, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Advanced Proficiency');
+INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order, is_system_default)
+SELECT 'Expert', 90.00, 100.00, 5, 1
+WHERE NOT EXISTS (SELECT 1 FROM competency_level_band WHERE name = 'Expert');
+
+INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct, effective_from, effective_to, created_by)
+SELECT 'organization', NULL, 80.00, NULL, NULL, NULL
+WHERE NOT EXISTS (
+  SELECT 1 FROM competency_benchmark_policy
+  WHERE scope_type = 'organization'
+    AND (scope_id IS NULL OR scope_id = '')
+);
+
+CREATE TABLE IF NOT EXISTS analytics_report_snapshot_v2 (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  questionnaire_id INT NULL,
+  generated_by INT NULL,
+  status ENUM('draft','finalized') NOT NULL DEFAULT 'draft',
+  locked TINYINT(1) NOT NULL DEFAULT 0,
+  summary_json LONGTEXT NOT NULL,
+  details_json LONGTEXT NOT NULL,
+  generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  finalized_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_snapshot_status (status),
+  KEY idx_snapshot_questionnaire (questionnaire_id),
+  KEY idx_snapshot_generated_at (generated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/scripts/generate_analytics_snapshot_v2.php
+++ b/scripts/generate_analytics_snapshot_v2.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/analytics_snapshot_v2.php';
+
+$questionnaireId = null;
+if (isset($argv[1]) && is_numeric($argv[1])) {
+    $parsed = (int)$argv[1];
+    if ($parsed > 0) {
+        $questionnaireId = $parsed;
+    }
+}
+
+$generatedBy = null;
+if (isset($argv[2]) && is_numeric($argv[2])) {
+    $parsedBy = (int)$argv[2];
+    if ($parsedBy > 0) {
+        $generatedBy = $parsedBy;
+    }
+}
+
+$snapshot = analytics_snapshot_v2_generate($pdo, $questionnaireId, $generatedBy);
+$snapshotId = isset($snapshot['snapshot_id']) ? (int)$snapshot['snapshot_id'] : 0;
+
+echo "Generated analytics snapshot v2.\n";
+if ($snapshotId > 0) {
+    echo "Snapshot ID: {$snapshotId}\n";
+}
+echo "Summary: " . json_encode($snapshot['summary'] ?? [], JSON_PRETTY_PRINT) . "\n";

--- a/scripts/generate_analytics_snapshot_v2.php
+++ b/scripts/generate_analytics_snapshot_v2.php
@@ -21,7 +21,14 @@ if (isset($argv[2]) && is_numeric($argv[2])) {
     }
 }
 
-$snapshot = analytics_snapshot_v2_generate($pdo, $questionnaireId, $generatedBy);
+$filters = [
+    'business_role' => isset($argv[3]) ? trim((string)$argv[3]) : '',
+    'directorate' => isset($argv[4]) ? trim((string)$argv[4]) : '',
+    'work_function' => isset($argv[5]) ? trim((string)$argv[5]) : '',
+    'user_id' => isset($argv[6]) && is_numeric($argv[6]) ? max(0, (int)$argv[6]) : 0,
+];
+
+$snapshot = analytics_snapshot_v2_generate($pdo, $questionnaireId, $generatedBy, $filters);
 $snapshotId = isset($snapshot['snapshot_id']) ? (int)$snapshot['snapshot_id'] : 0;
 
 echo "Generated analytics snapshot v2.\n";

--- a/tests/analytics_snapshot_v2_test.php
+++ b/tests/analytics_snapshot_v2_test.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/analytics_snapshot_v2.php';
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, department TEXT, business_role TEXT, profile_role TEXT)');
+$pdo->exec('CREATE TABLE questionnaire_response (id INTEGER PRIMARY KEY, user_id INT, questionnaire_id INT, status TEXT, score REAL)');
+$pdo->exec('CREATE TABLE competency_benchmark_policy (id INTEGER PRIMARY KEY, scope_type TEXT, scope_id TEXT, required_pct REAL)');
+$pdo->exec('CREATE TABLE analytics_report_snapshot_v2 (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    questionnaire_id INT NULL,
+    generated_by INT NULL,
+    status TEXT NOT NULL DEFAULT "draft",
+    locked INT NOT NULL DEFAULT 0,
+    summary_json TEXT NOT NULL,
+    details_json TEXT NOT NULL,
+    generated_at TEXT NOT NULL,
+    finalized_at TEXT NULL
+)');
+
+$pdo->exec("INSERT INTO users (id, department, business_role, profile_role) VALUES
+    (1, 'Finance', 'manager', NULL),
+    (2, 'Operations', 'staff', NULL),
+    (3, 'Operations', NULL, 'team_leader')");
+
+$pdo->exec("INSERT INTO questionnaire_response (id, user_id, questionnaire_id, status, score) VALUES
+    (1, 1, 1, 'approved', 88),
+    (2, 2, 1, 'submitted', 54),
+    (3, 3, 1, 'approved', 45)");
+
+$pdo->exec("INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct) VALUES
+    ('organization', NULL, 80.0)");
+
+$snapshot = analytics_snapshot_v2_generate($pdo, 1, 99);
+
+if (empty($snapshot['snapshot_id']) || (int)$snapshot['snapshot_id'] <= 0) {
+    fwrite(STDERR, "Snapshot ID should be generated and persisted.\n");
+    exit(1);
+}
+
+if (($snapshot['summary']['competency_level'] ?? '') !== 'Basic Proficiency') {
+    fwrite(STDERR, "Unexpected summary competency level.\n");
+    exit(1);
+}
+
+if (empty($snapshot['critical_gaps'])) {
+    fwrite(STDERR, "Expected at least one critical gap entry.\n");
+    exit(1);
+}
+
+$finalized = analytics_snapshot_v2_finalize($pdo, (int)$snapshot['snapshot_id']);
+if ($finalized !== true) {
+    fwrite(STDERR, "Snapshot finalize should return true.\n");
+    exit(1);
+}
+
+$locked = $pdo->query('SELECT locked, status FROM analytics_report_snapshot_v2 WHERE id = ' . (int)$snapshot['snapshot_id'])->fetch(PDO::FETCH_ASSOC);
+if ((int)($locked['locked'] ?? 0) !== 1 || (string)($locked['status'] ?? '') !== 'finalized') {
+    fwrite(STDERR, "Finalized snapshot should be locked and marked finalized.\n");
+    exit(1);
+}
+
+echo "Analytics snapshot v2 tests passed.\n";

--- a/tests/analytics_snapshot_v2_test.php
+++ b/tests/analytics_snapshot_v2_test.php
@@ -35,6 +35,15 @@ $pdo->exec("INSERT INTO questionnaire_response (id, user_id, questionnaire_id, s
 $pdo->exec("INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct) VALUES
     ('organization', NULL, 80.0)");
 
+$supervisorScoped = analytics_snapshot_v2_apply_viewer_scope(
+    ['role' => 'supervisor', 'directorate' => 'Operations'],
+    ['directorate' => 'Finance', 'business_role' => 'staff', 'work_function' => '', 'user_id' => 0]
+);
+if (($supervisorScoped['directorate'] ?? '') !== 'Operations') {
+    fwrite(STDERR, "Supervisor scope should enforce own directorate.\n");
+    exit(1);
+}
+
 $snapshot = analytics_snapshot_v2_generate($pdo, 1, 99, ['business_role' => 'staff']);
 
 if (empty($snapshot['snapshot_id']) || (int)$snapshot['snapshot_id'] <= 0) {

--- a/tests/analytics_snapshot_v2_test.php
+++ b/tests/analytics_snapshot_v2_test.php
@@ -15,6 +15,7 @@ $pdo->exec('CREATE TABLE analytics_report_snapshot_v2 (
     generated_by INT NULL,
     status TEXT NOT NULL DEFAULT "draft",
     locked INT NOT NULL DEFAULT 0,
+    filters_json TEXT NULL,
     summary_json TEXT NOT NULL,
     details_json TEXT NOT NULL,
     generated_at TEXT NOT NULL,
@@ -34,7 +35,7 @@ $pdo->exec("INSERT INTO questionnaire_response (id, user_id, questionnaire_id, s
 $pdo->exec("INSERT INTO competency_benchmark_policy (scope_type, scope_id, required_pct) VALUES
     ('organization', NULL, 80.0)");
 
-$snapshot = analytics_snapshot_v2_generate($pdo, 1, 99);
+$snapshot = analytics_snapshot_v2_generate($pdo, 1, 99, ['business_role' => 'staff']);
 
 if (empty($snapshot['snapshot_id']) || (int)$snapshot['snapshot_id'] <= 0) {
     fwrite(STDERR, "Snapshot ID should be generated and persisted.\n");
@@ -60,6 +61,12 @@ if ($finalized !== true) {
 $locked = $pdo->query('SELECT locked, status FROM analytics_report_snapshot_v2 WHERE id = ' . (int)$snapshot['snapshot_id'])->fetch(PDO::FETCH_ASSOC);
 if ((int)($locked['locked'] ?? 0) !== 1 || (string)($locked['status'] ?? '') !== 'finalized') {
     fwrite(STDERR, "Finalized snapshot should be locked and marked finalized.\n");
+    exit(1);
+}
+$persistedFilters = $pdo->query('SELECT filters_json FROM analytics_report_snapshot_v2 WHERE id = ' . (int)$snapshot['snapshot_id'])->fetchColumn();
+$decodedFilters = json_decode((string)$persistedFilters, true);
+if (($decodedFilters['business_role'] ?? '') !== 'staff') {
+    fwrite(STDERR, "Expected persisted business_role filter.\n");
     exit(1);
 }
 

--- a/tests/competency_framework_test.php
+++ b/tests/competency_framework_test.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/competency_framework.php';
+require_once __DIR__ . '/../lib/scoring.php';
+
+$bands = competency_default_level_bands();
+if (count($bands) !== 5) {
+    fwrite(STDERR, "Expected five default competency bands.\n");
+    exit(1);
+}
+
+$cases = [
+    [49.0, 'Not Proficient'],
+    [50.0, 'Basic Proficiency'],
+    [65.0, 'Intermediate Proficiency'],
+    [80.0, 'Advanced Proficiency'],
+    [95.0, 'Expert'],
+];
+
+foreach ($cases as $case) {
+    [$score, $expected] = $case;
+    $actual = questionnaire_competency_level($score);
+    if ($actual !== $expected) {
+        fwrite(STDERR, sprintf("Expected %s for score %.1f but received %s.\n", $expected, $score, $actual));
+        exit(1);
+    }
+}
+
+if (questionnaire_competency_gap(72.0, null) !== 28.0) {
+    fwrite(STDERR, "Expected 100-based gap to equal 28.0.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_gap(72.0, 80.0) !== 8.0) {
+    fwrite(STDERR, "Expected benchmark gap to equal 8.0.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_recommendation(59.0) !== 'Recommend training') {
+    fwrite(STDERR, "Expected training recommendation for low scores.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_recommendation(70.0) !== 'Recommend coaching') {
+    fwrite(STDERR, "Expected coaching recommendation for mid scores.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_recommendation(90.0) !== 'Consider mentorship role') {
+    fwrite(STDERR, "Expected mentorship recommendation for high scores.\n");
+    exit(1);
+}
+
+echo "Competency framework tests passed.\n";

--- a/tests/competency_framework_test.php
+++ b/tests/competency_framework_test.php
@@ -27,6 +27,31 @@ foreach ($cases as $case) {
     }
 }
 
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->exec(
+    'CREATE TABLE competency_level_band ('
+    . 'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+    . 'name TEXT NOT NULL, '
+    . 'min_pct REAL NOT NULL, '
+    . 'max_pct REAL NOT NULL, '
+    . 'rank_order INTEGER NOT NULL)'
+);
+$pdo->exec("INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order) VALUES ('Starter', 0.0, 74.99, 1)");
+$pdo->exec("INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order) VALUES ('Skilled', 75.0, 100.0, 2)");
+$GLOBALS['pdo'] = $pdo;
+competency_level_bands($pdo, true);
+
+if (questionnaire_competency_level(70.0) !== 'Starter') {
+    fwrite(STDERR, "Expected DB-configured level band Starter for score 70.0.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_level(90.0) !== 'Skilled') {
+    fwrite(STDERR, "Expected DB-configured level band Skilled for score 90.0.\n");
+    exit(1);
+}
+
 if (questionnaire_competency_gap(72.0, null) !== 28.0) {
     fwrite(STDERR, "Expected 100-based gap to equal 28.0.\n");
     exit(1);


### PR DESCRIPTION
### Motivation
- Introduce a role-based competency reporting model with configurable competency bands and benchmark policies to support executive summaries, drill-downs, and lockable report snapshots.
- Provide an immutable snapshot mechanism to persist generated analytics runs and enable CSV export and finalize/lock workflows for governance.

### Description
- Add database schema and migrations for competency reporting including tables `competency_level_band`, `competency_benchmark_policy`, and `analytics_report_snapshot_v2`, and add `users.business_role` and `users.directorate` fields via `init.sql`, `migration.sql`, and `config.php` schema initializer (`ensure_competency_reporting_schema`).
- Implement the snapshot engine and helpers in `lib/analytics_snapshot_v2.php` with functions `analytics_snapshot_v2_generate`, `analytics_snapshot_v2_finalize`, and helpers to enrich rows and compute critical gaps, plus `analytics_snapshot_v2_table_exists` and benchmark resolution.
- Add competency framework utilities in `lib/competency_framework.php` and wire them into scoring via updates to `lib/scoring.php` (level bands, gap and recommendation functions).
- Add admin UI and export endpoints with `admin/analytics_snapshot_v2.php` (snapshot workspace) and `admin/analytics_snapshot_v2_export.php` (CSV export), link from existing `admin/analytics.php`, and provide a CLI helper `scripts/generate_analytics_snapshot_v2.php`.
- Include documentation `docs/analytics_reporting_role_based_change_plan.md` describing the design and rollout plan and seed/default data insertion for bands and organization benchmark during schema initialization.
- Add automated tests `tests/competency_framework_test.php` and `tests/analytics_snapshot_v2_test.php` validating band mapping, gap/recommendation logic, snapshot persistence, and finalize/lock behavior.

### Testing
- Ran `tests/competency_framework_test.php` which exercises band defaults, `questionnaire_competency_level`, gap calculations, and recommendation rules, and it passed.
- Ran `tests/analytics_snapshot_v2_test.php` which uses an in-memory SQLite DB to validate snapshot generation, persistence into `analytics_report_snapshot_v2`, critical gap detection, and `analytics_snapshot_v2_finalize`, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6243cab74832d900081637854b55e)