### PR TITLE
Seed script: add status/year flags, randomize timestamps, and expand cleanup to include dummy_* users

### DIFF
--- a/docs/dummy-data-seeding.md
+++ b/docs/dummy-data-seeding.md
@@ -8,17 +8,20 @@ From the project root:
 
 ```bash
 php ./scripts/seed_dummy_data_from_questionnaires.php
+# Optional overrides:
+# php ./scripts/seed_dummy_data_from_questionnaires.php --statuses=draft,published --start-year=2020 --end-year=2025
 ```
 
 Before running, ensure your `.env` has valid `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, and `DB_PASS` values so `config.php` can open a database connection.
 
 ## What it does
 
+- Defaults to seeding both `draft` and `published` questionnaires (override with `--statuses=<comma-separated-statuses>`).
 - Selects questionnaires that have at least one active item, no active `likert` items, and at least one auto-gradable `choice` item marked `requires_correct = 1`.
 - Ensures a fixed set of `dummy_*` users exists (one supervisor and several staff users).
-- Creates/updates the current half-year performance period (`YYYY H1` or `YYYY H2`).
+- Creates/updates annual performance periods for the selected year range (default `2020`–`2025`, override with `--start-year` and `--end-year`).
 - Deletes prior dummy assignments and responses for `dummy_*` users, then recreates assignments and one response per dummy staff per selected questionnaire.
-- Seeds response-item answers and computes a score (graded for `requires_correct` questions; randomized fallback otherwise).
+- Seeds response-item answers and computes a score (graded for `requires_correct` questions; randomized fallback otherwise), with assignment/response timestamps spread across the selected year range.
 
 ## Scope notes
 
@@ -28,7 +31,7 @@ Before running, ensure your `.env` has valid `DB_HOST`, `DB_PORT`, `DB_NAME`, `D
 
 ## Cleanup
 
-Use `dummy_data_cleanup.sql` to remove seeded dummy-user submissions when needed.
+Use `dummy_data_cleanup.sql` to remove seeded dummy-user submissions when needed. The cleanup script removes both `demo_*` and `dummy_*` users and their related records, and does not delete questionnaire definitions.
 
 
 ## Admin toggle
@@ -36,4 +39,4 @@ Use `dummy_data_cleanup.sql` to remove seeded dummy-user submissions when needed
 Administrators can now enable or disable the full demo dataset directly from **Admin → Settings**:
 
 - **Enable Demo Dataset** executes `dummy_data.sql` (full demo users, questionnaires, responses, analytics history, and training recommendation mappings).
-- **Disable Demo Dataset** executes `dummy_data_cleanup.sql` (removes demo records and EPSA demo course mappings).
+- **Disable Demo Dataset** executes `dummy_data_cleanup.sql` (removes demo/dummy records and EPSA demo course mappings).

--- a/dummy_data_cleanup.sql
+++ b/dummy_data_cleanup.sql
@@ -1,48 +1,53 @@
--- dummy_data_cleanup.sql: remove seeded demo dataset records
-DROP TEMPORARY TABLE IF EXISTS tmp_demo_questionnaires;
-CREATE TEMPORARY TABLE tmp_demo_questionnaires (id INT PRIMARY KEY) ENGINE=Memory;
-INSERT INTO tmp_demo_questionnaires (id)
-SELECT id
-FROM questionnaire
-WHERE title IN ('EPSA Annual Performance Review 360', 'EPSA Leadership Confidence Pulse');
+-- dummy_data_cleanup.sql: remove seeded demo dataset records without deleting questionnaire definitions
 
 DELETE tr
 FROM training_recommendation tr
 JOIN questionnaire_response qr ON qr.id = tr.questionnaire_response_id
 JOIN users u ON u.id = qr.user_id
-WHERE u.username LIKE 'demo_%';
+WHERE u.username LIKE 'demo_%'
+   OR u.username LIKE 'dummy_%';
 
 DELETE qri
 FROM questionnaire_response_item qri
 JOIN questionnaire_response qr ON qr.id = qri.response_id
 JOIN users u ON u.id = qr.user_id
-WHERE u.username LIKE 'demo_%';
+WHERE u.username LIKE 'demo_%'
+   OR u.username LIKE 'dummy_%';
 
 DELETE FROM questionnaire_response
-WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires)
-   OR user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+WHERE user_id IN (
+       SELECT id
+       FROM users
+       WHERE username LIKE 'demo_%'
+          OR username LIKE 'dummy_%'
+   );
 
 DELETE FROM questionnaire_assignment
-WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires)
-   OR staff_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
-
-DELETE FROM questionnaire_work_function WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
-
-DELETE qio
-FROM questionnaire_item_option qio
-JOIN questionnaire_item qi ON qi.id = qio.questionnaire_item_id
-WHERE qi.questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
-
-DELETE FROM questionnaire_item WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
-DELETE FROM questionnaire_section WHERE questionnaire_id IN (SELECT id FROM tmp_demo_questionnaires);
-DELETE FROM questionnaire WHERE id IN (SELECT id FROM tmp_demo_questionnaires);
-DROP TEMPORARY TABLE IF EXISTS tmp_demo_questionnaires;
+WHERE staff_id IN (
+       SELECT id
+       FROM users
+       WHERE username LIKE 'demo_%'
+          OR username LIKE 'dummy_%'
+   );
 
 DELETE FROM analytics_report_schedule
-WHERE created_by IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+WHERE created_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
 
-DELETE FROM logs WHERE user_id IN (SELECT id FROM users WHERE username LIKE 'demo_%');
+DELETE FROM logs
+WHERE user_id IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
 
 DELETE FROM course_catalogue WHERE code LIKE 'EPSA-%';
 
-DELETE FROM users WHERE username LIKE 'demo_%';
+DELETE FROM users
+WHERE username LIKE 'demo_%'
+   OR username LIKE 'dummy_%';

--- a/scripts/seed_dummy_data_from_questionnaires.php
+++ b/scripts/seed_dummy_data_from_questionnaires.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Seed dummy users, questionnaire assignments, and submissions using existing questionnaires.
  *
  * Usage:
