### PR TITLE
Split analytics automation/Looker into separate pages and enrich analytics reporting and PDF

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -316,137 +316,6 @@ if (isset($_SESSION['analytics_report_flash']) && is_array($_SESSION['analytics_
     }
 }
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    csrf_check();
-    $action = $_POST['action'] ?? '';
-    if ($action === 'send-report') {
-        $recipientInput = trim((string)($_POST['report_recipients'] ?? ''));
-        $selectedQuestionnaire = (int)($_POST['report_questionnaire_id'] ?? 0);
-        $includeDetails = !empty($_POST['report_include_details']);
-        $recipients = analytics_report_parse_recipients($recipientInput);
-        if (!$recipients) {
-            $reportError = t($t, 'analytics_report_recipients_required', 'Please provide at least one valid email address.');
-        } else {
-            $targetQuestionnaire = $selectedQuestionnaire > 0 ? $selectedQuestionnaire : null;
-            try {
-                $snapshot = analytics_report_snapshot($pdo, $targetQuestionnaire, $includeDetails);
-                $pdfData = analytics_report_render_pdf($snapshot, $cfg);
-                /** @var DateTimeImmutable $generatedAt */
-                $generatedAt = $snapshot['generated_at'];
-                $filename = analytics_report_filename($snapshot['selected_questionnaire_id'], $generatedAt);
-                $siteName = trim((string)($cfg['site_name'] ?? 'HR Assessment'));
-                $subject = ($siteName !== '' ? $siteName : 'HR Assessment') . ' analytics report - ' . $generatedAt->format('Y-m-d');
-                $bodyLines = [
-                    'Hello,',
-                    '',
-                    'Please find the attached analytics report generated on ' . $generatedAt->format('Y-m-d H:i') . '.',
-                ];
-                if ($includeDetails && !empty($snapshot['selected_questionnaire_title'])) {
-                    $bodyLines[] = 'Questionnaire focus: ' . $snapshot['selected_questionnaire_title'];
-                }
-                $bodyLines[] = '';
-                $bodyLines[] = 'Regards,';
-                $bodyLines[] = $siteName !== '' ? $siteName : 'HR Assessment';
-                $attachments = [[
-                    'filename' => $filename,
-                    'content' => $pdfData,
-                    'content_type' => 'application/pdf',
-                ]];
-                if (send_notification_email($cfg, $recipients, $subject, implode("\n", $bodyLines), $attachments)) {
-                    $reportMessage = t($t, 'analytics_report_sent', 'Analytics report emailed successfully.');
-                } else {
-                    $reportError = t($t, 'analytics_report_send_failed', 'Unable to send the analytics report email.');
-                }
-            } catch (Throwable $e) {
-                error_log('analytics report send failed: ' . $e->getMessage());
-                $reportError = t($t, 'analytics_report_send_failed', 'Unable to send the analytics report email.');
-            }
-        }
-    } elseif ($action === 'create-schedule') {
-        $recipientInput = trim((string)($_POST['schedule_recipients'] ?? ''));
-        $frequency = strtolower(trim((string)($_POST['schedule_frequency'] ?? 'weekly')));
-        if (!in_array($frequency, analytics_report_allowed_frequencies(), true)) {
-            $frequency = 'weekly';
-        }
-        $includeDetails = !empty($_POST['schedule_include_details']);
-        $questionnaireSelection = (int)($_POST['schedule_questionnaire_id'] ?? 0);
-        $recipients = analytics_report_parse_recipients($recipientInput);
-        if (!$recipients) {
-            $reportError = t($t, 'analytics_report_recipients_required', 'Please provide at least one valid email address.');
-        } else {
-            $startInput = trim((string)($_POST['schedule_start_at'] ?? ''));
-            if ($startInput === '') {
-                $startAt = new DateTimeImmutable('now');
-            } else {
-                $startAt = DateTimeImmutable::createFromFormat('Y-m-d\TH:i', $startInput) ?: null;
-            }
-            if (!$startAt) {
-                $reportError = t($t, 'analytics_schedule_start_invalid', 'Please provide a valid start date and time.');
-            } else {
-                $targetQuestionnaire = $questionnaireSelection > 0 ? $questionnaireSelection : null;
-                $recipientsStored = implode(', ', $recipients);
-                $createdBy = $_SESSION['user']['id'] ?? null;
-                try {
-                    $stmt = $pdo->prepare(
-                        'INSERT INTO analytics_report_schedule (recipients, frequency, next_run_at, last_run_at, created_by, questionnaire_id, include_details, active, created_at, updated_at) '
-                        . 'VALUES (?, ?, ?, NULL, ?, ?, ?, 1, NOW(), NOW())'
-                    );
-                    $stmt->execute([
-                        $recipientsStored,
-                        $frequency,
-                        $startAt->format('Y-m-d H:i:s'),
-                        $createdBy,
-                        $targetQuestionnaire,
-                        $includeDetails ? 1 : 0,
-                    ]);
-                    $reportMessage = t($t, 'analytics_schedule_created', 'Report schedule created successfully.');
-                } catch (PDOException $e) {
-                    error_log('analytics schedule create failed: ' . $e->getMessage());
-                    $reportError = t($t, 'analytics_schedule_create_failed', 'Unable to save the schedule. Please try again.');
-                }
-            }
-        }
-    } elseif ($action === 'toggle-schedule') {
-        $scheduleId = (int)($_POST['schedule_id'] ?? 0);
-        if ($scheduleId > 0) {
-            try {
-                $rowStmt = $pdo->prepare('SELECT active FROM analytics_report_schedule WHERE id = ?');
-                $rowStmt->execute([$scheduleId]);
-                $row = $rowStmt->fetch(PDO::FETCH_ASSOC);
-                if ($row) {
-                    $newStatus = ((int)($row['active'] ?? 0) === 1) ? 0 : 1;
-                    $update = $pdo->prepare('UPDATE analytics_report_schedule SET active = ?, updated_at = NOW() WHERE id = ?');
-                    $update->execute([$newStatus, $scheduleId]);
-                    $reportMessage = $newStatus
-                        ? t($t, 'analytics_schedule_enabled', 'Schedule enabled.')
-                        : t($t, 'analytics_schedule_paused', 'Schedule paused.');
-                } else {
-                    $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
-                }
-            } catch (PDOException $e) {
-                error_log('analytics schedule toggle failed: ' . $e->getMessage());
-                $reportError = t($t, 'analytics_schedule_update_failed', 'Unable to update the schedule.');
-            }
-        } else {
-            $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
-        }
-    } elseif ($action === 'delete-schedule') {
-        $scheduleId = (int)($_POST['schedule_id'] ?? 0);
-        if ($scheduleId > 0) {
-            try {
-                $stmt = $pdo->prepare('DELETE FROM analytics_report_schedule WHERE id = ?');
-                $stmt->execute([$scheduleId]);
-                $reportMessage = t($t, 'analytics_schedule_deleted', 'Schedule removed.');
-            } catch (PDOException $e) {
-                error_log('analytics schedule delete failed: ' . $e->getMessage());
-                $reportError = t($t, 'analytics_schedule_update_failed', 'Unable to update the schedule.');
-            }
-        } else {
-            $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
-        }
-    }
-}
-
 $summary = [];
 $totalParticipants = 0;
 $questionnaires = [];
@@ -638,66 +507,15 @@ $downloadUrlFor = static function (array $params = []) use ($pdo, $userId): stri
     }
 };
 
