### PR TITLE
Fix parse error in lib/simple_pdf.php by removing duplicated footer code

### DIFF
--- a/lib/simple_pdf.php
+++ b/lib/simple_pdf.php
@@ -807,9 +807,6 @@ class SimplePdfDocument
         if ($this->pageNumber <= 0) {
             return;
         }
-        $barWidth = $this->width - $this->marginLeft - $this->marginRight;
-        $barY = $this->marginBottom - 8.0;
-        $this->drawFilledRect($this->marginLeft, $barY, $barWidth, 3.0, $barColor);
 
         $barColor = (
             $this->headerConfig !== null
@@ -820,37 +817,6 @@ class SimplePdfDocument
         $barWidth = $this->width - $this->marginLeft - $this->marginRight;
         $barY = $this->marginBottom - 8.0;
         $this->drawFilledRect($this->marginLeft, $barY, $barWidth, 3.0, $barColor);
-
-        $label = 'Page ' . self::PAGE_TOKEN . ' of ' . self::PAGE_TOTAL_TOKEN;
-        $fontSize = 9.0;
-        $textWidth = $this->estimateTextWidth($label, $fontSize);
-        $x = ($this->width / 2) - ($textWidth / 2);
-        $y = max(20.0, $barY - 12.0);
-        $this->drawText($label, 'F1', $fontSize, $x, $y);
-    }
-
-    private function applyTextFillColor(array $rgb): void
-    {
-        $r = $this->formatFloat(max(0, min(255, (float)($rgb[0] ?? 0))) / 255);
-        $g = $this->formatFloat(max(0, min(255, (float)($rgb[1] ?? 0))) / 255);
-        $b = $this->formatFloat(max(0, min(255, (float)($rgb[2] ?? 0))) / 255);
-        $this->currentOps[] = sprintf('%s %s %s rg', $r, $g, $b);
-    }
-
-        $barWidth = $this->width - $this->marginLeft - $this->marginRight;
-        $barY = $this->marginBottom - 8.0;
-        $this->drawFilledRect(
-            $this->marginLeft,
-            $barY,
-            $barWidth,
-            3.0,
-            (
-                $this->headerConfig !== null
-                && is_array($this->headerConfig['bar_color'] ?? null)
-            )
-                ? $this->headerConfig['bar_color']
-                : [32, 115, 191]
-        );
 
         $label = 'Page ' . self::PAGE_TOKEN . ' of ' . self::PAGE_TOTAL_TOKEN;
         $fontSize = 9.0;


### PR DESCRIPTION
### Motivation
- The file contained duplicated footer drawing statements and a duplicate `applyTextFillColor()` definition that left executable statements at class scope, causing PHP parse errors like "Unexpected variable" around line 840.
- Ensure footer rendering initializes `$barColor` before calling `drawFilledRect()` to avoid undefined variable or runtime issues.

### Description
- Removed the stray duplicated footer rendering block that was outside any method scope.
- Removed the duplicate `private function applyTextFillColor(array $rgb): void` definition so the method is defined once.
- Reordered and cleaned `renderPageFooter()` so `$barColor` is assigned before `drawFilledRect()` and eliminated duplicated statements.

### Testing
- Ran `php -l lib/simple_pdf.php` and it reported "No syntax errors detected", indicating the parse error is resolved.
- Ran `rg -n "function applyTextFillColor|function renderPageFooter|<<<<<<<|>>>>>>>|=====" lib/simple_pdf.php` and confirmed only the expected single occurrences remain.
- Inspected the footer region with `nl -ba lib/simple_pdf.php | sed -n '800,860p'` to visually verify the duplicated block was removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef826f3e44832d909e9268a022cf8a)