### PR TITLE
Document password validation implementation and enforcement points

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ permissions, and relevant PHP configuration such as `upload_max_filesize`, `post
 A built-in Swagger UI is available to administrators at `/swagger.php` (linked under **Administration → API Documentation**).
 The page renders the OpenAPI definition stored at `docs/openapi.json`, covering FHIR resources and internal helper endpoints.
 For SAP ERP integrations, see `docs/sap-erp-integration-mapping-template.md` for a practical field-mapping and reliability
-checklist template.
+checklist template. Password policy and enforcement details are documented in `docs/password-validation.md`.
 
 ## Internationalisation
 

--- a/docs/password-validation.md
+++ b/docs/password-validation.md
@@ -1,0 +1,44 @@
+# Password Validation Implementation
+
+This project enforces password requirements through a shared server-side policy in `lib/security.php` and applies that policy consistently in profile updates and administrator user management.
+
+## 1) Shared policy definition
+
+- `password_policy_pattern()` defines a single regex used across the app.
+- Policy rules:
+  - minimum 8 characters
+  - at least one number **or** symbol
+- `password_meets_policy()` wraps the regex check and returns a strict boolean result.
+
+## 2) Where the policy is enforced
+
+### Profile password set/reset (`profile.php`)
+
+When a signed-in user updates their profile:
+
+- If `must_reset_password` is set, a non-empty password is required before they can continue.
+- If a password is provided, it must pass `password_meets_policy()`.
+- On success, the password is hashed with `password_hash(..., PASSWORD_DEFAULT)` and `must_reset_password` is cleared.
+
+### Admin user creation and password resets (`admin/users.php`)
+
+When administrators create or update users:
+
+- Create flow requires username + password and validates password via `password_meets_policy()`.
+- Reset flow validates new passwords (when provided) with the same policy.
+- Passwords are persisted only as hashes via `password_hash(..., PASSWORD_DEFAULT)`.
+- The admin flows set `must_reset_password = 1` when appropriate to force users through a first-login/next-login password change workflow.
+
+## 3) Login behavior related to validation
+
+`login.php` and `admin/login.php` verify credentials using `password_verify()` against stored hashes.
+
+If `must_reset_password` is enabled for an authenticated user, both login flows redirect to `profile.php?force_password_reset=1`, where the policy enforcement occurs.
+
+## 4) User-facing policy message
+
+The same message key (`password_policy_invalid`) is used so users see a consistent explanation of requirements:
+
+> "Password must be at least 8 characters and include at least one number or symbol."
+
+Translations are maintained in `lang/en.json`, `lang/fr.json`, and `lang/am.json`.


### PR DESCRIPTION
### Motivation
- Provide explicit documentation of the shared password policy and where it is enforced so maintainers and auditors can understand and review password handling.

### Description
- Add `docs/password-validation.md` describing the shared regex (`password_policy_pattern()`), the validator (`password_meets_policy()`), enforcement in `profile.php` and `admin/users.php`, use of `password_hash(..., PASSWORD_DEFAULT)`, and the `must_reset_password` forced-reset flow, and update `README.md` to link to the new guide.

### Testing
- Ran PHP syntax checks with `php -l` on `lib/security.php`, `profile.php`, `admin/users.php`, `login.php`, and `admin/login.php`, and all files reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e907c8aac4832d8525282401c0ccf4)