-$lookerStudioQuery = <<<'SQL'
-SELECT
-  qr.id AS response_id,
-  qr.created_at AS response_created_at,
-  qr.status AS response_status,
-  qr.score AS response_score,
-  qr.reviewed_at,
-  qr.review_comment,
-  pp.label AS performance_period,
-  q.id AS questionnaire_id,
-  COALESCE(q.family_key, CONCAT('questionnaire-', q.id)) AS questionnaire_family_key,
-  q.title AS questionnaire_title,
-  u.id AS user_id,
-  u.username,
-  u.full_name,
-  u.email,
-  u.department,
-  u.cadre,
-  u.work_function,
-  u.gender,
-  u.account_status,
-  u.created_at AS user_created_at,
-  reviewer.full_name AS reviewer_name,
-  reviewer.email AS reviewer_email,
-  qi.id AS item_id,
-  qi.linkId AS item_link_id,
-  qi.text AS item_text,
-  qi.type AS item_type,
-  qs.title AS section_title,
-  qri.answer AS item_answer,
-  tr.recommended_courses,
-  tr.recommendation_reasons
-FROM questionnaire_response qr
-JOIN users u ON u.id = qr.user_id
-JOIN questionnaire q ON q.id = qr.questionnaire_id
-LEFT JOIN users reviewer ON reviewer.id = qr.reviewed_by
-LEFT JOIN performance_period pp ON pp.id = qr.performance_period_id
-LEFT JOIN questionnaire_response_item qri ON qri.response_id = qr.id
-LEFT JOIN questionnaire_item qi ON qi.linkId = qri.linkId AND qi.questionnaire_id = qr.questionnaire_id
-LEFT JOIN questionnaire_section qs ON qs.id = qi.section_id
-LEFT JOIN (
-  SELECT
-    tr.questionnaire_response_id,
-    GROUP_CONCAT(cc.title ORDER BY cc.title SEPARATOR '; ') AS recommended_courses,
-    GROUP_CONCAT(tr.recommendation_reason ORDER BY cc.title SEPARATOR '; ') AS recommendation_reasons
-  FROM training_recommendation tr
-  JOIN course_catalogue cc ON cc.id = tr.course_id
-  GROUP BY tr.questionnaire_response_id
-) tr ON tr.questionnaire_response_id = qr.id;
-SQL;
-
 $defaultReportDownloads = [
     [
-        'title' => t($t, 'analytics_download_summary', 'Overall summary report'),
-        'description' => t($t, 'analytics_download_summary_hint', 'Includes total responses, averages, and questionnaire performance.'),
+        'title' => t($t, 'analytics_download_summary', 'Executive Summary'),
+        'description' => t($t, 'analytics_download_summary_hint', 'High-level competency health summary for leadership review.'),
         'url' => $downloadUrlFor([]),
     ],
     [
-        'title' => t($t, 'analytics_download_summary_details', 'Summary with top contributors'),
-        'description' => t($t, 'analytics_download_summary_details_hint', 'Adds the leading contributors for the busiest questionnaire.'),
+        'title' => t($t, 'analytics_download_summary_details', 'Full Competency Report'),
+        'description' => t($t, 'analytics_download_summary_details_hint', 'Expanded participant, competency, department, and role-based analysis.'),
         'url' => $downloadUrlFor(['include_details' => 1]),
     ],
 ];
@@ -1048,20 +866,6 @@ usort($workFunctionChartData, static function ($a, $b) {
 });
 if (count($workFunctionChartData) > 12) {
     $workFunctionChartData = array_slice($workFunctionChartData, 0, 12);
-}
-
-try {
-    $scheduleStmt = $pdo->query(
-        'SELECT s.*, q.title AS questionnaire_title, u.full_name AS creator_name '
-        . 'FROM analytics_report_schedule s '
-        . 'LEFT JOIN questionnaire q ON q.id = s.questionnaire_id '
-        . 'LEFT JOIN users u ON u.id = s.created_by '
-        . 'ORDER BY s.next_run_at ASC'
-    );
-    $reportSchedules = $scheduleStmt ? $scheduleStmt->fetchAll(PDO::FETCH_ASSOC) : [];
-} catch (PDOException $e) {
-    error_log('analytics schedule fetch failed: ' . $e->getMessage());
-    $reportSchedules = [];
 }
 
 $chartJsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
@@ -1492,146 +1296,16 @@ $pageHelpKey = 'team.analytics';
   </div>
 
   <div class="md-card md-elev-2">