- *   php scripts/seed_dummy_data_from_questionnaires.php
+ *   php scripts/seed_dummy_data_from_questionnaires.php [--statuses=draft,published] [--start-year=2020] [--end-year=2025]
  */
 
 if (PHP_SAPI !== 'cli') {
@@ -24,22 +24,56 @@ if (!isset($pdo) || !$pdo instanceof PDO) {
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
 
+$flags = [
+    'statuses' => ['draft', 'published'],
+    'startYear' => 2020,
+    'endYear' => 2025,
+];
+
+foreach (array_slice($argv, 1) as $arg) {
+    if (str_starts_with($arg, '--statuses=')) {
+        $raw = trim((string)substr($arg, strlen('--statuses=')));
+        $flags['statuses'] = array_values(array_filter(array_map('trim', explode(',', $raw))));
+        continue;
+    }
+    if (str_starts_with($arg, '--start-year=')) {
+        $flags['startYear'] = (int)substr($arg, strlen('--start-year='));
+        continue;
+    }
+    if (str_starts_with($arg, '--end-year=')) {
+        $flags['endYear'] = (int)substr($arg, strlen('--end-year='));
+        continue;
+    }
+}
+
+if ($flags['startYear'] < 1900 || $flags['endYear'] > 2200 || $flags['startYear'] > $flags['endYear']) {
+    fwrite(STDERR, "Invalid year range. Expected --start-year <= --end-year." . PHP_EOL);
+    exit(1);
+}
+if (!$flags['statuses']) {
+    fwrite(STDERR, "Invalid statuses list. Provide at least one status via --statuses." . PHP_EOL);
+    exit(1);
+}
+
 /**
  * @return array<int, array<string, mixed>>
  */
-function load_questionnaires(PDO $pdo): array
+function load_questionnaires(PDO $pdo, array $statuses): array
 {
-    $stmt = $pdo->query(
+    $placeholders = implode(', ', array_fill(0, count($statuses), '?'));
+    $stmt = $pdo->prepare(
         "SELECT q.id, q.title, q.status,\n" .
         "COUNT(qi.id) AS item_count,\n" .
         "SUM(CASE WHEN qi.type = 'likert' THEN 1 ELSE 0 END) AS likert_count,\n" .
         "SUM(CASE WHEN qi.type = 'choice' AND qi.requires_correct = 1 THEN 1 ELSE 0 END) AS correct_count\n" .
         "FROM questionnaire q\n" .
         "LEFT JOIN questionnaire_item qi ON qi.questionnaire_id = q.id AND qi.is_active = 1\n" .
+        "WHERE q.status IN (" . $placeholders . ")\n" .
         "GROUP BY q.id, q.title, q.status\n" .
         "HAVING item_count > 0 AND likert_count = 0 AND correct_count > 0\n" .
-        "ORDER BY FIELD(q.status, 'published', 'draft', 'inactive'), q.id"
+        "ORDER BY q.id"
     );
+    $stmt->execute($statuses);
 
     return $stmt->fetchAll() ?: [];
 }
@@ -80,22 +114,28 @@ function ensure_dummy_users(PDO $pdo): array
     return $ids;
 }
 
-function ensure_current_performance_period(PDO $pdo): int
+/**
+ * @return array<int, int> map of year to performance_period.id
+ */
+function ensure_performance_period_range(PDO $pdo, int $startYear, int $endYear): array
 {
-    $year = (int)date('Y');
-    $label = (string)$year;
-    $start = sprintf('%d-01-01', $year);
-    $end = sprintf('%d-12-31', $year);
-
     $insert = $pdo->prepare(
         'INSERT INTO performance_period (label, period_start, period_end) VALUES (?, ?, ?) ' .
         'ON DUPLICATE KEY UPDATE period_start = VALUES(period_start), period_end = VALUES(period_end)'
     );
-    $insert->execute([$label, $start, $end]);
 
     $select = $pdo->prepare('SELECT id FROM performance_period WHERE label = ? LIMIT 1');
-    $select->execute([$label]);
-    return (int)$select->fetchColumn();
+    $periodByYear = [];
+    for ($year = $startYear; $year <= $endYear; $year++) {
+        $label = (string)$year;
+        $start = sprintf('%d-01-01', $year);
+        $end = sprintf('%d-12-31', $year);
+        $insert->execute([$label, $start, $end]);
+        $select->execute([$label]);
+        $periodByYear[$year] = (int)$select->fetchColumn();
+    }
+
+    return $periodByYear;
 }
 
 /**
@@ -170,9 +210,29 @@ function build_answer_payload(array $item, array $options): array
     ];
 }
 
-$questionnaires = load_questionnaires($pdo);
+function random_timestamp_in_year(int $year, int $startDay = 1, int $endDay = 365): int
+{
+    $maxDay = (int)date('z', strtotime(sprintf('%d-12-31', $year))) + 1;
+    $startDay = max(1, min($startDay, $maxDay));
+    $endDay = max($startDay, min($endDay, $maxDay));
+    $dayOfYear = random_int($startDay, $endDay);
+
+    $base = new DateTimeImmutable(sprintf('%d-01-01 00:00:00', $year));
+    $date = $base->modify('+' . ($dayOfYear - 1) . ' days');
+    $date = $date->setTime(random_int(8, 16), random_int(0, 59), random_int(0, 59));
+
+    return $date->getTimestamp();
+}
+
+$questionnaires = load_questionnaires($pdo, $flags['statuses']);
 if (!$questionnaires) {
-    fwrite(STDERR, "No questionnaires with active items were found. Nothing to seed." . PHP_EOL);
+    fwrite(
+        STDERR,
+        sprintf(
+            "No questionnaires with statuses [%s] and active eligible items were found. Nothing to seed.",
+            implode(', ', $flags['statuses'])
+        ) . PHP_EOL
+    );
     exit(1);
 }
 
@@ -193,7 +253,7 @@ try {
         }
     }
 
-    $periodId = ensure_current_performance_period($pdo);
+    $periodByYear = ensure_performance_period_range($pdo, $flags['startYear'], $flags['endYear']);
 
     $cleanupResponseItems = $pdo->prepare(
         'DELETE FROM questionnaire_response_item WHERE response_id IN (' .
@@ -218,11 +278,11 @@ try {
     );
 
     $insertAssignment = $pdo->prepare(
-        'INSERT INTO questionnaire_assignment (staff_id, questionnaire_id, assigned_by, assigned_at) VALUES (?, ?, ?, NOW())'
+        'INSERT INTO questionnaire_assignment (staff_id, questionnaire_id, assigned_by, assigned_at) VALUES (?, ?, ?, ?)'
     );
     $insertResponse = $pdo->prepare(
         'INSERT INTO questionnaire_response (user_id, questionnaire_id, performance_period_id, status, score, reviewed_by, reviewed_at, review_comment, created_at) ' .
-        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW())'
+        'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
     );
     $insertResponseItem = $pdo->prepare(
         'INSERT INTO questionnaire_response_item (response_id, linkId, answer) VALUES (?, ?, ?)'
@@ -240,10 +300,31 @@ try {
         }
 
         foreach ($staffIds as $staffId) {
-            $insertAssignment->execute([$staffId, $qid, $supervisorId > 0 ? $supervisorId : null]);
+            $year = random_int($flags['startYear'], $flags['endYear']);
+            $periodId = (int)($periodByYear[$year] ?? 0);
+            if ($periodId <= 0) {
+                throw new RuntimeException(sprintf('No performance period found for year %d.', $year));
+            }
+
+            $assignedTs = random_timestamp_in_year($year, 1, 320);
+            $assignedAt = date('Y-m-d H:i:s', $assignedTs);
+            $insertAssignment->execute([$staffId, $qid, $supervisorId > 0 ? $supervisorId : null, $assignedAt]);
 
             $status = random_int(0, 10) > 2 ? 'submitted' : 'approved';
-            $reviewedAt = $status === 'approved' ? date('Y-m-d H:i:s') : null;
+            $createdTs = min(
+                strtotime(sprintf('%d-12-31 23:59:59', $year)),
+                $assignedTs + (random_int(3, 45) * 86400)
+            );
+            $createdAt = date('Y-m-d H:i:s', $createdTs);
+            $reviewedAt = $status === 'approved'
+                ? date(
+                    'Y-m-d H:i:s',
+                    min(
+                        strtotime(sprintf('%d-12-31 23:59:59', $year)),
+                        $createdTs + (random_int(1, 12) * 86400)
+                    )
+                )
+                : null;
             $reviewComment = $status === 'approved' ? 'Reviewed dummy submission for seed data.' : null;
 
             $correctAnswerTotal = 0;
@@ -258,6 +339,7 @@ try {
                 $status === 'approved' ? ($supervisorId > 0 ? $supervisorId : null) : null,
                 $reviewedAt,
                 $reviewComment,
+                $createdAt,
             ]);
             $responseId = (int)$pdo->lastInsertId();
 


### PR DESCRIPTION
### Motivation

- Make the dummy-data seeding script more flexible to target questionnaire `status` and a range of years for performance periods. 
- Produce more realistic demo data by spreading assignment/response timestamps across a year range rather than using current timestamps. 
- Ensure cleanup removes both `demo_*` and `dummy_*` seeded users without deleting questionnaire definitions.

### Description

- Added CLI flags to `scripts/seed_dummy_data_from_questionnaires.php`: `--statuses=<comma>` and `--start-year`/`--end-year`, with defaults of `draft,published` and `2020–2025` respectively, plus validation of inputs. 
- Filtered questionnaire selection by the provided statuses, created/ensured annual `performance_period` rows for the requested year range, and pick a random year per assignment; assignment and response timestamps (`assigned_at`, `created_at`, `reviewed_at`) are randomized within the chosen year via a new helper `random_timestamp_in_year`. 
- Adjusted inserts to accept explicit timestamp fields and compute score/answers as before; added a mapping of year→performance_period id. 
- Updated documentation `docs/dummy-data-seeding.md` to document the new CLI overrides and default behavior. 
- Updated `dummy_data_cleanup.sql` to stop removing questionnaire definitions and to delete records for users whose usernames match either `demo_%` or `dummy_%`, and to remove related logs and schedules accordingly; also simplified the cleanup flow to avoid temporary questionnaire tables. 

### Testing

- Ran PHP syntax checks with `php -l scripts/seed_dummy_data_from_questionnaires.php` and `php -l` on the modified files, which reported no syntax errors. 
- Executed the updated `dummy_data_cleanup.sql` against a local development database to validate SQL parses and deletes the intended `demo_%`/`dummy_%` rows without dropping questionnaire definitions (success). 
- Performed a local dry-run of `scripts/seed_dummy_data_from_questionnaires.php` against a development DB (with the provided flags) to confirm questionnaires are selected by status and timestamps/performance periods are populated as expected (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e923d08cd0832dad60602da6fe3555)