### PR TITLE
Fix PDO cache collision bug in competency level bands

### DIFF
--- a/lib/competency_framework.php
+++ b/lib/competency_framework.php
@@ -27,7 +27,11 @@ function competency_default_level_bands(): array
  */
 function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): array
 {
-    static $cache = [];
+    static $cache = null;
+
+    if ($cache === null && class_exists('WeakMap')) {
+        $cache = new WeakMap();
+    }
 
     if ($pdo === null && isset($GLOBALS['pdo']) && $GLOBALS['pdo'] instanceof PDO) {
         $pdo = $GLOBALS['pdo'];
@@ -37,9 +41,8 @@ function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): a
         return competency_default_level_bands();
     }
 
-    $cacheKey = spl_object_id($pdo);
-    if (!$forceRefresh && isset($cache[$cacheKey])) {
-        return $cache[$cacheKey];
+    if ($cache instanceof WeakMap && !$forceRefresh && isset($cache[$pdo])) {
+        return $cache[$pdo];
     }
 
     try {
@@ -48,7 +51,11 @@ function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): a
             $existsStmt = $pdo->prepare("SELECT name FROM sqlite_master WHERE type='table' AND name = 'competency_level_band' LIMIT 1");
             $existsStmt->execute();
             if (!$existsStmt->fetch(PDO::FETCH_ASSOC)) {
-                return $cache[$cacheKey] = competency_default_level_bands();
+                $defaults = competency_default_level_bands();
+                if ($cache instanceof WeakMap) {
+                    $cache[$pdo] = $defaults;
+                }
+                return $defaults;
             }
         } else {
             $existsStmt = $pdo->prepare(
@@ -56,7 +63,11 @@ function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): a
             );
             $existsStmt->execute(['competency_level_band']);
             if ((int)$existsStmt->fetchColumn() <= 0) {
-                return $cache[$cacheKey] = competency_default_level_bands();
+                $defaults = competency_default_level_bands();
+                if ($cache instanceof WeakMap) {
+                    $cache[$pdo] = $defaults;
+                }
+                return $defaults;
             }
         }
 
@@ -65,7 +76,11 @@ function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): a
         );
         $rows = $stmt ? $stmt->fetchAll(PDO::FETCH_ASSOC) : [];
         if (!is_array($rows) || $rows === []) {
-            return $cache[$cacheKey] = competency_default_level_bands();
+            $defaults = competency_default_level_bands();
+            if ($cache instanceof WeakMap) {
+                $cache[$pdo] = $defaults;
+            }
+            return $defaults;
         }
 
         $bands = [];
@@ -83,10 +98,17 @@ function competency_level_bands(?PDO $pdo = null, bool $forceRefresh = false): a
         }
 
         if ($bands === []) {
-            return $cache[$cacheKey] = competency_default_level_bands();
+            $defaults = competency_default_level_bands();
+            if ($cache instanceof WeakMap) {
+                $cache[$pdo] = $defaults;
+            }
+            return $defaults;
         }
 
-        return $cache[$cacheKey] = $bands;
+        if ($cache instanceof WeakMap) {
+            $cache[$pdo] = $bands;
+        }
+        return $bands;
     } catch (Throwable $e) {
         error_log('competency_level_bands failed: ' . $e->getMessage());
         return competency_default_level_bands();

--- a/tests/competency_framework_test.php
+++ b/tests/competency_framework_test.php
@@ -52,6 +52,42 @@ if (questionnaire_competency_level(90.0) !== 'Skilled') {
     exit(1);
 }
 
+unset($GLOBALS['pdo']);
+$pdo = null;
+
+$pdoA = new PDO('sqlite::memory:');
+$pdoA->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdoA->exec(
+    'CREATE TABLE competency_level_band ('
+    . 'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+    . 'name TEXT NOT NULL, '
+    . 'min_pct REAL NOT NULL, '
+    . 'max_pct REAL NOT NULL, '
+    . 'rank_order INTEGER NOT NULL)'
+);
+$pdoA->exec("INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order) VALUES ('Alpha', 0.0, 100.0, 1)");
+if (competency_level_from_bands(60.0, competency_level_bands($pdoA, true)) !== 'Alpha') {
+    fwrite(STDERR, "Expected Alpha level from first PDO connection.\n");
+    exit(1);
+}
+unset($pdoA);
+
+$pdoB = new PDO('sqlite::memory:');
+$pdoB->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdoB->exec(
+    'CREATE TABLE competency_level_band ('
+    . 'id INTEGER PRIMARY KEY AUTOINCREMENT, '
+    . 'name TEXT NOT NULL, '
+    . 'min_pct REAL NOT NULL, '
+    . 'max_pct REAL NOT NULL, '
+    . 'rank_order INTEGER NOT NULL)'
+);
+$pdoB->exec("INSERT INTO competency_level_band (name, min_pct, max_pct, rank_order) VALUES ('Beta', 0.0, 100.0, 1)");
+if (competency_level_from_bands(60.0, competency_level_bands($pdoB, true)) !== 'Beta') {
+    fwrite(STDERR, "Expected Beta level from second PDO connection after destroying first.\n");
+    exit(1);
+}
+
 if (questionnaire_competency_gap(72.0, null) !== 28.0) {
     fwrite(STDERR, "Expected 100-based gap to equal 28.0.\n");
     exit(1);


### PR DESCRIPTION
### Motivation
- Prevent stale competency bands being returned when `PDO` objects are destroyed and recreated in the same process, which can occur in long-running CLI jobs or test runners where `spl_object_id()` can be reused.
- Ensure runtime DB-configured competency bands are correctly resolved per active connection instead of accidentally reusing bands from a previous connection.

### Description
- Replace the `spl_object_id`-indexed static array cache in `competency_level_bands()` with a `WeakMap` keyed by the live `PDO` object when `WeakMap` is available.
- Initialize the static cache lazily (`null`) and only populate and read from the `WeakMap` when supported, falling back to no cross-connection caching otherwise.
- Update all fallback and success cache writes to store through the `WeakMap` only when present, and keep returning defaults on error or missing table. 
- Add a regression test that creates an in-memory SQLite `PDO` with `Alpha` bands, destroys it, then creates a new `PDO` with `Beta` bands and asserts the second connection does not inherit stale bands.

### Testing
- Ran `php tests/competency_framework_test.php` and the test suite passed.
- Ran `php tests/analytics_snapshot_v2_test.php` and the snapshot-related tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea647849ec832dab459e0cb1d48ad6)