-    <h2 class="md-card-title"><?=t($t, 'analytics_looker_resources', 'Analytics guide & Looker Studio query')?></h2>
-    <p><?=t($t, 'analytics_looker_resources_hint', 'Share the PDF guide and copy the SQL query into Google Looker Studio to build custom dashboards.')?></p>
-    <div class="md-analytics-guide">
-      <div class="md-guide-actions">
-        <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars(asset_url('assets/analytics-guide.pdf'), ENT_QUOTES, 'UTF-8')?>" target="_blank" rel="noopener noreferrer">
-          <?=t($t, 'analytics_download_guide', 'Download analytics guide (PDF)')?>
-        </a>
-      </div>
-      <div class="md-query-card">
-        <div class="md-query-header">
-          <h3><?=t($t, 'analytics_looker_query_title', 'Google Looker Studio query')?></h3>
-          <button class="md-button md-outline" type="button" data-copy-target="looker-query" data-copy-default="<?=htmlspecialchars(t($t, 'copy_query', 'Copy query'), ENT_QUOTES, 'UTF-8')?>" data-copy-success="<?=htmlspecialchars(t($t, 'copy_query_success', 'Copied!'), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'copy_query', 'Copy query')?></button>
-        </div>
-        <pre class="md-query-pre" id="looker-query"><code><?=htmlspecialchars($lookerStudioQuery, ENT_QUOTES, 'UTF-8')?></code></pre>
-      </div>
-    </div>
-  </div>
-
-  <div class="md-card md-elev-2">
-    <h2 class="md-card-title"><?=t($t, 'analytics_email_report', 'Email analytics report')?></h2>
-    <form method="post" class="md-form-grid md-report-grid" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>">
-      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-      <input type="hidden" name="action" value="send-report">
-      <label class="md-field">
-        <span><?=t($t, 'recipients', 'Recipients')?></span>
-        <textarea name="report_recipients" placeholder="name@example.com, other@example.com" required></textarea>
-      </label>
-      <label class="md-field">
-        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
-        <select name="report_questionnaire_id">
-          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
-          <?php foreach ($questionnaires as $row): ?>
-            <option value="<?=$row['id']?>"><?=htmlspecialchars($row['title'] ?? t($t, 'questionnaire', 'Questionnaire'), ENT_QUOTES, 'UTF-8')?></option>
-          <?php endforeach; ?>
-        </select>
-      </label>
-      <label class="md-checkbox">
-        <input type="checkbox" name="report_include_details" value="1">
-        <span><?=t($t, 'include_detailed_breakdown', 'Include detailed questionnaire breakdown')?></span>
-      </label>
-      <div class="md-inline-actions">
-        <button class="md-button md-primary" type="submit"><?=t($t, 'send_report_now', 'Send report')?></button>
-      </div>
-    </form>
-  </div>
-
-  <div class="md-card md-elev-2">
-    <h2 class="md-card-title"><?=t($t, 'analytics_schedules', 'Scheduled analytics reports')?></h2>
-    <form method="post" class="md-form-grid md-report-grid" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>">
-      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-      <input type="hidden" name="action" value="create-schedule">
-      <label class="md-field">
-        <span><?=t($t, 'recipients', 'Recipients')?></span>
-        <textarea name="schedule_recipients" placeholder="name@example.com, other@example.com" required></textarea>
-      </label>
-      <label class="md-field">
-        <span><?=t($t, 'frequency', 'Frequency')?></span>
-        <select name="schedule_frequency">
-          <?php foreach (analytics_report_allowed_frequencies() as $freq): ?>
-            <option value="<?=$freq?>"><?=htmlspecialchars(t($t, 'frequency_' . $freq, analytics_report_frequency_label($freq)), ENT_QUOTES, 'UTF-8')?></option>
-          <?php endforeach; ?>
-        </select>
-      </label>
-      <label class="md-field">
-        <span><?=t($t, 'start_time', 'First delivery (local time)')?></span>
-        <input type="datetime-local" name="schedule_start_at">
-      </label>
-      <label class="md-field">
-        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
-        <select name="schedule_questionnaire_id">
-          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
-          <?php foreach ($questionnaires as $row): ?>
-            <option value="<?=$row['id']?>"><?=htmlspecialchars($row['title'] ?? t($t, 'questionnaire', 'Questionnaire'), ENT_QUOTES, 'UTF-8')?></option>
-          <?php endforeach; ?>
-        </select>
-      </label>
-      <label class="md-checkbox">
-        <input type="checkbox" name="schedule_include_details" value="1">
-        <span><?=t($t, 'include_detailed_breakdown', 'Include detailed questionnaire breakdown')?></span>
-      </label>
-      <div class="md-inline-actions">
-        <button class="md-button md-primary" type="submit"><?=t($t, 'create_schedule', 'Create schedule')?></button>
-      </div>
-    </form>
-
-    <?php if ($reportSchedules): ?>
-      <div class="md-table-responsive">
-        <table class="md-table">
-          <thead>
-            <tr>
-              <th><?=t($t, 'recipients', 'Recipients')?></th>
-              <th><?=t($t, 'frequency', 'Frequency')?></th>
-              <th><?=t($t, 'questionnaire', 'Questionnaire')?></th>
-              <th><?=t($t, 'include_detailed_breakdown', 'Detailed breakdown?')?></th>
-              <th><?=t($t, 'next_run', 'Next send')?></th>
-              <th><?=t($t, 'last_run', 'Last sent')?></th>
-              <th><?=t($t, 'status', 'Status')?></th>
-              <th><?=t($t, 'action', 'Action')?></th>
-            </tr>
-          </thead>
-          <tbody>
-            <?php foreach ($reportSchedules as $schedule): ?>
-              <?php
-                $isActive = (int)($schedule['active'] ?? 0) === 1;
-                $frequencyKey = (string)($schedule['frequency'] ?? '');
-                $frequencyLabel = t($t, 'frequency_' . $frequencyKey, analytics_report_frequency_label($frequencyKey));
-                $questionnaireLabel = $schedule['questionnaire_id'] ? ($schedule['questionnaire_title'] ?? t($t, 'questionnaire', 'Questionnaire')) : t($t, 'all_questionnaires', 'All questionnaires');
-              ?>
-              <tr>
-                <td><?=htmlspecialchars($schedule['recipients'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
-                <td><?=htmlspecialchars($frequencyLabel, ENT_QUOTES, 'UTF-8')?></td>
-                <td><?=htmlspecialchars($questionnaireLabel, ENT_QUOTES, 'UTF-8')?></td>
-                <td><?=!empty($schedule['include_details']) ? t($t, 'yes', 'Yes') : t($t, 'no', 'No')?></td>
-                <td><?=htmlspecialchars($schedule['next_run_at'] ?? '-', ENT_QUOTES, 'UTF-8')?></td>
-                <td><?=htmlspecialchars($schedule['last_run_at'] ?? '-', ENT_QUOTES, 'UTF-8')?></td>
-                <td><?= $isActive ? t($t, 'status_active', 'Active') : t($t, 'status_disabled', 'Disabled') ?></td>
-                <td>
-                  <div class="md-schedule-actions">
-                    <form method="post" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-inline-form">
-                      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-                      <input type="hidden" name="action" value="toggle-schedule">
-                      <input type="hidden" name="schedule_id" value="<?= (int)$schedule['id'] ?>">
-                      <button class="md-button" type="submit"><?= $isActive ? t($t, 'pause', 'Pause') : t($t, 'resume', 'Resume') ?></button>
-                    </form>
-                    <form method="post" action="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>" class="md-inline-form" onsubmit="return confirm('<?=htmlspecialchars(t($t, 'confirm_delete_schedule', 'Remove this schedule?'), ENT_QUOTES, 'UTF-8')?>');">
-                      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
-                      <input type="hidden" name="action" value="delete-schedule">
-                      <input type="hidden" name="schedule_id" value="<?= (int)$schedule['id'] ?>">
-                      <button class="md-button md-danger" type="submit"><?=t($t, 'delete', 'Delete')?></button>
-                    </form>
-                  </div>
-                </td>
-              </tr>
-            <?php endforeach; ?>
-          </tbody>
-        </table>
-      </div>
-    <?php else: ?>
-      <p class="md-upgrade-meta"><?=t($t, 'no_schedules_configured', 'No report schedules have been configured yet.')?></p>
-    <?php endif; ?>
+    <h2 class="md-card-title"><?=t($t, 'analytics_tools', 'Analytics tools')?></h2>
+    <p><?=t($t, 'analytics_tools_hint', 'Manage automation and external BI resources from dedicated workspaces.')?></p>
+    <p>
+      <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>">
+        <?=t($t, 'analytics_open_automation', 'Open automation workspace')?>
+      </a>
+      <a class="md-button md-outline" href="<?=htmlspecialchars(url_for('admin/analytics_looker.php'), ENT_QUOTES, 'UTF-8')?>">
+        <?=t($t, 'analytics_open_looker_resources', 'Open Looker resources')?>
+      </a>
+    </p>
   </div>
 
   <div class="md-card md-elev-2">

--- a/admin/analytics_automation.php
+++ b/admin/analytics_automation.php
@@ -1,0 +1,334 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/analytics_report.php';
+
+auth_required(['admin', 'supervisor']);
+refresh_current_user($pdo);
+require_profile_completion($pdo);
+$locale = ensure_locale();
+$t = load_lang($locale);
+$cfg = get_site_config($pdo);
+
+$reportMessage = '';
+$reportError = '';
+
+if (isset($_SESSION['analytics_automation_flash']) && is_array($_SESSION['analytics_automation_flash'])) {
+    $flash = $_SESSION['analytics_automation_flash'];
+    unset($_SESSION['analytics_automation_flash']);
+    $reportMessage = (string)($flash['message'] ?? '');
+    $reportError = (string)($flash['error'] ?? '');
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check();
+    $action = (string)($_POST['action'] ?? '');
+
+    if ($action === 'send-report') {
+        $recipientInput = trim((string)($_POST['report_recipients'] ?? ''));
+        $selectedQuestionnaire = (int)($_POST['report_questionnaire_id'] ?? 0);
+        $includeDetails = !empty($_POST['report_include_details']);
+        $recipients = analytics_report_parse_recipients($recipientInput);
+
+        if (!$recipients) {
+            $reportError = t($t, 'analytics_report_recipients_required', 'Please provide at least one valid email address.');
+        } else {
+            $targetQuestionnaire = $selectedQuestionnaire > 0 ? $selectedQuestionnaire : null;
+            try {
+                $snapshot = analytics_report_snapshot($pdo, $targetQuestionnaire, $includeDetails);
+                $pdfData = analytics_report_render_pdf($snapshot, $cfg);
+                /** @var DateTimeImmutable $generatedAt */
+                $generatedAt = $snapshot['generated_at'];
+                $filename = analytics_report_filename($snapshot['selected_questionnaire_id'], $generatedAt);
+                $siteName = trim((string)($cfg['site_name'] ?? 'HR Assessment'));
+                $subject = ($siteName !== '' ? $siteName : 'HR Assessment') . ' analytics report - ' . $generatedAt->format('Y-m-d');
+                $bodyLines = [
+                    'Hello,',
+                    '',
+                    'Please find the attached analytics report generated on ' . $generatedAt->format('Y-m-d H:i') . '.',
+                ];
+                if ($includeDetails && !empty($snapshot['selected_questionnaire_title'])) {
+                    $bodyLines[] = 'Questionnaire focus: ' . $snapshot['selected_questionnaire_title'];
+                }
+                $bodyLines[] = '';
+                $bodyLines[] = 'Regards,';
+                $bodyLines[] = $siteName !== '' ? $siteName : 'HR Assessment';
+                $attachments = [[
+                    'filename' => $filename,
+                    'content' => $pdfData,
+                    'content_type' => 'application/pdf',
+                ]];
+
+                if (send_notification_email($cfg, $recipients, $subject, implode("\n", $bodyLines), $attachments)) {
+                    $reportMessage = t($t, 'analytics_report_sent', 'Analytics report emailed successfully.');
+                } else {
+                    $reportError = t($t, 'analytics_report_send_failed', 'Unable to send the analytics report email.');
+                }
+            } catch (Throwable $e) {
+                error_log('analytics report send failed: ' . $e->getMessage());
+                $reportError = t($t, 'analytics_report_send_failed', 'Unable to send the analytics report email.');
+            }
+        }
+    } elseif ($action === 'create-schedule') {
+        $recipientInput = trim((string)($_POST['schedule_recipients'] ?? ''));
+        $frequency = strtolower(trim((string)($_POST['schedule_frequency'] ?? 'weekly')));
+        if (!in_array($frequency, analytics_report_allowed_frequencies(), true)) {
+            $frequency = 'weekly';
+        }
+        $includeDetails = !empty($_POST['schedule_include_details']);
+        $questionnaireSelection = (int)($_POST['schedule_questionnaire_id'] ?? 0);
+        $recipients = analytics_report_parse_recipients($recipientInput);
+
+        if (!$recipients) {
+            $reportError = t($t, 'analytics_report_recipients_required', 'Please provide at least one valid email address.');
+        } else {
+            $startInput = trim((string)($_POST['schedule_start_at'] ?? ''));
+            $startAt = $startInput === '' ? new DateTimeImmutable('now') : (DateTimeImmutable::createFromFormat('Y-m-d\TH:i', $startInput) ?: null);
+            if (!$startAt) {
+                $reportError = t($t, 'analytics_schedule_start_invalid', 'Please provide a valid start date and time.');
+            } else {
+                $targetQuestionnaire = $questionnaireSelection > 0 ? $questionnaireSelection : null;
+                $recipientsStored = implode(', ', $recipients);
+                $createdBy = $_SESSION['user']['id'] ?? null;
+
+                try {
+                    $stmt = $pdo->prepare(
+                        'INSERT INTO analytics_report_schedule (recipients, frequency, next_run_at, last_run_at, created_by, questionnaire_id, include_details, active, created_at, updated_at) '
+                        . 'VALUES (?, ?, ?, NULL, ?, ?, ?, 1, NOW(), NOW())'
+                    );
+                    $stmt->execute([
+                        $recipientsStored,
+                        $frequency,
+                        $startAt->format('Y-m-d H:i:s'),
+                        $createdBy,
+                        $targetQuestionnaire,
+                        $includeDetails ? 1 : 0,
+                    ]);
+                    $reportMessage = t($t, 'analytics_schedule_created', 'Report schedule created successfully.');
+                } catch (PDOException $e) {
+                    error_log('analytics schedule create failed: ' . $e->getMessage());
+                    $reportError = t($t, 'analytics_schedule_create_failed', 'Unable to save the schedule. Please try again.');
+                }
+            }
+        }
+    } elseif ($action === 'toggle-schedule') {
+        $scheduleId = (int)($_POST['schedule_id'] ?? 0);
+        if ($scheduleId > 0) {
+            try {
+                $rowStmt = $pdo->prepare('SELECT active FROM analytics_report_schedule WHERE id = ?');
+                $rowStmt->execute([$scheduleId]);
+                $row = $rowStmt->fetch(PDO::FETCH_ASSOC);
+                if ($row) {
+                    $newStatus = ((int)($row['active'] ?? 0) === 1) ? 0 : 1;
+                    $update = $pdo->prepare('UPDATE analytics_report_schedule SET active = ?, updated_at = NOW() WHERE id = ?');
+                    $update->execute([$newStatus, $scheduleId]);
+                    $reportMessage = $newStatus
+                        ? t($t, 'analytics_schedule_enabled', 'Schedule enabled.')
+                        : t($t, 'analytics_schedule_paused', 'Schedule paused.');
+                } else {
+                    $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
+                }
+            } catch (PDOException $e) {
+                error_log('analytics schedule toggle failed: ' . $e->getMessage());
+                $reportError = t($t, 'analytics_schedule_update_failed', 'Unable to update the schedule.');
+            }
+        } else {
+            $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
+        }
+    } elseif ($action === 'delete-schedule') {
+        $scheduleId = (int)($_POST['schedule_id'] ?? 0);
+        if ($scheduleId > 0) {
+            try {
+                $stmt = $pdo->prepare('DELETE FROM analytics_report_schedule WHERE id = ?');
+                $stmt->execute([$scheduleId]);
+                $reportMessage = t($t, 'analytics_schedule_deleted', 'Schedule removed.');
+            } catch (PDOException $e) {
+                error_log('analytics schedule delete failed: ' . $e->getMessage());
+                $reportError = t($t, 'analytics_schedule_update_failed', 'Unable to update the schedule.');
+            }
+        } else {
+            $reportError = t($t, 'analytics_schedule_missing', 'Schedule not found.');
+        }
+    }
+
+    $_SESSION['analytics_automation_flash'] = ['message' => $reportMessage, 'error' => $reportError];
+    header('Location: ' . url_for('admin/analytics_automation.php'));
+    exit;
+}
+
+$questionnaires = [];
+try {
+    $qStmt = $pdo->query('SELECT id, title FROM questionnaire ORDER BY title ASC');
+    $questionnaires = $qStmt ? ($qStmt->fetchAll(PDO::FETCH_ASSOC) ?: []) : [];
+} catch (PDOException $e) {
+    error_log('analytics automation questionnaire fetch failed: ' . $e->getMessage());
+}
+
+try {
+    $scheduleStmt = $pdo->query(
+        'SELECT s.*, q.title AS questionnaire_title, u.full_name AS creator_name '
+        . 'FROM analytics_report_schedule s '
+        . 'LEFT JOIN questionnaire q ON q.id = s.questionnaire_id '
+        . 'LEFT JOIN users u ON u.id = s.created_by '
+        . 'ORDER BY s.next_run_at ASC'
+    );
+    $reportSchedules = $scheduleStmt ? $scheduleStmt->fetchAll(PDO::FETCH_ASSOC) : [];
+} catch (PDOException $e) {
+    error_log('analytics schedule fetch failed: ' . $e->getMessage());
+    $reportSchedules = [];
+}
+?>
+<!doctype html>
+<html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+<head>
+  <meta charset="utf-8">
+  <title><?=htmlspecialchars(t($t, 'analytics_automation', 'Analytics automation'), ENT_QUOTES, 'UTF-8')?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="<?=asset_url('manifest.php')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
+</head>
+<body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
+<?php include __DIR__ . '/../templates/header.php'; ?>
+<section class="md-section">
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'analytics_automation', 'Analytics automation')?></h2>
+    <p>
+      <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'back_to_analytics', 'Back to analytics')?></a>
+      <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics_looker.php'), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'open_looker_resources', 'Open Looker resources')?></a>
+    </p>
+  </div>
+
+  <?php if ($reportMessage): ?>
+    <div class="md-alert success"><?=htmlspecialchars($reportMessage, ENT_QUOTES, 'UTF-8')?></div>
+  <?php endif; ?>
+  <?php if ($reportError): ?>
+    <div class="md-alert error"><?=htmlspecialchars($reportError, ENT_QUOTES, 'UTF-8')?></div>
+  <?php endif; ?>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'analytics_email_report', 'Email analytics report')?></h2>
+    <form method="post" class="md-form-grid md-report-grid" action="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>">
+      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <input type="hidden" name="action" value="send-report">
+      <label class="md-field">
+        <span><?=t($t, 'recipients', 'Recipients')?></span>
+        <textarea name="report_recipients" placeholder="name@example.com, other@example.com" required></textarea>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
+        <select name="report_questionnaire_id">
+          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
+          <?php foreach ($questionnaires as $row): ?>
+            <option value="<?=$row['id']?>"><?=htmlspecialchars($row['title'] ?? t($t, 'questionnaire', 'Questionnaire'), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-checkbox">
+        <input type="checkbox" name="report_include_details" value="1">
+        <span><?=t($t, 'include_detailed_breakdown', 'Include detailed questionnaire breakdown')?></span>
+      </label>
+      <div class="md-inline-actions">
+        <button class="md-button md-primary" type="submit"><?=t($t, 'send_report_now', 'Send report')?></button>
+      </div>
+    </form>
+  </div>
+
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'analytics_schedules', 'Scheduled analytics reports')?></h2>
+    <form method="post" class="md-form-grid md-report-grid" action="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>">
+      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+      <input type="hidden" name="action" value="create-schedule">
+      <label class="md-field">
+        <span><?=t($t, 'recipients', 'Recipients')?></span>
+        <textarea name="schedule_recipients" placeholder="name@example.com, other@example.com" required></textarea>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'frequency', 'Frequency')?></span>
+        <select name="schedule_frequency">
+          <?php foreach (analytics_report_allowed_frequencies() as $freq): ?>
+            <option value="<?=$freq?>"><?=htmlspecialchars(t($t, 'frequency_' . $freq, analytics_report_frequency_label($freq)), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'start_time', 'First delivery (local time)')?></span>
+        <input type="datetime-local" name="schedule_start_at">
+      </label>
+      <label class="md-field">
+        <span><?=t($t, 'questionnaire', 'Questionnaire')?></span>
+        <select name="schedule_questionnaire_id">
+          <option value="0"><?=t($t, 'all_questionnaires', 'All questionnaires')?></option>
+          <?php foreach ($questionnaires as $row): ?>
+            <option value="<?=$row['id']?>"><?=htmlspecialchars($row['title'] ?? t($t, 'questionnaire', 'Questionnaire'), ENT_QUOTES, 'UTF-8')?></option>
+          <?php endforeach; ?>
+        </select>
+      </label>
+      <label class="md-checkbox">
+        <input type="checkbox" name="schedule_include_details" value="1">
+        <span><?=t($t, 'include_detailed_breakdown', 'Include detailed questionnaire breakdown')?></span>
+      </label>
+      <div class="md-inline-actions">
+        <button class="md-button md-primary" type="submit"><?=t($t, 'create_schedule', 'Create schedule')?></button>
+      </div>
+    </form>
+
+    <?php if ($reportSchedules): ?>
+      <div class="md-table-responsive">
+        <table class="md-table">
+          <thead>
+            <tr>
+              <th><?=t($t, 'recipients', 'Recipients')?></th>
+              <th><?=t($t, 'frequency', 'Frequency')?></th>
+              <th><?=t($t, 'questionnaire', 'Questionnaire')?></th>
+              <th><?=t($t, 'details', 'Detailed')?></th>
+              <th><?=t($t, 'next_run', 'Next run')?></th>
+              <th><?=t($t, 'last_run', 'Last run')?></th>
+              <th><?=t($t, 'status', 'Status')?></th>
+              <th><?=t($t, 'actions', 'Actions')?></th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($reportSchedules as $schedule): ?>
+              <?php
+                $isActive = (int)($schedule['active'] ?? 0) === 1;
+                $frequencyKey = (string)($schedule['frequency'] ?? '');
+                $frequencyLabel = t($t, 'frequency_' . $frequencyKey, analytics_report_frequency_label($frequencyKey));
+                $questionnaireLabel = $schedule['questionnaire_id'] ? ($schedule['questionnaire_title'] ?? t($t, 'questionnaire', 'Questionnaire')) : t($t, 'all_questionnaires', 'All questionnaires');
+              ?>
+              <tr>
+                <td><?=htmlspecialchars($schedule['recipients'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($frequencyLabel, ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($questionnaireLabel, ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=!empty($schedule['include_details']) ? t($t, 'yes', 'Yes') : t($t, 'no', 'No')?></td>
+                <td><?=htmlspecialchars($schedule['next_run_at'] ?? '-', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?=htmlspecialchars($schedule['last_run_at'] ?? '-', ENT_QUOTES, 'UTF-8')?></td>
+                <td><?= $isActive ? t($t, 'active', 'Active') : t($t, 'paused', 'Paused') ?></td>
+                <td>
+                  <div class="md-inline-actions">
+                    <form method="post" action="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>" class="md-inline-form">
+                      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+                      <input type="hidden" name="action" value="toggle-schedule">
+                      <input type="hidden" name="schedule_id" value="<?= (int)$schedule['id'] ?>">
+                      <button type="submit" class="md-button md-outline"><?= $isActive ? t($t, 'pause', 'Pause') : t($t, 'enable', 'Enable') ?></button>
+                    </form>
+                    <form method="post" action="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>" class="md-inline-form" onsubmit="return confirm('<?=htmlspecialchars(t($t, 'confirm_delete_schedule', 'Remove this schedule?'), ENT_QUOTES, 'UTF-8')?>');">
+                      <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+                      <input type="hidden" name="action" value="delete-schedule">
+                      <input type="hidden" name="schedule_id" value="<?= (int)$schedule['id'] ?>">
+                      <button type="submit" class="md-button md-danger"><?=t($t, 'delete', 'Delete')?></button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php else: ?>
+      <p class="md-upgrade-meta"><?=t($t, 'no_schedules_configured', 'No report schedules have been configured yet.')?></p>
+    <?php endif; ?>
+  </div>
+</section>
+<?php include __DIR__ . '/../templates/footer.php'; ?>
+</body>
+</html>

--- a/admin/analytics_looker.php
+++ b/admin/analytics_looker.php
@@ -1,0 +1,100 @@
+<?php
+require_once __DIR__ . '/../config.php';
+
+auth_required(['admin', 'supervisor']);
+refresh_current_user($pdo);
+require_profile_completion($pdo);
+$locale = ensure_locale();
+$t = load_lang($locale);
+$cfg = get_site_config($pdo);
+
+$lookerStudioQuery = <<<'SQL'
+SELECT
+  qr.id AS response_id,
+  qr.created_at AS response_created_at,
+  qr.status AS response_status,
+  qr.score AS response_score,
+  qr.reviewed_at,
+  qr.review_comment,
+  pp.label AS performance_period,
+  q.id AS questionnaire_id,
+  COALESCE(q.family_key, CONCAT('questionnaire-', q.id)) AS questionnaire_family_key,
+  q.title AS questionnaire_title,
+  u.id AS user_id,
+  u.username,
+  u.full_name,
+  u.email,
+  u.department,
+  u.cadre,
+  u.work_function,
+  u.gender,
+  u.account_status,
+  u.created_at AS user_created_at,
+  reviewer.full_name AS reviewer_name,
+  reviewer.email AS reviewer_email,
+  qi.id AS item_id,
+  qi.linkId AS item_link_id,
+  qi.text AS item_text,
+  qi.type AS item_type,
+  qs.title AS section_title,
+  qri.answer AS item_answer,
+  tr.recommended_courses,
+  tr.recommendation_reasons
+FROM questionnaire_response qr
+JOIN users u ON u.id = qr.user_id
+JOIN questionnaire q ON q.id = qr.questionnaire_id
+LEFT JOIN users reviewer ON reviewer.id = qr.reviewed_by
+LEFT JOIN performance_period pp ON pp.id = qr.performance_period_id
+LEFT JOIN questionnaire_response_item qri ON qri.response_id = qr.id
+LEFT JOIN questionnaire_item qi ON qi.linkId = qri.linkId AND qi.questionnaire_id = qr.questionnaire_id
+LEFT JOIN questionnaire_section qs ON qs.id = qi.section_id
+LEFT JOIN (
+  SELECT
+    tr.questionnaire_response_id,
+    GROUP_CONCAT(cc.title ORDER BY cc.title SEPARATOR '; ') AS recommended_courses,
+    GROUP_CONCAT(tr.recommendation_reason ORDER BY cc.title SEPARATOR '; ') AS recommendation_reasons
+  FROM training_recommendation tr
+  JOIN course_catalogue cc ON cc.id = tr.course_id
+  GROUP BY tr.questionnaire_response_id
+) tr ON tr.questionnaire_response_id = qr.id;
+SQL;
+?>
+<!doctype html>
+<html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
+<head>
+  <meta charset="utf-8">
+  <title><?=htmlspecialchars(t($t, 'analytics_looker_resources', 'Analytics guide & Looker Studio query'), ENT_QUOTES, 'UTF-8')?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="<?=asset_url('manifest.php')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/material.css')?>">
+  <link rel="stylesheet" href="<?=asset_url('assets/css/styles.css')?>">
+</head>
+<body class="<?=htmlspecialchars(site_body_classes($cfg), ENT_QUOTES, 'UTF-8')?>">
+<?php include __DIR__ . '/../templates/header.php'; ?>
+<section class="md-section">
+  <div class="md-card md-elev-2">
+    <h2 class="md-card-title"><?=t($t, 'analytics_looker_resources', 'Analytics guide & Looker Studio query')?></h2>
+    <p><?=t($t, 'analytics_looker_resources_hint', 'Share the PDF guide and copy the SQL query into Google Looker Studio to build custom dashboards.')?></p>
+    <p>
+      <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics.php'), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'back_to_analytics', 'Back to analytics')?></a>
+      <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'open_analytics_automation', 'Open automation')?></a>
+    </p>
+    <div class="md-analytics-guide">
+      <div class="md-guide-actions">
+        <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars(asset_url('assets/analytics-guide.pdf'), ENT_QUOTES, 'UTF-8')?>" target="_blank" rel="noopener noreferrer">
+          <?=t($t, 'analytics_download_guide', 'Download analytics guide (PDF)')?>
+        </a>
+      </div>
+      <div class="md-query-card">
+        <div class="md-query-header">
+          <h3><?=t($t, 'analytics_looker_query_title', 'Google Looker Studio query')?></h3>
+          <button class="md-button md-outline" type="button" data-copy-target="looker-query" data-copy-default="<?=htmlspecialchars(t($t, 'copy_query', 'Copy query'), ENT_QUOTES, 'UTF-8')?>" data-copy-success="<?=htmlspecialchars(t($t, 'copy_query_success', 'Copied!'), ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'copy_query', 'Copy query')?></button>
+        </div>
+        <pre class="md-query-pre" id="looker-query"><code><?=htmlspecialchars($lookerStudioQuery, ENT_QUOTES, 'UTF-8')?></code></pre>
+      </div>
+    </div>
+  </div>
+</section>
+<?php include __DIR__ . '/../templates/footer.php'; ?>
+</body>
+</html>

--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -61,6 +61,43 @@ function analytics_report_parse_recipients(string $input): array
     return array_values($emails);
 }
 
+function analytics_report_table_has_column(PDO $pdo, string $table, string $column): bool
+{
+    static $cache = [];
+    $key = strtolower($table . '.' . $column);
+    if (array_key_exists($key, $cache)) {
+        return $cache[$key];
+    }
+
+    $driver = (string)$pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    try {
+        if ($driver === 'sqlite') {
+            $stmt = $pdo->query("PRAGMA table_info($table)");
+            $rows = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+            foreach ($rows as $row) {
+                if (strcasecmp((string)($row['name'] ?? ''), $column) === 0) {
+                    $cache[$key] = true;
+                    return true;
+                }
+            }
+        } else {
+            $stmt = $pdo->query('SHOW COLUMNS FROM `' . str_replace('`', '``', $table) . '`');
+            $rows = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+            foreach ($rows as $row) {
+                if (strcasecmp((string)($row['Field'] ?? ''), $column) === 0) {
+                    $cache[$key] = true;
+                    return true;
+                }
+            }
+        }
+    } catch (Throwable $e) {
+        error_log('analytics_report schema lookup failed: ' . $e->getMessage());
+    }
+
+    $cache[$key] = false;
+    return false;
+}
+
 function analytics_report_snapshot(PDO $pdo, ?int $questionnaireId = null, bool $includeDetails = false): array
 {
     $translations = [];
@@ -276,6 +313,42 @@ function analytics_report_snapshot(PDO $pdo, ?int $questionnaireId = null, bool 
     $periodSeries = analytics_report_collect_period_series($pdo, null);
     $selectedPeriodSeries = $selectedId ? analytics_report_collect_period_series($pdo, $selectedId) : [];
 
+    $departmentAnalysis = [];
+    if (analytics_report_table_has_column($pdo, 'users', 'department')) {
+        $departmentStmt = $pdo->query(
+            "SELECT COALESCE(NULLIF(u.department, ''), 'Unknown') AS department, COUNT(*) AS total_responses, AVG(qr.score) AS avg_score "
+            . "FROM questionnaire_response qr "
+            . "JOIN users u ON u.id = qr.user_id "
+            . "GROUP BY COALESCE(NULLIF(u.department, ''), 'Unknown') "
+            . "ORDER BY avg_score DESC, total_responses DESC"
+        );
+        $departmentAnalysis = $departmentStmt ? ($departmentStmt->fetchAll(PDO::FETCH_ASSOC) ?: []) : [];
+    }
+
+    $roleOverview = [];
+    if (analytics_report_table_has_column($pdo, 'users', 'cadre')) {
+        $roleStmt = $pdo->query(
+            "SELECT COALESCE(NULLIF(u.cadre, ''), 'Unspecified') AS role_label, COUNT(DISTINCT qr.user_id) AS total_participants, AVG(qr.score) AS avg_score "
+            . "FROM questionnaire_response qr "
+            . "JOIN users u ON u.id = qr.user_id "
+            . "GROUP BY COALESCE(NULLIF(u.cadre, ''), 'Unspecified') "
+            . "ORDER BY total_participants DESC, role_label ASC"
+        );
+        $roleOverview = $roleStmt ? ($roleStmt->fetchAll(PDO::FETCH_ASSOC) ?: []) : [];
+    }
+
+    $genderDistribution = [];
+    if (analytics_report_table_has_column($pdo, 'users', 'gender')) {
+        $genderStmt = $pdo->query(
+            "SELECT COALESCE(NULLIF(u.gender, ''), 'Unspecified') AS gender_label, COUNT(DISTINCT qr.user_id) AS total_participants "
+            . "FROM questionnaire_response qr "
+            . "JOIN users u ON u.id = qr.user_id "
+            . "GROUP BY COALESCE(NULLIF(u.gender, ''), 'Unspecified') "
+            . "ORDER BY total_participants DESC, gender_label ASC"
+        );
+        $genderDistribution = $genderStmt ? ($genderStmt->fetchAll(PDO::FETCH_ASSOC) ?: []) : [];
+    }
+
     return [
         'summary' => $summary,
         'total_participants' => $totalParticipants,
@@ -289,6 +362,9 @@ function analytics_report_snapshot(PDO $pdo, ?int $questionnaireId = null, bool 
         'work_function_chart' => $workFunctionChart,
         'period_chart' => $periodSeries,
         'period_chart_selected' => $selectedPeriodSeries,
+        'department_analysis' => $departmentAnalysis,
+        'role_overview' => $roleOverview,
+        'gender_distribution' => $genderDistribution,
         'include_details' => $includeDetails,
         'generated_at' => new DateTimeImmutable('now'),
     ];
@@ -356,20 +432,70 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
     $pdf->addParagraph('Generated on ' . $generatedAt->format('Y-m-d H:i'));
 
     $summary = $snapshot['summary'];
-    $summaryRows = [
-        ['Total responses', analytics_report_format_number($summary['total_responses'] ?? 0)],
-        ['Approved', analytics_report_format_number($summary['approved_count'] ?? 0)],
-        ['Submitted', analytics_report_format_number($summary['submitted_count'] ?? 0)],
-        ['Draft', analytics_report_format_number($summary['draft_count'] ?? 0)],
-        ['Rejected', analytics_report_format_number($summary['rejected_count'] ?? 0)],
-        ['Average score', analytics_report_format_score($summary['avg_score'])],
-        ['Average competency', questionnaire_competency_level(isset($summary['avg_score']) ? (float)$summary['avg_score'] : null) ?: '—'],
-        ['Latest submission', analytics_report_format_date($summary['latest_at'])],
-        ['Unique participants', analytics_report_format_number($snapshot['total_participants'] ?? 0)],
-    ];
+    $isFullCompetencyReport = !empty($snapshot['include_details']);
+    $avgScore = isset($summary['avg_score']) ? (float)$summary['avg_score'] : null;
+    $competencyLevel = questionnaire_competency_level($avgScore) ?: '—';
 
-    $pdf->addSubheading('Overall summary');
-    $pdf->addTable(['Metric', 'Value'], $summaryRows, [32, 18]);
+    $assessmentPeriod = 'All available periods';
+    if (!empty($snapshot['period_chart'])) {
+        $firstPeriod = (string)($snapshot['period_chart'][0]['label'] ?? '');
+        $lastPeriod = (string)($snapshot['period_chart'][count($snapshot['period_chart']) - 1]['label'] ?? '');
+        if ($firstPeriod !== '' && $lastPeriod !== '') {
+            $assessmentPeriod = $firstPeriod === $lastPeriod ? $firstPeriod : ($firstPeriod . ' → ' . $lastPeriod);
+        }
+    }
+
+    $departmentsCovered = count($snapshot['department_analysis'] ?? []);
+    $pdf->addSubheading('1. Executive Summary');
+    $pdf->addParagraph('Assessment Period: ' . $assessmentPeriod);
+    $pdf->addParagraph('Total Participants: ' . analytics_report_format_number($snapshot['total_participants'] ?? 0));
+    $pdf->addParagraph('Departments Covered: ' . analytics_report_format_number($departmentsCovered));
+    $pdf->addParagraph('Assessment Date: ' . $generatedAt->format('Y-m-d'));
+    $pdf->addParagraph('Overall Organizational Competency Score: ' . analytics_report_format_score($avgScore));
+    $pdf->addParagraph('Competency Level Classification: ' . $competencyLevel);
+    $pdf->addBulletList([
+        'Not Proficient',
+        'Basic Proficiency',
+        'Intermediate Proficiency',
+        'Advanced Proficiency',
+        'Expert Level',
+    ]);
+
+    $topStrengths = [];
+    $topGaps = [];
+    foreach ($snapshot['questionnaires'] as $row) {
+        if (!isset($row['avg_score']) || $row['avg_score'] === null) {
+            continue;
+        }
+        $topStrengths[] = [
+            'name' => (string)($row['title'] ?? 'Questionnaire'),
+            'score' => (float)$row['avg_score'],
+        ];
+    }
+    usort($topStrengths, static fn(array $a, array $b): int => ($b['score'] <=> $a['score']));
+    $topGaps = array_reverse($topStrengths);
+    $topStrengths = array_slice($topStrengths, 0, 3);
+    $topGaps = array_slice($topGaps, 0, 3);
+
+    $highestDepartment = 'N/A';
+    $lowestDepartment = 'N/A';
+    if (!empty($snapshot['department_analysis'])) {
+        $departmentRows = array_values(array_filter($snapshot['department_analysis'], static function (array $row): bool {
+            return isset($row['avg_score']) && $row['avg_score'] !== null;
+        }));
+        if ($departmentRows) {
+            usort($departmentRows, static fn(array $a, array $b): int => ((float)$b['avg_score'] <=> (float)$a['avg_score']));
+            $highestDepartment = (string)($departmentRows[0]['department'] ?? 'N/A');
+            $lowestDepartment = (string)($departmentRows[count($departmentRows) - 1]['department'] ?? 'N/A');
+        }
+    }
+
+    $pdf->addParagraph('Key Findings:');
+    $pdf->addBulletList([
+        'Top 3 strongest competencies: ' . ($topStrengths ? implode(', ', array_map(static fn(array $row): string => $row['name'] . ' (' . number_format($row['score'], 1) . '%)', $topStrengths)) : 'N/A'),
+        'Top 3 critical competency gaps: ' . ($topGaps ? implode(', ', array_map(static fn(array $row): string => $row['name'] . ' (' . number_format(100 - $row['score'], 1) . '% gap)', $topGaps)) : 'N/A'),
+        'Departments with highest and lowest performance: ' . $highestDepartment . ' / ' . $lowestDepartment,
+    ]);
 
     $pdf->addSubheading('Questionnaire performance');
     $questionnaireRows = [];
@@ -534,9 +660,117 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
         }
     }
 
-    if (!empty($snapshot['include_details']) && !empty($snapshot['user_breakdown'])) {
+    if ($isFullCompetencyReport) {
+        $pdf->addSubheading('3. Participant Overview Auto-Generated');
+        $roleRows = $snapshot['role_overview'] ?? [];
+        $directorCount = 0;
+        $managerCount = 0;
+        $leaderCount = 0;
+        $staffCount = 0;
+        foreach ($roleRows as $roleRow) {
+            $label = strtolower(trim((string)($roleRow['role_label'] ?? '')));
+            $count = (int)($roleRow['total_participants'] ?? 0);
+            if (str_contains($label, 'director')) {
+                $directorCount += $count;
+            } elseif (str_contains($label, 'manager')) {
+                $managerCount += $count;
+            } elseif (str_contains($label, 'leader')) {
+                $leaderCount += $count;
+            } else {
+                $staffCount += $count;
+            }
+        }
+        $pdf->addParagraph('By Role:');
+        $pdf->addBulletList([
+            'Directors: ' . analytics_report_format_number($directorCount),
+            'Managers: ' . analytics_report_format_number($managerCount),
+            'Team Leaders: ' . analytics_report_format_number($leaderCount),
+            'Staff: ' . analytics_report_format_number($staffCount),
+        ]);
+
+        $pdf->addParagraph('By Department:');
+        $departmentLines = [];
+        foreach (array_slice($snapshot['department_analysis'] ?? [], 0, 6) as $deptRow) {
+            $departmentLines[] = (string)($deptRow['department'] ?? 'Department') . ' – ' . analytics_report_format_number($deptRow['total_responses'] ?? 0) . ' participants';
+        }
+        $pdf->addBulletList($departmentLines ?: ['No department data available']);
+
+        $pdf->addParagraph('Gender Distribution (Auto-populated from registration data)');
+        $genderLines = [];
+        foreach ($snapshot['gender_distribution'] ?? [] as $genderRow) {
+            $genderLines[] = (string)($genderRow['gender_label'] ?? 'Unspecified') . ': ' . analytics_report_format_number($genderRow['total_participants'] ?? 0);
+        }
+        $pdf->addBulletList($genderLines ?: ['No gender data available']);
+
+        $pdf->addSubheading('4. Overall Competency Results Dashboard');
+        $orgRows = [];
+        foreach (array_slice($snapshot['questionnaires'] ?? [], 0, 6) as $row) {
+            if (!isset($row['avg_score']) || $row['avg_score'] === null) {
+                continue;
+            }
+            $score = (float)$row['avg_score'];
+            $orgRows[] = [
+                (string)($row['title'] ?? 'Competency Area'),
+                number_format($score, 1) . '%',
+                questionnaire_competency_level($score) ?: '—',
+                number_format(max(0, 100 - $score), 1) . '%',
+            ];
+        }
+        if ($orgRows) {
+            $pdf->addTable(['Competency Area', 'Average Score (%)', 'Competency Level', 'Gap (%)'], $orgRows, [22, 14, 14, 10]);
+        } else {
+            $pdf->addParagraph('No organization-level competency rows are available yet.');
+        }
+        $pdf->addParagraph('(Gap % = 100% – actual score OR based on required benchmark level)');
+
+        $pdf->addSubheading('5. Department-Level Analysis');
+        $deptRows = [];
+        foreach (array_slice($snapshot['department_analysis'] ?? [], 0, 10) as $row) {
+            $score = isset($row['avg_score']) && $row['avg_score'] !== null ? (float)$row['avg_score'] : null;
+            $deptRows[] = [
+                (string)($row['department'] ?? 'Unknown'),
+                analytics_report_format_score($score),
+                questionnaire_competency_level($score) ?: '—',
+                $score !== null ? number_format(max(0, 100 - $score), 1) . '%' : '—',
+            ];
+        }
+        if ($deptRows) {
+            $pdf->addTable(['Department', 'Average Score', 'Level', 'Key Gap'], $deptRows, [24, 12, 12, 12]);
+        } else {
+            $pdf->addParagraph('No department-level records are available yet.');
+        }
+        $pdf->addBulletList([
+            'Heatmap visualization',
+            'Bar chart comparison across departments',
+        ]);
+
+        $pdf->addSubheading('6. Role-Based Analysis');
+        $roleTable = [];
+        foreach (array_slice($roleRows, 0, 10) as $row) {
+            $score = isset($row['avg_score']) && $row['avg_score'] !== null ? (float)$row['avg_score'] : null;
+            $roleTable[] = [
+                (string)($row['role_label'] ?? 'Role'),
+                analytics_report_format_score($score),
+                $score !== null ? number_format(max(0, 100 - $score), 1) . '%' : '—',
+            ];
+        }
+        if ($roleTable) {
+            $pdf->addTable(['Role', 'Average Score', 'Primary Gap'], $roleTable, [26, 14, 20]);
+        } else {
+            $pdf->addParagraph('No role-based records are available yet.');
+        }
+        $pdf->addParagraph('This section allows filtering by:');
+        $pdf->addBulletList([
+            'Role',
+            'Work Role',
+            'Directorate',
+            'Individual',
+        ]);
+    }
+
+    if ($isFullCompetencyReport && !empty($snapshot['user_breakdown'])) {
         $selectedTitle = trim((string)($snapshot['selected_questionnaire_title'] ?? ''));
-        $pdf->addSubheading('Top contributors' . ($selectedTitle !== '' ? ': ' . $selectedTitle : ''));
+        $pdf->addSubheading('Full Competency Report Contributors' . ($selectedTitle !== '' ? ': ' . $selectedTitle : ''));
         $detailRows = [];
         foreach ($snapshot['user_breakdown'] as $row) {
             $display = trim((string)($row['full_name'] ?? ''));


### PR DESCRIPTION
### Motivation
- Separate the analytics UI so automation and external BI resources are managed from dedicated workspaces rather than the main analytics page.
- Improve analytics reporting by adding department/role/gender breakdowns when registration schema provides those fields.
- Produce a richer, executive-style PDF snapshot that gives higher-level findings, department/role summaries and configurable "full competency" detail.

### Description
- Removed in-page email/scheduling and Looker query UI from `admin/analytics.php` and replaced the section with links to dedicated pages `admin/analytics_automation.php` and `admin/analytics_looker.php`.
- Added `admin/analytics_automation.php` to handle sending reports, creating/toggling/deleting schedules and listing schedules; added `admin/analytics_looker.php` to display the Looker Studio SQL and analytics guide.
- Extended `lib/analytics_report.php` with `analytics_report_table_has_column()` for safe schema checks and expanded `analytics_report_snapshot()` to include `department_analysis`, `role_overview`, and `gender_distribution` when available.
- Enhanced `analytics_report_render_pdf()` to generate an executive summary, competency dashboards, department/role tables and an optional full competency contributors table when `include_details` is enabled, plus renamed some download labels and adjusted report content.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9044faa70832db925fcb573c63a0e)