### PR TITLE
Honor runtime competency level bands in scoring and snapshots

### DIFF
--- a/lib/competency_framework.php
+++ b/lib/competency_framework.php
@@ -19,6 +19,81 @@ function competency_default_level_bands(): array
 }
 
 /**
+ * Resolve competency level bands from runtime configuration when available.
+ *
+ * Falls back to default level bands if no database connection or overrides exist.
+ *
+ * @return array<int, array{name:string,min_pct:float,max_pct:float,rank_order:int}>
+ */
+function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): array
+{
+    static $cache = [];
+
+    if ($pdo === null && isset($GLOBALS['pdo']) && $GLOBALS['pdo'] instanceof PDO) {
+        $pdo = $GLOBALS['pdo'];
+    }
+
+    if (!$pdo instanceof PDO) {
+        return competency_default_level_bands();
+    }
+
+    $cacheKey = spl_object_id($pdo);
+    if (!$forceRefresh && isset($cache[$cacheKey])) {
+        return $cache[$cacheKey];
+    }
+
+    try {
+        $driver = strtolower((string)$pdo->getAttribute(PDO::ATTR_DRIVER_NAME));
+        if ($driver === 'sqlite') {
+            $existsStmt = $pdo->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = 'competency_level_band' LIMIT 1");
+            $existsStmt->execute();
+            if (!$existsStmt->fetch(PDO::FETCH_ASSOC)) {
+                return $cache[$cacheKey] = competency_default_level_bands();
+            }
+        } else {
+            $existsStmt = $pdo->prepare(
+                'SELECT COUNT(1) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = ?'
+            );
+            $existsStmt->execute(['competency_level_band']);
+            if ((int)$existsStmt->fetchColumn() <= 0) {
+                return $cache[$cacheKey] = competency_default_level_bands();
+            }
+        }
+
+        $stmt = $pdo->query(
+            'SELECT name, min_pct, max_pct, rank_order FROM competency_level_band ORDER BY rank_order ASC, id ASC'
+        );
+        $rows = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
+        if (!is_array($rows) || $rows === []) {
+            return $cache[$cacheKey] = competency_default_level_bands();
+        }
+
+        $bands = [];
+        foreach ($rows as $row) {
+            $name = trim((string)($row['name'] ?? ''));
+            if ($name === '') {
+                continue;
+            }
+            $bands[] = [
+                'name' => $name,
+                'min_pct' => isset($row['min_pct']) ? (float)$row['min_pct'] : 0.0,
+                'max_pct' => isset($row['max_pct']) ? (float)$row['max_pct'] : 0.0,
+                'rank_order' => isset($row['rank_order']) ? (int)$row['rank_order'] : (count($bands) + 1),
+            ];
+        }
+
+        if ($bands === []) {
+            return $cache[$cacheKey] = competency_default_level_bands();
+        }
+
+        return $cache[$cacheKey] = $bands;
+    } catch (Throwable $e) {
+        error_log('competency_level_bands failed: ' . $e->getMessage());
+        return competency_default_level_bands();
+    }
+}
+
+/**
  * Evaluate a competency level label for a percentage score.
  *
  * @param array<int, array{name:string,min_pct:float,max_pct:float}> $bands

--- a/lib/scoring.php
+++ b/lib/scoring.php
@@ -219,7 +219,7 @@ function questionnaire_answer_is_correct(array $answerSet, string $correctValue)
  */
 function questionnaire_competency_level(?float $score): string
 {
-    return competency_level_from_bands($score, competency_default_level_bands());
+    return competency_level_from_bands($score, competency_level_bands());
 }
 
 /**

--- a/tests/competency_framework_test.php
+++ b/tests/competency_framework_test.php
@@ -27,6 +27,31 @@ foreach ($cases as $case) {
     }
 }
 
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->exec(
+    'CREATE TABLE competency_level_band ('
+    . 'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+    . 'name TEXT NOT NULL, '
+    . 'min_pct REAL NOT NULL, '
+    . 'max_pct REAL NOT NULL, '
+    . 'rank_order INTEGER NOT NULL)'
+);
+$pdo->exec("INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order) VALUES ('Starter', 0.0, 74.99, 1)");
+$pdo->exec("INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order) VALUES ('Skilled', 75.0, 100.0, 2)");
+$GLOBALS['pdo'] = $pdo;
+competency_level_bands($pdo, true);
+
+if (questionnaire_competency_level(70.0) !== 'Starter') {
+    fwrite(STDERR, "Expected DB-configured level band Starter for score 70.0.\n");
+    exit(1);
+}
+
+if (questionnaire_competency_level(90.0) !== 'Skilled') {
+    fwrite(STDERR, "Expected DB-configured level band Skilled for score 90.0.\n");
+    exit(1);
+}
+
 if (questionnaire_competency_gap(72.0, null) !== 28.0) {
     fwrite(STDERR, "Expected 100-based gap to equal 28.0.\n");
     exit(1);


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where scoring and analytics used hard-coded default competency bands instead of any runtime DB overrides in `competency_level_band`.
- Ensure Analytics Snapshot v2 and all competency classifications follow the active configured policy rather than silently ignoring overrides.

### Description
- Add `competency_level_bands(?PDO $pdo, bool $forceRefresh = false)` in `lib/competency_framework.php` to load bands from the `competency_level_band` table with SQLite/MySQL table checks, per-connection caching via `spl_object_id`, use of the active `$GLOBALS['pdo']` when available, and safe fallback to `competency_default_level_bands()` on error or missing config.
- Change `questionnaire_competency_level()` in `lib/scoring.php` to call `competency_level_bands()` instead of always using `competency_default_level_bands()`, so runtime bands are honored across reporting and snapshots.
- Extend `tests/competency_framework_test.php` to create an in-memory SQLite `competency_level_band` table and assert that DB-configured bands override defaults as expected.

### Testing
- Ran `php -d detect_unicode=0 tests/competency_framework_test.php` and the test suite passed.
- Ran `php tests/analytics_snapshot_v2_test.php` and the snapshot-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2a651318832d96fd733d3791e1c3)