### PR TITLE
Enforce supervisor scope when finalizing Analytics Snapshot v2

### DIFF
--- a/admin/analytics_snapshot_v2.php
+++ b/admin/analytics_snapshot_v2.php
@@ -60,7 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             ];
         } elseif ($action === 'finalize') {
             $snapshotId = isset($_POST['snapshot_id']) ? (int)$_POST['snapshot_id'] : 0;
-            if ($snapshotId <= 0 || !analytics_snapshot_v2_finalize($pdo, $snapshotId)) {
+            if ($snapshotId <= 0 || !analytics_snapshot_v2_finalize_for_viewer($pdo, $snapshotId, $viewer)) {
                 throw new RuntimeException(t($t, 'analytics_snapshot_v2_finalize_failed', 'Unable to finalize snapshot.'));
             }
             $_SESSION['analytics_snapshot_v2_flash'] = [
@@ -145,10 +145,7 @@ if (analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
             $snapshots[] = $row;
             continue;
         }
-        $filters = json_decode((string)($row['filters_json'] ?? '{}'), true);
-        $rowDirectorate = trim((string)($filters['directorate'] ?? ''));
-        $generatedBy = (int)($row['generated_by'] ?? 0);
-        if ($generatedBy === $viewerId || ($selectedDirectorate !== '' && $rowDirectorate === $selectedDirectorate)) {
+        if (analytics_snapshot_v2_viewer_can_access_snapshot($viewer, $row)) {
             $snapshots[] = $row;
         }
     }

--- a/lib/analytics_snapshot_v2.php
+++ b/lib/analytics_snapshot_v2.php
@@ -338,3 +338,55 @@ function analytics_snapshot_v2_finalize(PDO $pdo, int $snapshotId): bool
     $stmt->execute([$snapshotId]);
     return $stmt->rowCount() > 0;
 }
+
+/**
+ * @param array<string, mixed> $viewer
+ * @param array<string, mixed> $snapshotRow
+ */
+function analytics_snapshot_v2_viewer_can_access_snapshot(array $viewer, array $snapshotRow): bool
+{
+    $viewerRole = trim((string)($viewer['role'] ?? ''));
+    if ($viewerRole !== 'supervisor') {
+        return true;
+    }
+
+    $viewerId = (int)($viewer['id'] ?? 0);
+    $generatedBy = (int)($snapshotRow['generated_by'] ?? 0);
+    if ($viewerId > 0 && $generatedBy === $viewerId) {
+        return true;
+    }
+
+    $viewerDirectorate = trim((string)($viewer['directorate'] ?? ''));
+    if ($viewerDirectorate === '') {
+        $viewerDirectorate = trim((string)($viewer['department'] ?? ''));
+    }
+    if ($viewerDirectorate === '') {
+        return false;
+    }
+
+    $filters = json_decode((string)($snapshotRow['filters_json'] ?? '{}'), true);
+    if (!is_array($filters)) {
+        return false;
+    }
+    $rowDirectorate = trim((string)($filters['directorate'] ?? ''));
+    return $rowDirectorate !== '' && hash_equals($viewerDirectorate, $rowDirectorate);
+}
+
+/**
+ * @param array<string, mixed> $viewer
+ */
+function analytics_snapshot_v2_finalize_for_viewer(PDO $pdo, int $snapshotId, array $viewer): bool
+{
+    if ($snapshotId <= 0 || !analytics_snapshot_v2_table_exists($pdo, 'analytics_report_snapshot_v2')) {
+        return false;
+    }
+
+    $stmt = $pdo->prepare('SELECT id, generated_by, filters_json FROM analytics_report_snapshot_v2 WHERE id = ? LIMIT 1');
+    $stmt->execute([$snapshotId]);
+    $snapshotRow = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!is_array($snapshotRow) || !analytics_snapshot_v2_viewer_can_access_snapshot($viewer, $snapshotRow)) {
+        return false;
+    }
+
+    return analytics_snapshot_v2_finalize($pdo, $snapshotId);
+}

--- a/tests/analytics_snapshot_v2_test.php
+++ b/tests/analytics_snapshot_v2_test.php
@@ -79,4 +79,34 @@ if (($decodedFilters['business_role'] ?? '') !== 'staff') {
     exit(1);
 }
 
+$insertScoped = $pdo->prepare(
+    'INSERT INTO analytics_report_snapshot_v2 (questionnaire_id, generated_by, status, locked, filters_json, summary_json, details_json, generated_at) '
+    . 'VALUES (1, 777, "draft", 0, :filters_json, "{}", "{}", CURRENT_TIMESTAMP)'
+);
+$insertScoped->execute([':filters_json' => json_encode(['directorate' => 'Finance'])]);
+$forgedSnapshotId = (int)$pdo->lastInsertId();
+
+$supervisorViewer = ['id' => 500, 'role' => 'supervisor', 'directorate' => 'Operations'];
+if (analytics_snapshot_v2_finalize_for_viewer($pdo, $forgedSnapshotId, $supervisorViewer)) {
+    fwrite(STDERR, "Supervisor should not finalize snapshot outside their directorate.\n");
+    exit(1);
+}
+
+$forgedStatus = $pdo->query('SELECT locked, status FROM analytics_report_snapshot_v2 WHERE id = ' . $forgedSnapshotId)->fetch(PDO::FETCH_ASSOC);
+if ((int)($forgedStatus['locked'] ?? 0) !== 0 || (string)($forgedStatus['status'] ?? '') !== 'draft') {
+    fwrite(STDERR, "Out-of-scope snapshot should remain draft and unlocked.\n");
+    exit(1);
+}
+
+$insertOwn = $pdo->prepare(
+    'INSERT INTO analytics_report_snapshot_v2 (questionnaire_id, generated_by, status, locked, filters_json, summary_json, details_json, generated_at) '
+    . 'VALUES (1, 500, "draft", 0, :filters_json, "{}", "{}", CURRENT_TIMESTAMP)'
+);
+$insertOwn->execute([':filters_json' => json_encode(['directorate' => 'Finance'])]);
+$ownSnapshotId = (int)$pdo->lastInsertId();
+if (!analytics_snapshot_v2_finalize_for_viewer($pdo, $ownSnapshotId, $supervisorViewer)) {
+    fwrite(STDERR, "Supervisor should finalize their own snapshot.\n");
+    exit(1);
+}
+
 echo "Analytics snapshot v2 tests passed.\n";


### PR DESCRIPTION
### Motivation

- Fix a P1 authorization bug where a supervisor could finalize a snapshot by posting an arbitrary `snapshot_id` for another directorate, breaking role-based access guarantees.

### Description

- Added `analytics_snapshot_v2_viewer_can_access_snapshot(...)` to `lib/analytics_snapshot_v2.php` to verify supervisor access by `generated_by` ownership or matching `filters_json` directorate.
- Added `analytics_snapshot_v2_finalize_for_viewer(...)` to `lib/analytics_snapshot_v2.php` to validate scope before calling the existing finalize routine `analytics_snapshot_v2_finalize(...)`.
- Updated `admin/analytics_snapshot_v2.php` to call `analytics_snapshot_v2_finalize_for_viewer(...)` in the POST `finalize` branch and to reuse `analytics_snapshot_v2_viewer_can_access_snapshot(...)` when building the visible snapshot list.
- Extended `tests/analytics_snapshot_v2_test.php` with regression coverage that rejects forged out-of-scope finalize attempts and confirms supervisors can finalize their own snapshots.

### Testing

- Ran `php tests/analytics_snapshot_v2_test.php`, which passed (prints "Analytics snapshot v2 tests passed.").
- Ran syntax checks `php -l lib/analytics_snapshot_v2.php` and `php -l admin/analytics_snapshot_v2.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2a6ecd20832daf863c0dd2104401)