### PR TITLE
Limit and normalize department/team slugs; improve unique slug generation and clean up PDF footer code

### DIFF
--- a/lib/department_teams.php
+++ b/lib/department_teams.php
@@ -34,7 +34,12 @@ function built_in_department_definitions(): array
 function canonical_department_slug(string $value): string
 {
     $normalized = preg_replace('/[^a-z0-9]+/i', '_', strtolower(trim($value))) ?? '';
-    return trim($normalized, '_');
+    $normalized = trim($normalized, '_');
+    if ($normalized === '') {
+        return '';
+    }
+
+    return substr($normalized, 0, 120);
 }
 
 function canonical_department_team_slug(string $value): string
@@ -68,12 +73,23 @@ function is_placeholder_team_value(string $value): bool
     return (bool)preg_match('/^(none|na|n_a|null|unknown|not_applicable)_\d+$/', $canonical);
 }
 
-function unique_slug(string $candidate, array $existing): string
+function unique_slug(string $candidate, array $existing, int $maxLength = 120): string
 {
-    $base = $candidate;
+    $candidate = trim($candidate);
+    if ($candidate === '') {
+        $candidate = 'item';
+    }
+    if ($maxLength < 8) {
+        $maxLength = 8;
+    }
+
+    $base = substr($candidate, 0, $maxLength);
+    $candidate = $base;
     $suffix = 2;
     while (isset($existing[$candidate])) {
-        $candidate = $base . '_' . $suffix;
+        $suffixToken = '_' . $suffix;
+        $baseLimit = max(1, $maxLength - strlen($suffixToken));
+        $candidate = substr($base, 0, $baseLimit) . $suffixToken;
         $suffix++;
         if ($suffix > 10000) {
             break;

--- a/lib/simple_pdf.php
+++ b/lib/simple_pdf.php
@@ -807,9 +807,6 @@ class SimplePdfDocument
         if ($this->pageNumber <= 0) {
             return;
         }
-        $barWidth = $this->width - $this->marginLeft - $this->marginRight;
-        $barY = $this->marginBottom - 8.0;
-        $this->drawFilledRect($this->marginLeft, $barY, $barWidth, 3.0, $barColor);
 
         $barColor = (
             $this->headerConfig !== null
@@ -820,37 +817,6 @@ class SimplePdfDocument
         $barWidth = $this->width - $this->marginLeft - $this->marginRight;
         $barY = $this->marginBottom - 8.0;
         $this->drawFilledRect($this->marginLeft, $barY, $barWidth, 3.0, $barColor);
-
-        $label = 'Page ' . self::PAGE_TOKEN . ' of ' . self::PAGE_TOTAL_TOKEN;
-        $fontSize = 9.0;
-        $textWidth = $this->estimateTextWidth($label, $fontSize);
-        $x = ($this->width / 2) - ($textWidth / 2);
-        $y = max(20.0, $barY - 12.0);
-        $this->drawText($label, 'F1', $fontSize, $x, $y);
-    }
-
-    private function applyTextFillColor(array $rgb): void
-    {
-        $r = $this->formatFloat(max(0, min(255, (float)($rgb[0] ?? 0))) / 255);
-        $g = $this->formatFloat(max(0, min(255, (float)($rgb[1] ?? 0))) / 255);
-        $b = $this->formatFloat(max(0, min(255, (float)($rgb[2] ?? 0))) / 255);
-        $this->currentOps[] = sprintf('%s %s %s rg', $r, $g, $b);
-    }
-
-        $barWidth = $this->width - $this->marginLeft - $this->marginRight;
-        $barY = $this->marginBottom - 8.0;
-        $this->drawFilledRect(
-            $this->marginLeft,
-            $barY,
-            $barWidth,
-            3.0,
-            (
-                $this->headerConfig !== null
-                && is_array($this->headerConfig['bar_color'] ?? null)
-            )
-                ? $this->headerConfig['bar_color']
-                : [32, 115, 191]
-        );
 
         $label = 'Page ' . self::PAGE_TOKEN . ' of ' . self::PAGE_TOTAL_TOKEN;
         $fontSize = 9.0;


### PR DESCRIPTION
### Motivation
- Ensure department and team slugs are normalized, bounded in length, and never produce invalid empty or overly long identifiers.
- Make `unique_slug` more robust when given empty or long candidates and ensure suffixes preserve the maximum length.
- Remove duplicated/incorrect PDF footer code and keep text color helpers consolidated to avoid duplicated logic.

### Description
- Update `canonical_department_slug` to trim to a maximum of `120` characters and return an empty string for empty inputs, and keep underscores trimmed from ends.
- Add a `maxLength` parameter to `unique_slug` with default `120`, ensure a minimum allowed limit of `8`, default empty candidates to `'item'`, truncate the base to `maxLength`, and compute suffix insertion so the final slug never exceeds `maxLength` while avoiding collisions.
- Keep `canonical_department_team_slug` delegating to `canonical_department_slug` and leave placeholder detection behavior unchanged aside from the canonical truncation.
- Clean up `SimplePdfDocument::renderPageFooter()` by removing duplicated footer drawing and moving color selection and drawing into a single coherent block, and remove duplicate `applyTextFillColor` code so the helper is defined once.

### Testing
- Ran the project's unit test suite via `vendor/bin/phpunit`, and the tests completed successfully.
- Ran syntax checks on modified files with `php -l`, and there were no parse errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef826f3e44832d909e9268a022cf8a)