### PR TITLE
Improve PDF header/footer, chart label wrapping, and table rendering in analytics reports

### DIFF
--- a/lib/analytics_report.php
+++ b/lib/analytics_report.php
@@ -422,7 +422,7 @@ function analytics_report_render_pdf(array $snapshot, array $cfg): string
     $headerTitle = $siteName !== '' ? $siteName : 'HR Assessment';
     $headerSubtitle = analytics_report_header_tagline($cfg);
     $logoSpec = analytics_report_header_logo_spec($pdf, $cfg);
-    $pdf->setHeader($headerTitle, $headerSubtitle, $logoSpec);
+    $pdf->setHeader($headerTitle, $headerSubtitle, $logoSpec, analytics_report_header_style($cfg));
 
     $title = $headerTitle . ' Analytics Report';
     $pdf->addHeading($title);
@@ -853,10 +853,23 @@ function analytics_report_generate_bar_chart(array $points, array $palette, arra
     $barShadow = imagecolorallocate($image, $barShadowRgb[0], $barShadowRgb[1], $barShadowRgb[2]);
     $barHighlight = imagecolorallocate($image, $barHighlightRgb[0], $barHighlightRgb[1], $barHighlightRgb[2]);
 
+    $maxLabelChars = 0;
+    foreach ($normalized as $point) {
+        $labelLength = function_exists('mb_strlen')
+            ? (int)mb_strlen((string)$point['label'], 'UTF-8')
+            : strlen((string)$point['label']);
+        $maxLabelChars = max($maxLabelChars, $labelLength);
+    }
+    $estimatedLabelLines = $maxLabelChars > 16 ? 2 : 1;
+    $count = count($normalized);
+    $showEvery = max(1, (int)ceil($count / 8));
+    $labelLineCount = $showEvery > 1 ? 1 : $estimatedLabelLines;
+    $showValueLabels = $count <= 10;
+
     $marginLeft = 150;
     $marginRight = 80;
-    $marginTop = 90;
-    $marginBottom = 160;
+    $marginTop = 120;
+    $marginBottom = 150 + ($labelLineCount * 28) + ($showEvery > 1 ? 18 : 0);
 
     $chartWidth = $width - $marginLeft - $marginRight;
     $chartHeight = $height - $marginTop - $marginBottom;
@@ -904,7 +917,6 @@ function analytics_report_generate_bar_chart(array $points, array $palette, arra
     imageline($image, $marginLeft, $marginTop + $chartHeight, $marginLeft + $chartWidth, $marginTop + $chartHeight, $axisColor);
     imageline($image, $marginLeft, $marginTop, $marginLeft, $marginTop + $chartHeight, $axisColor);
 
-    $count = count($normalized);
     $segment = $chartWidth / max($count, 1);
     $barWidth = max(24, min(80, $segment * 0.6));
     $baseline = $marginTop + $chartHeight;
@@ -924,17 +936,24 @@ function analytics_report_generate_bar_chart(array $points, array $palette, arra
         imageline($image, $x1, $y2, $x2, $y2, $barShadow);
         imageline($image, $x1, $y1, $x2, $y1, $barHighlight);
 
-        $valueLabel = number_format($point['value'], $precision) . $valueSuffix;
-        analytics_report_draw_text($image, $valueLabel, $textColor, 18, (int)round($centerX), $y1 - 12, [
-            'align' => 'center',
-            'baseline' => 'top',
-        ]);
+        if ($showValueLabels) {
+            $valueLabel = number_format($point['value'], $precision) . $valueSuffix;
+            $valueLabelY = max(24, $y1 - 14);
+            analytics_report_draw_text($image, $valueLabel, $textColor, 16, (int)round($centerX), $valueLabelY, [
+                'align' => 'center',
+                'baseline' => 'top',
+            ]);
+        }
 
-        $labelY = $baseline + 16;
-        analytics_report_draw_text($image, $point['label'], $textColor, 18, (int)round($centerX), $labelY, [
-            'align' => 'center',
-            'baseline' => 'top',
-        ]);
+        if (($index % $showEvery) === 0) {
+            $labelY = $baseline + 16 + (($index % 2) * 18);
+            analytics_report_draw_wrapped_text($image, $point['label'], $textColor, 14, (int)round($centerX), $labelY, 140, [
+                'align' => 'center',
+                'baseline' => 'top',
+                'line_gap' => 5,
+                'max_lines' => $showEvery > 1 ? 1 : 2,
+            ]);
+        }
     }
 
     $result = analytics_report_export_gd_image($image);
@@ -995,10 +1014,24 @@ function analytics_report_generate_line_chart(array $points, array $palette, arr
     $fillColor = imagecolorallocate($image, $fillRgb[0], $fillRgb[1], $fillRgb[2]);
     $pointColor = imagecolorallocate($image, $pointRgb[0], $pointRgb[1], $pointRgb[2]);
 
+    $maxLabelChars = 0;
+    foreach ($normalized as $point) {
+        $labelLength = function_exists('mb_strlen')
+            ? (int)mb_strlen((string)$point['label'], 'UTF-8')
+            : strlen((string)$point['label']);
+        $maxLabelChars = max($maxLabelChars, $labelLength);
+    }
+    $estimatedLabelLines = $maxLabelChars > 16 ? 2 : 1;
+    $count = count($normalized);
+    $showEvery = max(1, (int)ceil($count / 8));
+    $labelLineCount = $showEvery > 1 ? 1 : $estimatedLabelLines;
+    $seriesDensityPadding = $count > 8 ? 24 : 0;
+    $showValueLabels = $count <= 10;
+
     $marginLeft = 140;
     $marginRight = 80;
-    $marginTop = 90;
-    $marginBottom = 160;
+    $marginTop = 100;
+    $marginBottom = 150 + ($labelLineCount * 28) + $seriesDensityPadding + ($showEvery > 1 ? 12 : 0);
 
     $chartWidth = $width - $marginLeft - $marginRight;
     $chartHeight = $height - $marginTop - $marginBottom;
@@ -1045,7 +1078,6 @@ function analytics_report_generate_line_chart(array $points, array $palette, arr
     imageline($image, $marginLeft, $marginTop + $chartHeight, $marginLeft + $chartWidth, $marginTop + $chartHeight, $axisColor);
     imageline($image, $marginLeft, $marginTop, $marginLeft, $marginTop + $chartHeight, $axisColor);
 
-    $count = count($normalized);
     $baseline = $marginTop + $chartHeight;
     $segment = $count > 1 ? ($chartWidth / ($count - 1)) : 0;
     $points = [];
@@ -1096,21 +1128,33 @@ function analytics_report_generate_line_chart(array $points, array $palette, arr
         imagesetthickness($image, 1);
     }
 
-    foreach ($points as [$x, $y, $meta]) {
+    $lastLabelRightEdge = null;
+    foreach ($points as $pointIndex => [$x, $y, $meta]) {
         $radius = 8;
         imagefilledellipse($image, (int)round($x), (int)round($y), $radius, $radius, $pointColor);
         imageellipse($image, (int)round($x), (int)round($y), $radius + 2, $radius + 2, $lineColor);
 
-        $valueLabel = number_format($meta['value'], (int)($options['decimal_places'] ?? 0)) . $valueSuffix;
-        analytics_report_draw_text($image, $valueLabel, $textColor, 18, (int)round($x), (int)round($y) - 14, [
-            'align' => 'center',
-            'baseline' => 'bottom',
-        ]);
+        if ($showValueLabels) {
+            $valueLabel = number_format($meta['value'], (int)($options['decimal_places'] ?? 0)) . $valueSuffix;
+            analytics_report_draw_text($image, $valueLabel, $textColor, 18, (int)round($x), (int)round($y) - 14, [
+                'align' => 'center',
+                'baseline' => 'bottom',
+            ]);
+        }
 
-        analytics_report_draw_text($image, $meta['label'], $textColor, 18, (int)round($x), $baseline + 16, [
-            'align' => 'center',
-            'baseline' => 'top',
-        ]);
+        if (($pointIndex % $showEvery) === 0) {
+            $labelY = $baseline + 16 + (($pointIndex % 2) * 18);
+            if ($lastLabelRightEdge !== null && $count > 1 && $segment > 0 && ($x - $lastLabelRightEdge) < 40) {
+                $labelY += 16;
+            }
+            analytics_report_draw_wrapped_text($image, $meta['label'], $textColor, 14, (int)round($x), (int)round($labelY), 150, [
+                'align' => 'center',
+                'baseline' => 'top',
+                'line_gap' => 4,
+                'max_lines' => $showEvery > 1 ? 1 : 2,
+            ]);
+            $lastLabelRightEdge = $x + 65;
+        }
     }
 
     $result = analytics_report_export_gd_image($image);
@@ -1238,6 +1282,7 @@ function analytics_report_generate_radar_chart(array $sections, array $palette, 
     }
 
     $polygon = [];
+    $showValueLabels = $count <= 8;
     foreach ($normalized as $index => $section) {
         $angle = $startAngle + $angleStep * $index;
         $value = max(0.0, min($axisMax, $section['value']));
@@ -1270,13 +1315,15 @@ function analytics_report_generate_radar_chart(array $sections, array $palette, 
         imagefilledellipse($image, $pointXInt, $pointYInt, 16, 16, $vertexColor);
         imageellipse($image, $pointXInt, $pointYInt, 18, 18, $strokeColor);
 
-        $valueLabel = number_format($section['value'], (int)($options['decimal_places'] ?? 1)) . $valueSuffix;
-        $valueLabelX = $centerX + cos($angle) * $radius * max(0.1, $ratio) * 0.85;
-        $valueLabelY = $centerY + sin($angle) * $radius * max(0.1, $ratio) * 0.85;
-        analytics_report_draw_text($image, $valueLabel, $textColor, 18, (int)round($valueLabelX), (int)round($valueLabelY), [
-            'align' => 'center',
-            'baseline' => 'middle',
-        ]);
+        if ($showValueLabels) {
+            $valueLabel = number_format($section['value'], (int)($options['decimal_places'] ?? 1)) . $valueSuffix;
+            $valueLabelX = $centerX + cos($angle) * $radius * min(1.0, max(0.25, $ratio + 0.2));
+            $valueLabelY = $centerY + sin($angle) * $radius * min(1.0, max(0.25, $ratio + 0.2));
+            analytics_report_draw_text($image, $valueLabel, $textColor, 16, (int)round($valueLabelX), (int)round($valueLabelY), [
+                'align' => 'center',
+                'baseline' => 'middle',
+            ]);
+        }
 
         $labelAngleCos = cos($angle);
         $labelAngleSin = sin($angle);
@@ -1294,9 +1341,11 @@ function analytics_report_generate_radar_chart(array $sections, array $palette, 
         } elseif ($labelAngleSin < -0.4) {
             $baseline = 'bottom';
         }
-        analytics_report_draw_text($image, $section['label'], $textColor, 20, (int)round($labelX), (int)round($labelY), [
+        analytics_report_draw_wrapped_text($image, $section['label'], $textColor, 15, (int)round($labelX), (int)round($labelY), 150, [
             'align' => $align,
             'baseline' => $baseline,
+            'line_gap' => 4,
+            'max_lines' => $count > 10 ? 1 : 2,
         ]);
     }
 
@@ -1331,6 +1380,28 @@ function analytics_report_draw_text($image, string $text, int $color, float $fon
 
     if ($fontPath && function_exists('imagettftext') && function_exists('imagettfbbox')) {
         $box = imagettfbbox($fontSize, 0, $fontPath, $text);
+        if (!is_array($box) || count($box) < 8) {
+            $font = $options['font'] ?? 3;
+            $charWidth = imagefontwidth($font);
+            $charHeight = imagefontheight($font);
+            $textWidth = $charWidth * strlen($text);
+            $drawX = $x;
+            if ($align === 'center') {
+                $drawX = (int)round($x - $textWidth / 2);
+            } elseif ($align === 'right') {
+                $drawX = (int)round($x - $textWidth);
+            }
+            $drawY = $y;
+            if ($baseline === 'top') {
+                $drawY = $y;
+            } elseif ($baseline === 'middle') {
+                $drawY = (int)round($y - ($charHeight / 2));
+            } else {
+                $drawY = (int)round($y - $charHeight);
+            }
+            imagestring($image, $font, $drawX, $drawY, $text, $color);
+            return;
+        }
         $textWidth = analytics_report_ttf_box_width($box);
         $textHeight = analytics_report_ttf_box_height($box);
         $drawX = $x;
@@ -1370,6 +1441,77 @@ function analytics_report_draw_text($image, string $text, int $color, float $fon
     imagestring($image, $font, $drawX, $drawY, $text, $color);
 }
 
+function analytics_report_draw_wrapped_text($image, string $text, int $color, float $fontSize, int $x, int $y, int $maxWidth, array $options = []): void
+{
+    $lines = analytics_report_wrap_text_lines($text, $fontSize, $maxWidth, (int)($options['max_lines'] ?? 2));
+    $baseline = (string)($options['baseline'] ?? 'top');
+    $lineGap = max(0, (int)($options['line_gap'] ?? 4));
+    $lineHeight = (int)round($fontSize + $lineGap);
+
+    if ($baseline === 'middle') {
+        $startY = (int)round($y - (($lineHeight * max(1, count($lines))) / 2));
+    } elseif ($baseline === 'bottom') {
+        $startY = (int)round($y - ($lineHeight * max(1, count($lines))));
+    } else {
+        $startY = $y;
+    }
+
+    foreach ($lines as $lineIndex => $line) {
+        analytics_report_draw_text($image, $line, $color, $fontSize, $x, $startY + ($lineIndex * $lineHeight), [
+            'align' => $options['align'] ?? 'left',
+            'baseline' => 'top',
+        ]);
+    }
+}
+
+function analytics_report_wrap_text_lines(string $text, float $fontSize, int $maxWidth, int $maxLines = 2): array
+{
+    $source = trim(preg_replace('/\s+/u', ' ', $text) ?? '');
+    if ($source === '') {
+        return [''];
+    }
+
+    $words = preg_split('/\s+/u', $source) ?: [$source];
+    $lines = [];
+    $line = '';
+    foreach ($words as $word) {
+        $candidate = $line === '' ? $word : ($line . ' ' . $word);
+        if (analytics_report_measure_text_width($candidate, $fontSize) <= $maxWidth) {
+            $line = $candidate;
+            continue;
+        }
+
+        if ($line !== '') {
+            $lines[] = $line;
+            $line = $word;
+        } else {
+            $lines[] = analytics_report_truncate_label($word, 14);
+            $line = '';
+        }
+
+        if (count($lines) >= max(1, $maxLines)) {
+            return $lines;
+        }
+    }
+
+    if ($line !== '' && count($lines) < max(1, $maxLines)) {
+        $lines[] = $line;
+    }
+
+    if (count($lines) > $maxLines) {
+        $lines = array_slice($lines, 0, $maxLines);
+    }
+
+    if (count($lines) === $maxLines) {
+        $last = $lines[$maxLines - 1];
+        if (analytics_report_measure_text_width($last, $fontSize) > $maxWidth) {
+            $lines[$maxLines - 1] = analytics_report_truncate_label($last, 16);
+        }
+    }
+
+    return $lines ?: [''];
+}
+
 function analytics_report_truncate_label(string $label, int $limit = 22): string
 {
     $trimmed = trim($label);
@@ -1403,6 +1545,18 @@ function analytics_report_header_logo_spec(SimplePdfDocument $pdf, array $cfg): 
         'name' => $imageName,
         'width' => $dimensions['width'],
         'height' => $dimensions['height'],
+    ];
+}
+
+function analytics_report_header_style(array $cfg): array
+{
+    $palette = analytics_report_palette_colors($cfg);
+    $barHex = (string)($palette['primary'] ?? '#2073bf');
+    $textHex = '#0f172a';
+
+    return [
+        'bar_color' => analytics_report_color_to_rgb($barHex),
+        'text_color' => analytics_report_color_to_rgb($textHex),
     ];
 }
 
@@ -1760,28 +1914,63 @@ function analytics_report_contrast_for_color(string $hex): string
 
 function analytics_report_default_font_path(): ?string
 {
+    static $resolved = null;
+    static $checked = false;
+    if ($checked) {
+        return $resolved;
+    }
+
     $candidates = [
+        '/usr/share/fonts/truetype/msttcorefonts/calibri.ttf',
+        '/usr/share/fonts/truetype/msttcorefonts/Calibri.ttf',
+        '/usr/share/fonts/truetype/calibri/Calibri.ttf',
+        '/usr/share/fonts/truetype/carlito/Carlito-Regular.ttf',
+        '/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf',
+        '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
         '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
         '/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf',
     ];
 
     foreach ($candidates as $candidate) {
         if (is_string($candidate) && is_file($candidate)) {
-            return $candidate;
+            $resolved = $candidate;
+            $checked = true;
+            return $resolved;
         }
     }
 
-    return null;
+    $checked = true;
+    $resolved = null;
+    return $resolved;
 }
 
-function analytics_report_ttf_box_width(array $box): float
+function analytics_report_measure_text_width(string $text, float $fontSize): float
 {
+    $fontPath = analytics_report_default_font_path();
+    if ($fontPath && function_exists('imagettfbbox')) {
+        $box = imagettfbbox($fontSize, 0, $fontPath, $text);
+        if (is_array($box)) {
+            return analytics_report_ttf_box_width($box);
+        }
+    }
+
+    return strlen($text) * max(6.0, $fontSize * 0.55);
+}
+
+function analytics_report_ttf_box_width($box): float
+{
+    if (!is_array($box) || count($box) < 8) {
+        return 0.0;
+    }
     $xs = [$box[0], $box[2], $box[4], $box[6]];
     return max($xs) - min($xs);
 }
 
-function analytics_report_ttf_box_height(array $box): float
+function analytics_report_ttf_box_height($box): float
 {
+    if (!is_array($box) || count($box) < 8) {
+        return 0.0;
+    }
     $ys = [$box[1], $box[3], $box[5], $box[7]];
     return max($ys) - min($ys);
 }

--- a/lib/simple_pdf.php
+++ b/lib/simple_pdf.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 class SimplePdfDocument
 {
+    private const PAGE_TOKEN = '__PDF_PAGE__';
+    private const PAGE_TOTAL_TOKEN = '__PDF_PAGE_TOTAL__';
+
     private float $width = 595.28; // A4 width in points
     private float $height = 841.89; // A4 height in points
     private float $marginLeft = 50.0;
@@ -18,6 +21,7 @@ class SimplePdfDocument
     private int $imageCounter = 0;
     private ?array $headerConfig = null;
     private float $headerSpacing = 0.0;
+    private int $pageNumber = 0;
 
     public function __construct()
     {
@@ -50,7 +54,7 @@ class SimplePdfDocument
         return $this->registerImageResource($data, $pixelWidth, $pixelHeight, 'DCTDecode', '/DeviceRGB', 8);
     }
 
-    public function setHeader(?string $title, ?string $subtitle = null, ?array $imageSpec = null): void
+    public function setHeader(?string $title, ?string $subtitle = null, ?array $imageSpec = null, ?array $style = null): void
     {
         $normalizedTitle = $this->normalizeHeaderText($title);
         $normalizedSubtitle = $this->normalizeHeaderText($subtitle);
@@ -64,6 +68,25 @@ class SimplePdfDocument
             ];
         }
 
+        $barColor = [32, 115, 191];
+        $textColor = [255, 255, 255];
+        if (is_array($style)) {
+            if (isset($style['bar_color']) && is_array($style['bar_color']) && count($style['bar_color']) === 3) {
+                $barColor = [
+                    max(0, min(255, (int)$style['bar_color'][0])),
+                    max(0, min(255, (int)$style['bar_color'][1])),
+                    max(0, min(255, (int)$style['bar_color'][2])),
+                ];
+            }
+            if (isset($style['text_color']) && is_array($style['text_color']) && count($style['text_color']) === 3) {
+                $textColor = [
+                    max(0, min(255, (int)$style['text_color'][0])),
+                    max(0, min(255, (int)$style['text_color'][1])),
+                    max(0, min(255, (int)$style['text_color'][2])),
+                ];
+            }
+        }
+
         if ($normalizedTitle === null && $normalizedSubtitle === null && $image === null) {
             $this->headerConfig = null;
             $this->headerSpacing = 0.0;
@@ -73,11 +96,13 @@ class SimplePdfDocument
         $titleFontSize = 16.0;
         $subtitleFontSize = 11.0;
         $lineGap = 4.0;
-        $topPadding = 10.0;
+        $topBarHeight = 8.0;
+        $topPadding = 8.0;
         $bottomPadding = 14.0;
-        $ruleGap = 8.0;
-        $contentGap = 12.0;
+        $ruleGap = 6.0;
+        $contentGap = 14.0;
         $textGap = $image !== null ? 12.0 : 0.0;
+        $topBarGap = 8.0;
 
         $textHeight = 0.0;
         if ($normalizedTitle !== null) {
@@ -92,7 +117,7 @@ class SimplePdfDocument
 
         $imageHeight = $image['height'] ?? 0.0;
         $contentHeight = max($textHeight, $imageHeight);
-        $this->headerSpacing = $topPadding + $contentHeight + $bottomPadding + $ruleGap + $contentGap;
+        $this->headerSpacing = $topBarHeight + $topBarGap + $topPadding + $contentHeight + $bottomPadding + $ruleGap + $contentGap;
 
         $this->headerConfig = [
             'title' => $normalizedTitle,
@@ -106,6 +131,10 @@ class SimplePdfDocument
             'content_gap' => $contentGap,
             'text_gap' => $textGap,
             'image' => $image,
+            'bar_color' => $barColor,
+            'text_color' => $textColor,
+            'top_bar_height' => $topBarHeight,
+            'top_bar_gap' => $topBarGap,
         ];
     }
 
@@ -202,19 +231,67 @@ class SimplePdfDocument
     public function addTable(array $headers, array $rows, array $columnWidths, float $fontSize = 10.0): void
     {
         $this->ensurePage();
-        $resolvedWidths = $this->resolveTableColumnWidths($columnWidths, $fontSize);
-        $lineHeight = $this->lineHeight($fontSize, 1.35);
-        $formattedHeader = $this->formatTableRow($headers, $resolvedWidths);
-        $this->writeMonospaceLine($formattedHeader, $fontSize);
-        $this->cursorY -= $lineHeight;
-        $this->ensureSpace($lineHeight);
-        $separator = $this->formatTableSeparator($resolvedWidths);
-        $this->writeMonospaceLine($separator, $fontSize);
-        $this->cursorY -= $lineHeight;
-        foreach ($rows as $row) {
-            $this->ensureSpace($lineHeight);
-            $this->writeMonospaceLine($this->formatTableRow($row, $resolvedWidths), $fontSize);
-            $this->cursorY -= $lineHeight;
+        $resolvedWidths = $this->resolveTableColumnWidthsInPoints($columnWidths);
+        $lineHeight = $this->lineHeight($fontSize, 1.3);
+        $cellPaddingX = 6.0;
+        $cellPaddingY = 4.0;
+        $headerFill = [237, 242, 247];
+        $rowFill = [250, 252, 255];
+        $borderColor = [203, 213, 225];
+
+        $renderRow = function (array $row, bool $isHeader, bool $alternate = false) use (
+            $resolvedWidths,
+            $fontSize,
+            $lineHeight,
+            $cellPaddingX,
+            $cellPaddingY,
+            $headerFill,
+            $rowFill,
+            $borderColor
+        ): void {
+            $cellLines = [];
+            $maxLines = 1;
+            foreach ($resolvedWidths as $index => $width) {
+                $value = trim((string)($row[$index] ?? ''));
+                $availableTextWidth = max(20.0, $width - ($cellPaddingX * 2));
+                $wrapped = $this->wrapTextToWidth($value, $fontSize, $availableTextWidth);
+                if ($wrapped === []) {
+                    $wrapped = [''];
+                }
+                $cellLines[$index] = $wrapped;
+                $maxLines = max($maxLines, count($wrapped));
+            }
+
+            $rowHeight = ($maxLines * $lineHeight) + ($cellPaddingY * 2);
+            $this->ensureSpace($rowHeight + 2.0);
+
+            $x = $this->marginLeft;
+            $rowTopY = $this->cursorY;
+            $rowBottomY = $rowTopY - $rowHeight;
+            foreach ($resolvedWidths as $index => $width) {
+                if ($isHeader) {
+                    $this->drawFilledRect($x, $rowBottomY, $width, $rowHeight, $headerFill);
+                } elseif ($alternate) {
+                    $this->drawFilledRect($x, $rowBottomY, $width, $rowHeight, $rowFill);
+                }
+                $this->drawRectOutline($x, $rowBottomY, $width, $rowHeight, $borderColor, 0.5);
+
+                $textY = $rowTopY - $cellPaddingY - $fontSize;
+                foreach ($cellLines[$index] as $line) {
+                    $font = $isHeader ? 'F2' : 'F1';
+                    $this->drawText($line, $font, $fontSize, $x + $cellPaddingX, $textY);
+                    $textY -= $lineHeight;
+                }
+
+                $x += $width;
+            }
+
+            $this->cursorY = $rowBottomY;
+        };
+
+        $renderRow($headers, true);
+        foreach (array_values($rows) as $rowIndex => $row) {
+            $renderRow((array)$row, false, ($rowIndex % 2) === 1);
         }
         $this->addSpacer(6.0);
     }
@@ -373,8 +450,17 @@ class SimplePdfDocument
             $imageReferences[$name] = $objNum;
         }
 
-        foreach ($this->pages as $ops) {
-            $content = implode("\n", $ops) . "\n";
+        $totalPages = count($this->pages);
+        foreach ($this->pages as $pageIndex => $ops) {
+            $resolvedOps = [];
+            foreach ($ops as $op) {
+                $resolvedOps[] = str_replace(
+                    [self::PAGE_TOKEN, self::PAGE_TOTAL_TOKEN],
+                    [(string)($pageIndex + 1), (string)$totalPages],
+                    $op
+                );
+            }
+            $content = implode("\n", $resolvedOps) . "\n";
             $contentObjNum = $objectIndex++;
             $objects[$contentObjNum] = '<< /Length ' . strlen($content) . " >>\nstream\n" . $content . "endstream";
             $pageObjNum = $objectIndex++;
@@ -457,10 +543,12 @@ class SimplePdfDocument
         if ($this->pageOpen) {
             $this->pages[] = $this->currentOps;
         }
+        $this->pageNumber = count($this->pages) + 1;
         $this->currentOps = [];
         $this->pageOpen = true;
         $this->cursorY = $this->height - $this->marginTop;
         $this->renderHeader();
+        $this->renderPageFooter();
     }
 
     private function ensureSpace(float $lineHeight): void
@@ -527,6 +615,67 @@ class SimplePdfDocument
         );
     }
 
+    private function drawLineWithColor(float $startX, float $startY, float $endX, float $endY, array $rgb, float $lineWidth = 1.0): void
+    {
+        $r = $this->formatFloat(max(0, min(255, (float)($rgb[0] ?? 0))) / 255);
+        $g = $this->formatFloat(max(0, min(255, (float)($rgb[1] ?? 0))) / 255);
+        $b = $this->formatFloat(max(0, min(255, (float)($rgb[2] ?? 0))) / 255);
+
+        $this->currentOps[] = sprintf(
+            'q %s %s %s RG %s w %s %s m %s %s l S Q',
+            $r,
+            $g,
+            $b,
+            $this->formatFloat($lineWidth),
+            $this->formatFloat($startX),
+            $this->formatFloat($startY),
+            $this->formatFloat($endX),
+            $this->formatFloat($endY)
+        );
+    }
+
+    private function drawFilledRect(float $x, float $y, float $width, float $height, array $rgb): void
+    {
+        if ($width <= 0.0 || $height <= 0.0) {
+            return;
+        }
+        $r = $this->formatFloat(max(0, min(255, (float)($rgb[0] ?? 0))) / 255);
+        $g = $this->formatFloat(max(0, min(255, (float)($rgb[1] ?? 0))) / 255);
+        $b = $this->formatFloat(max(0, min(255, (float)($rgb[2] ?? 0))) / 255);
+
+        $this->currentOps[] = sprintf(
+            'q %s %s %s rg %s %s %s %s re f Q',
+            $r,
+            $g,
+            $b,
+            $this->formatFloat($x),
+            $this->formatFloat($y),
+            $this->formatFloat($width),
+            $this->formatFloat($height)
+        );
+    }
+
+    private function drawRectOutline(float $x, float $y, float $width, float $height, array $rgb, float $lineWidth = 0.5): void
+    {
+        if ($width <= 0.0 || $height <= 0.0) {
+            return;
+        }
+        $r = $this->formatFloat(max(0, min(255, (float)($rgb[0] ?? 0))) / 255);
+        $g = $this->formatFloat(max(0, min(255, (float)($rgb[1] ?? 0))) / 255);
+        $b = $this->formatFloat(max(0, min(255, (float)($rgb[2] ?? 0))) / 255);
+        $this->currentOps[] = sprintf(
+            'q %s %s %s RG %s w %s %s %s %s re S Q',
+            $r,
+            $g,
+            $b,
+            $this->formatFloat($lineWidth),
+            $this->formatFloat($x),
+            $this->formatFloat($y),
+            $this->formatFloat($width),
+            $this->formatFloat($height)
+        );
+    }
+
     private function renderHeader(): void
     {
         $topY = $this->height - $this->marginTop;
@@ -539,10 +688,24 @@ class SimplePdfDocument
         $image = $config['image'] ?? null;
         $textX = $this->marginLeft;
         $imageHeight = 0.0;
+        $barColor = is_array($config['bar_color'] ?? null) ? $config['bar_color'] : [32, 115, 191];
+        $textColor = is_array($config['text_color'] ?? null) ? $config['text_color'] : [32, 41, 59];
+        $topBarHeight = max(2.0, (float)($config['top_bar_height'] ?? 8.0));
+        $topBarGap = max(0.0, (float)($config['top_bar_gap'] ?? 8.0));
+
+        $titleHeight = $config['title'] !== null ? (float)$config['title_font_size'] : 0.0;
+        $subtitleHeight = $config['subtitle'] !== null ? (float)$config['subtitle_font_size'] : 0.0;
+        $lineGap = ($config['title'] !== null && $config['subtitle'] !== null) ? (float)$config['line_gap'] : 0.0;
+        $textContentHeight = $titleHeight + $subtitleHeight + $lineGap;
+        $headerBarY = $topY - $topBarHeight;
+        $barWidth = $this->width - $this->marginLeft - $this->marginRight;
+        $this->drawFilledRect($this->marginLeft, $headerBarY, $barWidth, $topBarHeight, $barColor);
+
+        $contentTopY = $headerBarY - $topBarGap - (float)$config['top_padding'];
 
         if (is_array($image) && $image['width'] > 0.0 && $image['height'] > 0.0) {
             $imageX = $this->marginLeft;
-            $imageY = $topY - $image['height'];
+            $imageY = $contentTopY - $image['height'];
             $this->drawImage($image['name'], $imageX, $imageY, $image['width'], $image['height']);
             $textX += $image['width'] + $config['text_gap'];
             $imageHeight = $image['height'];
@@ -550,32 +713,100 @@ class SimplePdfDocument
             $textX += $config['text_gap'];
         }
 
-        $currentTop = $topY - $config['top_padding'];
+        $this->applyTextFillColor($textColor);
+
+        $availableTextWidth = max(80.0, ($this->width - $this->marginRight) - $textX);
+        $textBottomY = $contentTopY;
+        $currentTop = $contentTopY;
         if ($config['title'] !== null) {
-            $currentTop -= $config['title_font_size'];
-            $this->drawText($config['title'], 'F2', $config['title_font_size'], $textX, $currentTop);
+            $titleLines = $this->wrapTextToWidth((string)$config['title'], (float)$config['title_font_size'], $availableTextWidth);
+            if (count($titleLines) > 2) {
+                $titleLines = array_slice($titleLines, 0, 2);
+                $titleLines[1] = rtrim($titleLines[1]) . '…';
+            }
+            foreach ($titleLines as $lineIndex => $titleLine) {
+                $currentTop -= $config['title_font_size'];
+                $titleX = $this->width - $this->marginRight;
+                $titleWidth = $this->estimateTextWidth($titleLine, (float)$config['title_font_size']);
+                $titleX = max($textX, $titleX - $titleWidth);
+                $this->drawText($titleLine, 'F2', $config['title_font_size'], $titleX, $currentTop);
+                $textBottomY = min($textBottomY, $currentTop - (float)$config['title_font_size']);
+                if ($lineIndex < count($titleLines) - 1) {
+                    $currentTop -= max(2.0, $config['line_gap'] * 0.5);
+                }
+            }
             $currentTop -= $config['line_gap'];
         }
 
         if ($config['subtitle'] !== null) {
-            $currentTop -= $config['subtitle_font_size'];
-            $this->drawText($config['subtitle'], 'F1', $config['subtitle_font_size'], $textX, $currentTop);
+            $subtitleLines = $this->wrapTextToWidth((string)$config['subtitle'], (float)$config['subtitle_font_size'], $availableTextWidth);
+            if (count($subtitleLines) > 2) {
+                $subtitleLines = array_slice($subtitleLines, 0, 2);
+                $subtitleLines[1] = rtrim($subtitleLines[1]) . '…';
+            }
+            foreach ($subtitleLines as $lineIndex => $subtitleLine) {
+                $currentTop -= $config['subtitle_font_size'];
+                $subtitleX = $this->width - $this->marginRight;
+                $subtitleWidth = $this->estimateTextWidth($subtitleLine, (float)$config['subtitle_font_size']);
+                $subtitleX = max($textX, $subtitleX - $subtitleWidth);
+                $this->drawText($subtitleLine, 'F1', $config['subtitle_font_size'], $subtitleX, $currentTop);
+                $textBottomY = min($textBottomY, $currentTop - (float)$config['subtitle_font_size']);
+                if ($lineIndex < count($subtitleLines) - 1) {
+                    $currentTop -= max(2.0, $config['line_gap'] * 0.4);
+                }
+            }
         }
+        $this->resetTextFillColor();
 
         $contentGap = (float)($config['content_gap'] ?? 10.0);
         $ruleGap = (float)($config['rule_gap'] ?? 6.0);
-        $ruleY = $topY - $this->headerSpacing + $contentGap + $ruleGap;
-        if ($imageHeight > 0.0 || $config['title'] !== null || $config['subtitle'] !== null) {
-            $this->drawLine(
-                $this->marginLeft,
-                $ruleY,
-                $this->width - $this->marginRight,
-                $ruleY,
-                0.6
-            );
+        $headerContentBottomY = min($contentTopY - $imageHeight, $textBottomY);
+        $ruleY = $headerContentBottomY - (float)$config['bottom_padding'] - $ruleGap;
+        $this->drawLineWithColor(
+            $this->marginLeft,
+            $ruleY,
+            $this->width - $this->marginRight,
+            $ruleY,
+            $barColor,
+            0.8
+        );
+
+        $this->cursorY = $ruleY - $contentGap;
+    }
+
+    private function renderPageFooter(): void
+    {
+        if ($this->pageNumber <= 0) {
+            return;
         }
 
-        $this->cursorY = $topY - $this->headerSpacing + $contentGap;
+        $barColor = [32, 115, 191];
+        if ($this->headerConfig !== null && is_array($this->headerConfig['bar_color'] ?? null)) {
+            $barColor = $this->headerConfig['bar_color'];
+        }
+        $barWidth = $this->width - $this->marginLeft - $this->marginRight;
+        $barY = $this->marginBottom - 8.0;
+        $this->drawFilledRect($this->marginLeft, $barY, $barWidth, 3.0, $barColor);
+
+        $label = 'Page ' . self::PAGE_TOKEN . ' of ' . self::PAGE_TOTAL_TOKEN;
+        $fontSize = 9.0;
+        $textWidth = $this->estimateTextWidth($label, $fontSize);
+        $x = ($this->width / 2) - ($textWidth / 2);
+        $y = max(20.0, $barY - 12.0);
+        $this->drawText($label, 'F1', $fontSize, $x, $y);
+    }
+
+    private function applyTextFillColor(array $rgb): void
+    {
+        $r = $this->formatFloat(max(0, min(255, (float)($rgb[0] ?? 0))) / 255);
+        $g = $this->formatFloat(max(0, min(255, (float)($rgb[1] ?? 0))) / 255);
+        $b = $this->formatFloat(max(0, min(255, (float)($rgb[2] ?? 0))) / 255);
+        $this->currentOps[] = sprintf('%s %s %s rg', $r, $g, $b);
+    }
+
+    private function resetTextFillColor(): void
+    {
+        $this->currentOps[] = '0 0 0 rg';
     }
 
     private function normalizeHeaderText(?string $value): ?string
@@ -863,6 +1094,36 @@ class SimplePdfDocument
         ksort($assignments);
 
         return array_values($assignments);
+    }
+
+    private function resolveTableColumnWidthsInPoints(array $columnWidths): array
+    {
+        $count = count($columnWidths);
+        if ($count === 0) {
+            return [];
+        }
+
+        $availableWidth = max(0.0, $this->width - $this->marginLeft - $this->marginRight);
+        if ($availableWidth <= 0.0) {
+            return array_fill(0, $count, 1.0);
+        }
+
+        $weights = [];
+        foreach ($columnWidths as $width) {
+            $weights[] = max(1.0, (float)$width);
+        }
+
+        $total = array_sum($weights);
+        if ($total <= 0.0) {
+            return array_fill(0, $count, $availableWidth / $count);
+        }
+
+        $result = [];
+        foreach ($weights as $weight) {
+            $result[] = $availableWidth * ($weight / $total);
+        }
+
+        return $result;
     }
 
     private function monospaceCharacterWidth(float $fontSize): float

--- a/my_performance_download.php
+++ b/my_performance_download.php
@@ -141,7 +141,12 @@ $siteName = (string) ($cfg['site_name'] ?? 'My Performance');
 
 $pdf = new SimplePdfDocument();
 $logoSpec = analytics_report_header_logo_spec($pdf, $cfg);
-$pdf->setHeader($siteName, t($t, 'my_performance_pdf_subtitle', 'Personal performance summary'), $logoSpec);
+$pdf->setHeader(
+    $siteName,
+    t($t, 'my_performance_pdf_subtitle', 'Personal performance summary'),
+    $logoSpec,
+    analytics_report_header_style($cfg)
+);
 $userDetails = [];
 $nameLine = trim((string) ($user['full_name'] ?? ''));
 if ($nameLine === '') {


### PR DESCRIPTION
### Motivation
- Improve readability and branding of generated PDFs by exposing header styling (palette-aware top bar and text color) and adding page footers with page numbers.
- Make chart rendering more robust against long labels and dense series by measuring/wrapping labels, adjusting margins, and conditionally showing value labels.
- Replace the simplistic monospace table output with a proper table renderer for PDF exports and add safer TTF text measurement and fallbacks.

### Description
- Added `analytics_report_header_style()` and threaded a new `style` parameter into `SimplePdfDocument::setHeader()` so headers use configured palette colors for a top bar and text.
- Implemented page footer rendering with page number tokens (`__PDF_PAGE__` / `__PDF_PAGE_TOTAL__`) and replaced tokens when assembling the PDF pages.
- Extended `SimplePdfDocument` with drawing helpers (`drawFilledRect`, `drawLineWithColor`, `drawRectOutline`), text color application helpers, page footer render, and improved header layout with multiline title/subtitle wrapping and logo placement.
- Rewrote table rendering in `SimplePdfDocument::addTable()` to compute column widths in points, wrap cell text, draw header fill and alternating row fills, and draw table borders instead of emitting monospace text.
- Added GD/text utilities in `analytics_report.php`: `analytics_report_draw_wrapped_text()`, `analytics_report_wrap_text_lines()`, `analytics_report_measure_text_width()`, and robust TTF box width/height helpers, plus a safer fallback for `imagettftext` drawing in `analytics_report_draw_text()`.
- Updated chart generators (bar, line, radar) to inspect label lengths, compute `showEvery` intervals, wrap labels, optionally hide value labels for dense series, and adjust margins based on estimated label line counts; improved label placement to avoid overlap.
- Improved default font path resolution with caching and additional candidates, and preserved existing truncation behavior via `analytics_report_truncate_label()`.
- Updated `my_performance_download.php` to pass the new header style when creating a `SimplePdfDocument`.

### Testing
- Performed PHP syntax checks using `php -l` on the modified files `lib/analytics_report.php`, `lib/simple_pdf.php`, and `my_performance_download.php` with no syntax errors reported.
- Ran the project's PHPUnit test suite via `vendor/bin/phpunit` and observed no failing tests.
- Executed automated report-generation smoke tests in CI that produce PDF outputs to verify header/footer, tables, and charts render without runtime errors (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea29bad208832db001031de3698777)