### PR TITLE
Analytics: overview/drilldown modes, department×role heatmap, table filters and UI/UX improvements

### DIFF
--- a/admin/analytics.php
+++ b/admin/analytics.php
@@ -442,6 +442,10 @@ foreach ($questionnaireKpiTracker as $familyKey => $userScores) {
 
 $questionnaireIds = array_map(static fn($row) => (int)$row['id'], $questionnaires);
 $selectedQuestionnaireId = (int)($_GET['questionnaire_id'] ?? 0);
+$analyticsViewMode = strtolower((string)($_GET['view'] ?? 'overview'));
+if ($analyticsViewMode !== 'drilldown') {
+    $analyticsViewMode = 'overview';
+}
 $selectedQuestionnaireFamilyKey = '';
 $selectedQuestionnaireStructureId = 0;
 if ($questionnaires) {
@@ -457,6 +461,7 @@ if ($questionnaires) {
     }
 } else {
     $selectedQuestionnaireId = 0;
+    $analyticsViewMode = 'overview';
 }
 
 if (isset($summary['avg_score']) && $summary['avg_score'] !== null) {
@@ -780,6 +785,7 @@ $teamCatalog = department_team_catalog($pdo);
 $workFunctionSummary = [];
 $departmentSummary = [];
 $teamSummary = [];
+$departmentRoleSummary = [];
 try {
     $trainingRecommendationStmt = $pdo->query(
         'SELECT cc.id AS course_id, cc.title AS course_title, '
@@ -826,6 +832,17 @@ try {
         . "ORDER BY total_responses DESC"
     );
     $teamSummary = $teamSummaryStmt ? $teamSummaryStmt->fetchAll(PDO::FETCH_ASSOC) : [];
+
+    $departmentRoleStmt = $pdo->query(
+        "SELECT u.department, u.work_function, COUNT(*) AS total_responses, "
+        . "SUM(qr.status='approved') AS approved_count, "
+        . "AVG(qr.score) AS avg_score "
+        . "FROM questionnaire_response qr "
+        . "JOIN users u ON u.id = qr.user_id "
+        . "GROUP BY u.department, u.work_function "
+        . "ORDER BY u.department ASC, u.work_function ASC"
+    );
+    $departmentRoleSummary = $departmentRoleStmt ? $departmentRoleStmt->fetchAll(PDO::FETCH_ASSOC) : [];
 } catch (PDOException $e) {
     error_log('analytics summary queries failed: ' . $e->getMessage());
 }
@@ -839,6 +856,25 @@ foreach ($workFunctionSummary as &$wfRow) {
     }
 }
 unset($wfRow);
+
+$departmentRoleMap = [];
+$departmentRoleDepartments = [];
+$departmentRoleFunctions = [];
+foreach ($departmentRoleSummary as $row) {
+    $departmentKey = (string)($row['department'] ?? '');
+    $workFunctionKey = (string)($row['work_function'] ?? '');
+    $departmentRoleDepartments[$departmentKey] = $departmentOptions[$departmentKey]
+        ?? ($departmentKey !== '' ? $departmentKey : t($t, 'unknown', 'Unknown'));
+    $departmentRoleFunctions[$workFunctionKey] = $workFunctionOptions[$workFunctionKey]
+        ?? ($workFunctionKey !== '' ? $workFunctionKey : t($t, 'unknown', 'Unknown'));
+    $departmentRoleMap[$departmentKey][$workFunctionKey] = [
+        'score' => $row['avg_score'] !== null ? (float)$row['avg_score'] : null,
+        'responses' => (int)($row['total_responses'] ?? 0),
+        'approved' => (int)($row['approved_count'] ?? 0),
+    ];
+}
+asort($departmentRoleDepartments, SORT_NATURAL | SORT_FLAG_CASE);
+asort($departmentRoleFunctions, SORT_NATURAL | SORT_FLAG_CASE);
 
 $questionnaireChartData = [];
 foreach ($questionnaires as $row) {
@@ -884,6 +920,29 @@ if (count($workFunctionChartData) > 12) {
     $workFunctionChartData = array_slice($workFunctionChartData, 0, 12);
 }
 
+$lowestQuestionnaire = null;
+$highestWorkFunction = null;
+$totalRecommendedStaff = 0;
+foreach ($questionnaires as $row) {
+    if (($row['avg_score'] ?? null) === null) {
+        continue;
+    }
+    if ($lowestQuestionnaire === null || (float)$row['avg_score'] < (float)$lowestQuestionnaire['avg_score']) {
+        $lowestQuestionnaire = $row;
+    }
+}
+foreach ($workFunctionSummary as $row) {
+    if (($row['avg_score'] ?? null) === null) {
+        continue;
+    }
+    if ($highestWorkFunction === null || (float)$row['avg_score'] > (float)$highestWorkFunction['avg_score']) {
+        $highestWorkFunction = $row;
+    }
+}
+foreach ($trainingRecommendationReport as $row) {
+    $totalRecommendedStaff += (int)($row['recommended_staff_count'] ?? 0);
+}
+
 $chartJsonFlags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 if (defined('JSON_THROW_ON_ERROR')) {
     $chartJsonFlags |= JSON_THROW_ON_ERROR;
@@ -902,6 +961,25 @@ $formatScore = static function ($score, int $precision = 1): string {
         return '—';
     }
     return number_format((float)$score, $precision);
+};
+
+$heatColorForScore = static function ($score): string {
+    if ($score === null) {
+        return '#f3f4f6';
+    }
+    $value = max(0, min(100, (float)$score));
+    if ($value <= 50) {
+        $ratio = $value / 50;
+        $r = 211 + (249 - 211) * $ratio;
+        $g = 47 + (168 - 47) * $ratio;
+        $b = 47 + (37 - 47) * $ratio;
+    } else {
+        $ratio = ($value - 50) / 50;
+        $r = 249 + (46 - 249) * $ratio;
+        $g = 168 + (125 - 168) * $ratio;
+        $b = 37 + (50 - 37) * $ratio;
+    }
+    return sprintf('rgba(%d, %d, %d, 0.82)', (int)round($r), (int)round($g), (int)round($b));
 };
 
 $formatCompetencyLevel = static function ($score) use ($t): string {
@@ -1075,6 +1153,27 @@ $pageHelpKey = 'team.analytics';
       font-size: 1.25rem;
       margin-bottom: 0.35rem;
     }
+    .md-insight-strip {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem;
+      margin: 0.75rem 0 0;
+    }
+    .md-insight {
+      background: #eef6ff;
+      border-left: 4px solid #1d4ed8;
+      border-radius: 8px;
+      padding: 0.7rem 0.8rem;
+      font-size: 0.9rem;
+    }
+    .md-insight strong {
+      display: block;
+      margin-bottom: 0.25rem;
+      font-size: 0.82rem;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      color: #1e3a8a;
+    }
     .md-report-grid {
       display: grid;
       gap: 1rem;
@@ -1181,12 +1280,112 @@ $pageHelpKey = 'team.analytics';
       margin-top: 0.35rem;
       font-size: 0.9rem;
     }
+    .md-analytics-top-nav {
+      position: sticky;
+      top: 0.5rem;
+      z-index: 10;
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      padding: 0.75rem;
+      margin-bottom: 1rem;
+      border-radius: 10px;
+      background: var(--app-surface, #fff);
+      border: 1px solid var(--app-border, #e2e8f0);
+    }
+    .md-analytics-top-nav a {
+      display: inline-block;
+      text-decoration: none;
+      padding: 0.4rem 0.75rem;
+      border-radius: 999px;
+      color: var(--app-text, #1f2937);
+      background: var(--app-surface-alt, #f5f7fa);
+      font-size: 0.9rem;
+    }
+    .md-analytics-top-nav a:hover,
+    .md-analytics-top-nav a:focus {
+      background: #dbeafe;
+      color: #0b3f93;
+    }
+    .md-disclosure {
+      margin-top: 0.75rem;
+      border-top: 1px solid var(--app-border, #e2e8f0);
+      padding-top: 0.5rem;
+    }
+    .md-disclosure > summary {
+      cursor: pointer;
+      font-weight: 600;
+      margin: 0.25rem 0 0.5rem;
+    }
+    .md-disclosure[open] > summary {
+      margin-bottom: 0.75rem;
+    }
+    .md-table-toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 0.75rem;
+      align-items: center;
+      margin: 0.75rem 0;
+    }
+    .md-table-toolbar label {
+      font-size: 0.85rem;
+      color: var(--app-text-secondary, #4b5563);
+    }
+    .md-table-toolbar input,
+    .md-table-toolbar select {
+      min-width: 160px;
+    }
+    .md-row-toggle {
+      margin-top: 0.5rem;
+    }
+    tr.is-hidden-by-filter {
+      display: none;
+    }
+    .md-matrix-wrapper {
+      overflow-x: auto;
+    }
+    .md-matrix-table {
+      width: 100%;
+      min-width: 640px;
+      border-collapse: separate;
+      border-spacing: 4px;
+    }
+    .md-matrix-table th {
+      background: var(--app-surface-alt, #f5f7fa);
+      padding: 0.5rem;
+      font-size: 0.85rem;
+      text-align: left;
+      border-radius: 6px;
+    }
+    .md-matrix-cell {
+      color: #111827;
+      font-weight: 600;
+      text-align: center;
+      border-radius: 6px;
+      padding: 0.6rem 0.35rem;
+      min-width: 86px;
+    }
+    .md-matrix-cell small {
+      display: block;
+      font-weight: 500;
+      opacity: 0.9;
+    }
+    .md-matrix-cell--empty {
+      background: #f3f4f6;
+      color: #6b7280;
+      font-weight: 500;
+    }
     .md-table-responsive {
       overflow-x: auto;
     }
     .md-sectional-table th,
     .md-sectional-table td {
       white-space: nowrap;
+    }
+    @media (max-width: 860px) {
+      .md-analytics-top-nav {
+        top: 0;
+      }
     }
   </style>
 </head>
@@ -1199,7 +1398,20 @@ $pageHelpKey = 'team.analytics';
   <?php if ($reportError): ?>
     <div class="md-alert error"><?=htmlspecialchars($reportError, ENT_QUOTES, 'UTF-8')?></div>
   <?php endif; ?>
-  <div class="md-card md-kpi-card md-elev-2">
+  <nav class="md-analytics-top-nav" aria-label="<?=htmlspecialchars(t($t, 'analytics_page_sections', 'Analytics page sections'), ENT_QUOTES, 'UTF-8')?>">
+    <a href="<?=htmlspecialchars(url_for('admin/analytics.php') . '?view=overview&questionnaire_id=' . (int)$selectedQuestionnaireId, ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'overview_mode', 'Overview mode')?></a>
+    <a href="<?=htmlspecialchars(url_for('admin/analytics.php') . '?view=drilldown&questionnaire_id=' . (int)$selectedQuestionnaireId, ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'drilldown_mode', 'Drilldown mode')?></a>
+    <?php if ($analyticsViewMode === 'overview'): ?>
+      <a href="#overview"><?=t($t, 'analytics_overview', 'Analytics overview')?></a>
+      <a href="#questionnaire-performance"><?=t($t, 'questionnaire_performance', 'Questionnaire performance')?></a>
+      <a href="#org-heatmap"><?=t($t, 'department_role_heatmap', 'Department × Role heatmap')?></a>
+      <a href="#training-recommendations"><?=t($t, 'training_recommendation_report', 'Training recommendations by staff')?></a>
+      <a href="#downloads-tools"><?=t($t, 'analytics_download_and_tools', 'Downloads & tools')?></a>
+    <?php elseif ($selectedQuestionnaireId): ?>
+      <a href="#questionnaire-drilldown"><?=t($t, 'questionnaire_drilldown', 'Questionnaire drilldown')?></a>
+    <?php endif; ?>
+  </nav>
+  <div class="md-card md-kpi-card md-elev-2" id="overview">
     <div class="md-kpi-hero">
       <div class="md-kpi-hero__copy">
         <p class="md-kpi-hero__eyebrow"><?=t($t, 'epss_kpi_label', 'EPSS KPI')?></p>
@@ -1289,57 +1501,97 @@ $pageHelpKey = 'team.analytics';
     <?php if (!empty($summary['latest_at'])): ?>
       <p class="md-analytics-meta"><?=t($t, 'latest_submission', 'Latest submission:')?> <?=htmlspecialchars($summary['latest_at'], ENT_QUOTES, 'UTF-8')?></p>
     <?php endif; ?>
+    <div class="md-insight-strip">
+      <div class="md-insight">
+        <strong><?=t($t, 'insight_lowest_questionnaire', 'Lowest questionnaire')?></strong>
+        <?php if ($lowestQuestionnaire): ?>
+          <?=htmlspecialchars((string)($lowestQuestionnaire['title'] ?? t($t, 'unknown', 'Unknown')), ENT_QUOTES, 'UTF-8')?> · <?=htmlspecialchars($formatScore($lowestQuestionnaire['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?>%
+        <?php else: ?>
+          <?=t($t, 'not_available', 'N/A')?>
+        <?php endif; ?>
+      </div>
+      <div class="md-insight">
+        <strong><?=t($t, 'insight_best_work_role', 'Best work role')?></strong>
+        <?php if ($highestWorkFunction): ?>
+          <?php $bestWfKey = (string)($highestWorkFunction['work_function'] ?? ''); ?>
+          <?=htmlspecialchars((string)($workFunctionOptions[$bestWfKey] ?? ($bestWfKey !== '' ? $bestWfKey : t($t, 'unknown', 'Unknown'))), ENT_QUOTES, 'UTF-8')?> · <?=htmlspecialchars($formatScore($highestWorkFunction['avg_score'] ?? null), ENT_QUOTES, 'UTF-8')?>%
+        <?php else: ?>
+          <?=t($t, 'not_available', 'N/A')?>
+        <?php endif; ?>
+      </div>
+      <div class="md-insight">
+        <strong><?=t($t, 'insight_training_recommendations', 'Training recommendations')?></strong>
+        <?=sprintf(t($t, 'insight_training_recommendations_value', '%d staff recommendations'), $totalRecommendedStaff)?>
+      </div>
+    </div>
   </div>
 
-  <div class="md-card md-elev-2">
+  <?php if ($analyticsViewMode === 'overview'): ?>
+  <div class="md-card md-elev-2" id="downloads-tools">
     <h2 class="md-card-title"><?=t($t, 'analytics_download_reports', 'Download default reports')?></h2>
-    <p><?=t($t, 'analytics_download_reports_hint', 'Quickly download PDF snapshots for offline sharing.')?></p>
-    <p>
-      <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics_data_viewer.php'), ENT_QUOTES, 'UTF-8')?>">
-        <?=t($t, 'analytics_report_explorer_open', 'Open report explorer')?>
-      </a>
-    </p>
-    <h3><?=t($t, 'analytics_download_summary_section', 'Main overview report')?></h3>
-    <div class="md-download-grid">
-      <?php foreach ($overviewReportDownloads as $download): ?>
-        <div class="md-download-card">
-          <h3><?=htmlspecialchars($download['title'], ENT_QUOTES, 'UTF-8')?></h3>
-          <p><?=htmlspecialchars($download['description'], ENT_QUOTES, 'UTF-8')?></p>
-          <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars($download['url'], ENT_QUOTES, 'UTF-8')?>">
-            <?=t($t, 'analytics_download_button', 'Download PDF')?></a>
-        </div>
-      <?php endforeach; ?>
-    </div>
-    <h3><?=t($t, 'analytics_download_detailed_section', 'Detailed reports')?></h3>
-    <div class="md-download-grid">
-      <?php foreach ($detailedReportDownloads as $download): ?>
-        <div class="md-download-card">
-          <h3><?=htmlspecialchars($download['title'], ENT_QUOTES, 'UTF-8')?></h3>
-          <p><?=htmlspecialchars($download['description'], ENT_QUOTES, 'UTF-8')?></p>
-          <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars($download['url'], ENT_QUOTES, 'UTF-8')?>">
-            <?=t($t, 'analytics_download_button', 'Download PDF')?></a>
-        </div>
-      <?php endforeach; ?>
-    </div>
+    <details class="md-disclosure">
+      <summary><?=t($t, 'show_download_reports', 'Show download reports')?></summary>
+      <p><?=t($t, 'analytics_download_reports_hint', 'Quickly download PDF snapshots for offline sharing.')?></p>
+      <p>
+        <a class="md-button" href="<?=htmlspecialchars(url_for('admin/analytics_data_viewer.php'), ENT_QUOTES, 'UTF-8')?>">
+          <?=t($t, 'analytics_report_explorer_open', 'Open report explorer')?>
+        </a>
+      </p>
+      <h3><?=t($t, 'analytics_download_summary_section', 'Main overview report')?></h3>
+      <div class="md-download-grid">
+        <?php foreach ($overviewReportDownloads as $download): ?>
+          <div class="md-download-card">
+            <h3><?=htmlspecialchars($download['title'], ENT_QUOTES, 'UTF-8')?></h3>
+            <p><?=htmlspecialchars($download['description'], ENT_QUOTES, 'UTF-8')?></p>
+            <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars($download['url'], ENT_QUOTES, 'UTF-8')?>">
+              <?=t($t, 'analytics_download_button', 'Download PDF')?></a>
+          </div>
+        <?php endforeach; ?>
+      </div>
+      <h3><?=t($t, 'analytics_download_detailed_section', 'Detailed reports')?></h3>
+      <div class="md-download-grid">
+        <?php foreach ($detailedReportDownloads as $download): ?>
+          <div class="md-download-card">
+            <h3><?=htmlspecialchars($download['title'], ENT_QUOTES, 'UTF-8')?></h3>
+            <p><?=htmlspecialchars($download['description'], ENT_QUOTES, 'UTF-8')?></p>
+            <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars($download['url'], ENT_QUOTES, 'UTF-8')?>">
+              <?=t($t, 'analytics_download_button', 'Download PDF')?></a>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    </details>
   </div>
 
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'analytics_tools', 'Analytics tools')?></h2>
-    <p><?=t($t, 'analytics_tools_hint', 'Manage automation and external BI resources from dedicated workspaces.')?></p>
-    <p>
-      <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>">
-        <?=t($t, 'analytics_open_automation', 'Open automation workspace')?>
-      </a>
-      <a class="md-button md-outline" href="<?=htmlspecialchars(url_for('admin/analytics_looker.php'), ENT_QUOTES, 'UTF-8')?>">
-        <?=t($t, 'analytics_open_looker_resources', 'Open Looker resources')?>
-      </a>
-    </p>
+    <details class="md-disclosure">
+      <summary><?=t($t, 'show_analytics_tools', 'Show analytics tools')?></summary>
+      <p><?=t($t, 'analytics_tools_hint', 'Manage automation and external BI resources from dedicated workspaces.')?></p>
+      <p>
+        <a class="md-button md-primary md-elev-1" href="<?=htmlspecialchars(url_for('admin/analytics_automation.php'), ENT_QUOTES, 'UTF-8')?>">
+          <?=t($t, 'analytics_open_automation', 'Open automation workspace')?>
+        </a>
+        <a class="md-button md-outline" href="<?=htmlspecialchars(url_for('admin/analytics_looker.php'), ENT_QUOTES, 'UTF-8')?>">
+          <?=t($t, 'analytics_open_looker_resources', 'Open Looker resources')?>
+        </a>
+      </p>
+    </details>
   </div>
 
-  <div class="md-card md-elev-2">
+  <div class="md-card md-elev-2" id="questionnaire-performance">
     <h2 class="md-card-title"><?=t($t, 'questionnaire_performance', 'Questionnaire performance')?></h2>
     <?php if ($questionnaires): ?>
       <p class="md-upgrade-meta"><?=t($t, 'questionnaire_drilldown_hint', 'Select a questionnaire to drill into individual responses.')?></p>
+      <div class="md-table-toolbar">
+        <label>
+          <?=t($t, 'filter_questionnaires', 'Filter questionnaires')?>
+          <input type="search" data-table-filter="questionnaires" placeholder="<?=htmlspecialchars(t($t, 'search', 'Search'), ENT_QUOTES, 'UTF-8')?>">
+        </label>
+        <label>
+          <?=t($t, 'minimum_score', 'Minimum score')?>
+          <input type="number" min="0" max="100" step="1" data-score-filter="questionnaires" placeholder="0-100">
+        </label>
+      </div>
       <?php if ($questionnaireChartData): ?>
         <div
           class="md-chart-container"
@@ -1351,7 +1603,7 @@ $pageHelpKey = 'team.analytics';
         </div>
         <p class="md-analytics-meta md-analytics-meta--hint"><?=t($t, 'performance_heatmap_hint', 'Heatmap colours shift from red to green so low scores stand out for follow-up.')?></p>
       <?php endif; ?>
-      <table class="md-table md-table--interactive">
+      <table class="md-table md-table--interactive" data-filter-target="questionnaires" data-row-limit="10">
         <thead>
           <tr>
             <th><?=t($t, 'questionnaire', 'Questionnaire')?></th>
@@ -1384,13 +1636,55 @@ $pageHelpKey = 'team.analytics';
           <?php endforeach; ?>
         </tbody>
       </table>
+      <button type="button" class="md-button md-row-toggle" data-table-toggle="questionnaires"><?=t($t, 'show_more', 'Show more')?></button>
     <?php else: ?>
       <p class="md-upgrade-meta"><?=t($t, 'no_questionnaire_stats', 'No questionnaire responses are available yet.')?></p>
     <?php endif; ?>
   </div>
 
-  <?php if ($selectedQuestionnaireId): ?>
-    <div class="md-card md-elev-2">
+  <div class="md-card md-elev-2" id="org-heatmap">
+    <h2 class="md-card-title"><?=t($t, 'department_role_heatmap', 'Department × Role heatmap')?></h2>
+    <p class="md-upgrade-meta"><?=t($t, 'department_role_heatmap_hint', 'Average score by department (rows) and work role (columns). Darker green indicates stronger performance.')?></p>
+    <?php if ($departmentRoleDepartments && $departmentRoleFunctions): ?>
+      <div class="md-matrix-wrapper">
+        <table class="md-matrix-table" aria-label="<?=htmlspecialchars(t($t, 'department_role_heatmap', 'Department × Role heatmap'), ENT_QUOTES, 'UTF-8')?>">
+          <thead>
+            <tr>
+              <th><?=t($t, 'department', 'Department')?></th>
+              <?php foreach ($departmentRoleFunctions as $workFunctionLabel): ?>
+                <th><?=htmlspecialchars((string)$workFunctionLabel, ENT_QUOTES, 'UTF-8')?></th>
+              <?php endforeach; ?>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($departmentRoleDepartments as $departmentKey => $departmentLabel): ?>
+              <tr>
+                <th><?=htmlspecialchars((string)$departmentLabel, ENT_QUOTES, 'UTF-8')?></th>
+                <?php foreach ($departmentRoleFunctions as $workFunctionKey => $workFunctionLabel): ?>
+                  <?php $cell = $departmentRoleMap[$departmentKey][$workFunctionKey] ?? null; ?>
+                  <?php $score = $cell['score'] ?? null; ?>
+                  <?php if ($cell): ?>
+                    <td class="md-matrix-cell" style="background: <?=htmlspecialchars($heatColorForScore($score), ENT_QUOTES, 'UTF-8')?>;">
+                      <?= $score !== null ? htmlspecialchars(number_format((float)$score, 1), ENT_QUOTES, 'UTF-8') . '%' : '—' ?>
+                      <small><?=sprintf(t($t, 'responses_short', 'n=%d'), (int)($cell['responses'] ?? 0))?></small>
+                    </td>
+                  <?php else: ?>
+                    <td class="md-matrix-cell md-matrix-cell--empty">—</td>
+                  <?php endif; ?>
+                <?php endforeach; ?>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+    <?php else: ?>
+      <p class="md-upgrade-meta"><?=t($t, 'department_role_heatmap_empty', 'Complete submissions to populate the department and role heatmap.')?></p>
+    <?php endif; ?>
+  </div>
+  <?php endif; ?>
+
+  <?php if ($selectedQuestionnaireId && $analyticsViewMode === 'drilldown'): ?>
+    <div class="md-card md-elev-2" id="questionnaire-drilldown">
       <?php
         $selectedQuestionnaire = null;
         foreach ($questionnaires as $candidate) {
@@ -1404,6 +1698,7 @@ $pageHelpKey = 'team.analytics';
         <?=t($t, 'responses_for_questionnaire', 'Responses for questionnaire')?> ·
         <?=htmlspecialchars($selectedQuestionnaire['title'] ?? '', ENT_QUOTES, 'UTF-8')?>
       </h2>
+      <p><a class="md-button md-outline" href="<?=htmlspecialchars(url_for('admin/analytics.php') . '?view=overview&questionnaire_id=' . (int)$selectedQuestionnaireId, ENT_QUOTES, 'UTF-8')?>"><?=t($t, 'back_to_overview', 'Back to overview')?></a></p>
       <?php if ($selectedAggregate['total'] > 0): ?>
         <p class="md-upgrade-meta">
           <?=t($t, 'selected_summary', 'Average score: ')?>
@@ -1414,7 +1709,7 @@ $pageHelpKey = 'team.analytics';
           <?=t($t, 'status_draft', 'Draft')?>: <?=$selectedAggregate['draft']?> ·
           <?=t($t, 'status_rejected', 'Rejected')?>: <?=$selectedAggregate['rejected']?>
         </p>
-        <table class="md-table">
+        <table class="md-table" data-filter-target="responses" data-row-limit="12">
           <thead>
             <tr>
               <th><?=t($t, 'user', 'User')?></th>
@@ -1448,6 +1743,7 @@ $pageHelpKey = 'team.analytics';
             <?php endforeach; ?>
           </tbody>
         </table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="responses"><?=t($t, 'show_more', 'Show more')?></button>
       <?php else: ?>
         <p class="md-upgrade-meta"><?=t($t, 'no_responses_for_selection', 'There are no responses for this questionnaire yet.')?></p>
       <?php endif; ?>
@@ -1456,42 +1752,46 @@ $pageHelpKey = 'team.analytics';
     <?php if ($sectionColumns && $sectionScoresByResponse): ?>
       <div class="md-card md-elev-2">
         <h2 class="md-card-title"><?=t($t, 'sectional_scores_by_user', 'Sectional performance by participant')?></h2>
-        <p class="md-upgrade-meta"><?=t($t, 'sectional_scores_by_user_hint', 'Scores reflect the weighted result for each questionnaire section per submission.')?></p>
-        <div class="md-table-responsive">
-          <table class="md-table md-sectional-table">
-            <thead>
-              <tr>
-                <th><?=t($t, 'user', 'User')?></th>
-                <th><?=t($t, 'performance_period', 'Asessment Period')?></th>
-                <th><?=t($t, 'status', 'Status')?></th>
-                <th><?=t($t, 'score', 'Score (%)')?></th>
-                <?php foreach ($sectionColumns as $col): ?>
-                  <th><?=htmlspecialchars($col['label'], ENT_QUOTES, 'UTF-8')?></th>
-                <?php endforeach; ?>
-              </tr>
-            </thead>
-            <tbody>
-              <?php foreach ($sectionScoresByResponse as $row): ?>
-                <?php $statusKey = $row['status'] ?? ''; ?>
+        <details class="md-disclosure">
+          <summary><?=t($t, 'show_sectional_scores_by_user', 'Show sectional participant scores')?></summary>
+          <p class="md-upgrade-meta"><?=t($t, 'sectional_scores_by_user_hint', 'Scores reflect the weighted result for each questionnaire section per submission.')?></p>
+          <div class="md-table-responsive">
+            <table class="md-table md-sectional-table" data-filter-target="sectional-scores" data-row-limit="10">
+              <thead>
                 <tr>
-                  <td>
-                    <?=htmlspecialchars($row['username'] ?? '', ENT_QUOTES, 'UTF-8')?>
-                    <?php if (!empty($row['full_name'])): ?>
-                      <br><span class="md-muted"><?=htmlspecialchars($row['full_name'], ENT_QUOTES, 'UTF-8')?></span>
-                    <?php endif; ?>
-                  </td>
-                  <td><?=htmlspecialchars($row['period'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
-                  <td><?=htmlspecialchars($statusLabels[$statusKey] ?? ucfirst((string)$statusKey), ENT_QUOTES, 'UTF-8')?></td>
-                  <td><?= $row['overall'] !== null ? (int)$row['overall'] : '—' ?></td>
+                  <th><?=t($t, 'user', 'User')?></th>
+                  <th><?=t($t, 'performance_period', 'Asessment Period')?></th>
+                  <th><?=t($t, 'status', 'Status')?></th>
+                  <th><?=t($t, 'score', 'Score (%)')?></th>
                   <?php foreach ($sectionColumns as $col): ?>
-                    <?php $value = $row['sections'][$col['key']] ?? null; ?>
-                    <td><?= $value !== null ? htmlspecialchars(number_format((float)$value, 1), ENT_QUOTES, 'UTF-8') : '—' ?></td>
+                    <th><?=htmlspecialchars($col['label'], ENT_QUOTES, 'UTF-8')?></th>
                   <?php endforeach; ?>
                 </tr>
-              <?php endforeach; ?>
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                <?php foreach ($sectionScoresByResponse as $row): ?>
+                  <?php $statusKey = $row['status'] ?? ''; ?>
+                  <tr>
+                    <td>
+                      <?=htmlspecialchars($row['username'] ?? '', ENT_QUOTES, 'UTF-8')?>
+                      <?php if (!empty($row['full_name'])): ?>
+                        <br><span class="md-muted"><?=htmlspecialchars($row['full_name'], ENT_QUOTES, 'UTF-8')?></span>
+                      <?php endif; ?>
+                    </td>
+                    <td><?=htmlspecialchars($row['period'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
+                    <td><?=htmlspecialchars($statusLabels[$statusKey] ?? ucfirst((string)$statusKey), ENT_QUOTES, 'UTF-8')?></td>
+                    <td><?= $row['overall'] !== null ? (int)$row['overall'] : '—' ?></td>
+                    <?php foreach ($sectionColumns as $col): ?>
+                      <?php $value = $row['sections'][$col['key']] ?? null; ?>
+                      <td><?= $value !== null ? htmlspecialchars(number_format((float)$value, 1), ENT_QUOTES, 'UTF-8') : '—' ?></td>
+                    <?php endforeach; ?>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+          <button type="button" class="md-button md-row-toggle" data-table-toggle="sectional-scores"><?=t($t, 'show_more', 'Show more')?></button>
+        </details>
       </div>
     <?php endif; ?>
 
@@ -1499,7 +1799,7 @@ $pageHelpKey = 'team.analytics';
       <div class="md-card md-elev-2">
         <h2 class="md-card-title"><?=t($t, 'sectional_scores_aggregated', 'Section averages for questionnaire')?></h2>
         <p class="md-upgrade-meta"><?=t($t, 'sectional_scores_aggregated_hint', 'Average weighted score per section across all submissions for this questionnaire.')?></p>
-        <table class="md-table">
+        <table class="md-table" data-filter-target="section-aggregates" data-row-limit="10">
           <thead>
             <tr>
               <th><?=t($t, 'section_label', 'Section')?></th>
@@ -1515,13 +1815,16 @@ $pageHelpKey = 'team.analytics';
             <?php endforeach; ?>
           </tbody>
         </table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="section-aggregates"><?=t($t, 'show_more', 'Show more')?></button>
       </div>
     <?php endif; ?>
 
     <div class="md-card md-elev-2">
       <h2 class="md-card-title"><?=t($t, 'user_breakdown', 'Participant breakdown')?></h2>
+      <details class="md-disclosure">
+        <summary><?=t($t, 'show_participant_breakdown', 'Show participant breakdown')?></summary>
       <?php if ($selectedUserBreakdown): ?>
-        <table class="md-table">
+        <table class="md-table" data-filter-target="participant-breakdown" data-row-limit="8">
           <thead>
             <tr>
               <th><?=t($t, 'user', 'User')?></th>
@@ -1555,104 +1858,120 @@ $pageHelpKey = 'team.analytics';
             <?php endforeach; ?>
           </tbody>
         </table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="participant-breakdown"><?=t($t, 'show_more', 'Show more')?></button>
       <?php else: ?>
         <p class="md-upgrade-meta"><?=t($t, 'no_user_breakdown', 'No participant data available for this questionnaire.')?></p>
       <?php endif; ?>
+      </details>
     </div>
   <?php endif; ?>
 
-  <div class="md-card md-elev-2">
+  <?php if ($analyticsViewMode === 'overview'): ?>
+  <div class="md-card md-elev-2" id="training-recommendations">
     <h2 class="md-card-title"><?=t($t, 'training_recommendation_report', 'Training recommendations by staff')?></h2>
-    <?php if ($trainingRecommendationReport): ?>
-      <table class="md-table">
-        <thead>
-          <tr>
-            <th><?=t($t, 'training_course', 'Training')?></th>
-            <th><?=t($t, 'recommended_staff_count', 'Recommended staff')?></th>
-            <th><?=t($t, 'staff_members', 'Staff members')?></th>
-          </tr>
-        </thead>
-        <tbody>
-          <?php foreach ($trainingRecommendationReport as $row): ?>
+    <details class="md-disclosure">
+      <summary><?=t($t, 'show_training_recommendations', 'Show training recommendations')?></summary>
+      <?php if ($trainingRecommendationReport): ?>
+        <table class="md-table" data-filter-target="training-recommendation" data-row-limit="8">
+          <thead>
             <tr>
-              <td><?=htmlspecialchars($row['course_title'] ?? t($t, 'unknown', 'Unknown'), ENT_QUOTES, 'UTF-8')?></td>
-              <td><?= (int)($row['recommended_staff_count'] ?? 0) ?></td>
-              <td><?=htmlspecialchars((string)($row['recommended_staff'] ?? '—'), ENT_QUOTES, 'UTF-8')?></td>
+              <th><?=t($t, 'training_course', 'Training')?></th>
+              <th><?=t($t, 'recommended_staff_count', 'Recommended staff')?></th>
+              <th><?=t($t, 'staff_members', 'Staff members')?></th>
             </tr>
-          <?php endforeach; ?>
-        </tbody>
-      </table>
-    <?php else: ?>
-      <p class="md-upgrade-meta"><?=t($t, 'training_recommendation_report_empty', 'No training recommendations have been recorded yet.')?></p>
-    <?php endif; ?>
+          </thead>
+          <tbody>
+            <?php foreach ($trainingRecommendationReport as $row): ?>
+              <tr>
+                <td><?=htmlspecialchars($row['course_title'] ?? t($t, 'unknown', 'Unknown'), ENT_QUOTES, 'UTF-8')?></td>
+                <td><?= (int)($row['recommended_staff_count'] ?? 0) ?></td>
+                <td><?=htmlspecialchars((string)($row['recommended_staff'] ?? '—'), ENT_QUOTES, 'UTF-8')?></td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="training-recommendation"><?=t($t, 'show_more', 'Show more')?></button>
+      <?php else: ?>
+        <p class="md-upgrade-meta"><?=t($t, 'training_recommendation_report_empty', 'No training recommendations have been recorded yet.')?></p>
+      <?php endif; ?>
+    </details>
   </div>
 
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'department_performance', 'Department Performance')?></h2>
-    <?php if ($departmentSummary): ?>
-      <table class="md-table"><thead><tr><th><?=t($t,'department','Department')?></th><th><?=t($t,'count','Responses')?></th><th><?=t($t,'approved','Approved')?></th><th><?=t($t,'average_score','Average score (%)')?></th></tr></thead><tbody>
-      <?php foreach ($departmentSummary as $row): ?>
-        <tr><td><?=htmlspecialchars($departmentOptions[$row['department'] ?? ''] ?? ($row['department'] ?: t($t,'unknown','Unknown')), ENT_QUOTES, 'UTF-8')?></td><td><?= (int)$row['total_responses'] ?></td><td><?= (int)$row['approved_count'] ?></td><td><?= $formatScore($row['avg_score'] ?? null) ?></td></tr>
-      <?php endforeach; ?></tbody></table>
-    <?php else: ?><p class="md-upgrade-meta">—</p><?php endif; ?>
+    <details class="md-disclosure">
+      <summary><?=t($t, 'show_department_performance', 'Show department performance')?></summary>
+      <?php if ($departmentSummary): ?>
+        <table class="md-table" data-filter-target="department-performance" data-row-limit="8"><thead><tr><th><?=t($t,'department','Department')?></th><th><?=t($t,'count','Responses')?></th><th><?=t($t,'approved','Approved')?></th><th><?=t($t,'average_score','Average score (%)')?></th></tr></thead><tbody>
+        <?php foreach ($departmentSummary as $row): ?>
+          <tr><td><?=htmlspecialchars($departmentOptions[$row['department'] ?? ''] ?? ($row['department'] ?: t($t,'unknown','Unknown')), ENT_QUOTES, 'UTF-8')?></td><td><?= (int)$row['total_responses'] ?></td><td><?= (int)$row['approved_count'] ?></td><td><?= $formatScore($row['avg_score'] ?? null) ?></td></tr>
+        <?php endforeach; ?></tbody></table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="department-performance"><?=t($t, 'show_more', 'Show more')?></button>
+      <?php else: ?><p class="md-upgrade-meta">—</p><?php endif; ?>
+    </details>
   </div>
 
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'team_performance', 'Team Performance')?></h2>
-    <?php if ($teamSummary): ?>
-      <table class="md-table"><thead><tr><th><?=t($t,'cadre','Team in the Department')?></th><th><?=t($t,'count','Responses')?></th><th><?=t($t,'approved','Approved')?></th><th><?=t($t,'average_score','Average score (%)')?></th></tr></thead><tbody>
-      <?php foreach ($teamSummary as $row): ?>
-        <tr><td><?=htmlspecialchars(team_label($pdo, (string)($row['cadre'] ?? '')), ENT_QUOTES, 'UTF-8')?></td><td><?= (int)$row['total_responses'] ?></td><td><?= (int)$row['approved_count'] ?></td><td><?= $formatScore($row['avg_score'] ?? null) ?></td></tr>
-      <?php endforeach; ?></tbody></table>
-    <?php else: ?><p class="md-upgrade-meta">—</p><?php endif; ?>
+    <details class="md-disclosure">
+      <summary><?=t($t, 'show_team_performance', 'Show team performance')?></summary>
+      <?php if ($teamSummary): ?>
+        <table class="md-table" data-filter-target="team-performance" data-row-limit="8"><thead><tr><th><?=t($t,'cadre','Team in the Department')?></th><th><?=t($t,'count','Responses')?></th><th><?=t($t,'approved','Approved')?></th><th><?=t($t,'average_score','Average score (%)')?></th></tr></thead><tbody>
+        <?php foreach ($teamSummary as $row): ?>
+          <tr><td><?=htmlspecialchars(team_label($pdo, (string)($row['cadre'] ?? '')), ENT_QUOTES, 'UTF-8')?></td><td><?= (int)$row['total_responses'] ?></td><td><?= (int)$row['approved_count'] ?></td><td><?= $formatScore($row['avg_score'] ?? null) ?></td></tr>
+        <?php endforeach; ?></tbody></table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="team-performance"><?=t($t, 'show_more', 'Show more')?></button>
+      <?php else: ?><p class="md-upgrade-meta">—</p><?php endif; ?>
+    </details>
   </div>
 
   <div class="md-card md-elev-2">
     <h2 class="md-card-title"><?=t($t, 'work_function_performance', 'Work Role Performance')?></h2>
-    <?php if ($workFunctionSummary): ?>
-      <?php if ($workFunctionChartData): ?>
-        <div
-          class="md-chart-container"
-          data-chart-target="work-function-heatmap"
-          data-has-data="true"
-          data-empty-message="<?= htmlspecialchars(t($t, 'work_function_heatmap_empty', 'Performance by work function will display after a few submissions are recorded.'), ENT_QUOTES, 'UTF-8') ?>"
-        >
-          <canvas id="work-function-heatmap" role="img" aria-label="<?=htmlspecialchars(t($t, 'work_function_heatmap_alt', 'Horizontal bar chart comparing work function averages using heatmap colours.'), ENT_QUOTES, 'UTF-8')?>"></canvas>
-        </div>
-      <?php endif; ?>
-      <table class="md-table">
-        <thead>
-          <tr>
-            <th><?=t($t, 'work_function', 'Work Role')?></th>
-            <th><?=t($t, 'count', 'Responses')?></th>
-            <th><?=t($t, 'approved', 'Approved')?></th>
-            <th><?=t($t, 'average_score', 'Average score (%)')?></th>
-          </tr>
-        </thead>
-        <tbody>
-          <?php foreach ($workFunctionSummary as $row): ?>
-            <?php $wfKey = $row['work_function'] ?? ''; ?>
+    <details class="md-disclosure">
+      <summary><?=t($t, 'show_work_role_performance', 'Show work role performance')?></summary>
+      <?php if ($workFunctionSummary): ?>
+        <?php if ($workFunctionChartData): ?>
+          <div
+            class="md-chart-container"
+            data-chart-target="work-function-heatmap"
+            data-has-data="true"
+            data-empty-message="<?= htmlspecialchars(t($t, 'work_function_heatmap_empty', 'Performance by work function will display after a few submissions are recorded.'), ENT_QUOTES, 'UTF-8') ?>"
+          >
+            <canvas id="work-function-heatmap" role="img" aria-label="<?=htmlspecialchars(t($t, 'work_function_heatmap_alt', 'Horizontal bar chart comparing work function averages using heatmap colours.'), ENT_QUOTES, 'UTF-8')?>"></canvas>
+          </div>
+        <?php endif; ?>
+        <table class="md-table" data-filter-target="work-role-performance" data-row-limit="8">
+          <thead>
             <tr>
-              <td><?=htmlspecialchars($workFunctionOptions[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t, 'unknown', 'Unknown')), ENT_QUOTES, 'UTF-8')?></td>
-              <td><?= (int)$row['total_responses'] ?></td>
-              <td><?= (int)$row['approved_count'] ?></td>
-              <td><?= $formatScore($row['avg_score'] ?? null) ?></td>
+              <th><?=t($t, 'work_function', 'Work Role')?></th>
+              <th><?=t($t, 'count', 'Responses')?></th>
+              <th><?=t($t, 'approved', 'Approved')?></th>
+              <th><?=t($t, 'average_score', 'Average score (%)')?></th>
             </tr>
-          <?php endforeach; ?>
-        </tbody>
-      </table>
-    <?php else: ?>
-      <p class="md-upgrade-meta"><?=t($t, 'work_function_empty', 'Assign questionnaires to teams to see benchmarks populate here.')?></p>
-    <?php endif; ?>
+          </thead>
+          <tbody>
+            <?php foreach ($workFunctionSummary as $row): ?>
+              <?php $wfKey = $row['work_function'] ?? ''; ?>
+              <tr>
+                <td><?=htmlspecialchars($workFunctionOptions[$wfKey] ?? ($wfKey !== '' ? $wfKey : t($t, 'unknown', 'Unknown')), ENT_QUOTES, 'UTF-8')?></td>
+                <td><?= (int)$row['total_responses'] ?></td>
+                <td><?= (int)$row['approved_count'] ?></td>
+                <td><?= $formatScore($row['avg_score'] ?? null) ?></td>
+              </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+        <button type="button" class="md-button md-row-toggle" data-table-toggle="work-role-performance"><?=t($t, 'show_more', 'Show more')?></button>
+      <?php else: ?>
+        <p class="md-upgrade-meta"><?=t($t, 'work_function_empty', 'Assign questionnaires to teams to see benchmarks populate here.')?></p>
+      <?php endif; ?>
+    </details>
   </div>
+  <?php endif; ?>
 </section>
 <script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
   document.addEventListener('DOMContentLoaded', () => {
     const copyButtons = document.querySelectorAll('[data-copy-target]');
-    if (!copyButtons.length) {
-      return;
-    }
-
     const fallbackCopy = (text) => {
       const helper = document.createElement('textarea');
       helper.value = text;
@@ -1695,6 +2014,65 @@ $pageHelpKey = 'team.analytics';
         }
       });
     });
+
+    const setupRowLimit = (tableName) => {
+      const table = document.querySelector(`[data-filter-target="${tableName}"]`);
+      const toggle = document.querySelector(`[data-table-toggle="${tableName}"]`);
+      if (!table || !toggle) {
+        return;
+      }
+      const limit = Number.parseInt(table.getAttribute('data-row-limit') || '0', 10);
+      const rows = Array.from(table.querySelectorAll('tbody tr'));
+      if (!limit || rows.length <= limit) {
+        toggle.style.display = 'none';
+        return;
+      }
+      let expanded = false;
+      const applyState = () => {
+        rows.forEach((row, index) => {
+          const hiddenByFilter = row.classList.contains('is-hidden-by-filter');
+          if (hiddenByFilter) {
+            row.style.display = 'none';
+            return;
+          }
+          row.style.display = (!expanded && index >= limit) ? 'none' : '';
+        });
+        toggle.textContent = expanded ? 'Show less' : 'Show more';
+      };
+      applyState();
+      toggle.addEventListener('click', () => {
+        expanded = !expanded;
+        applyState();
+      });
+    };
+
+    const questionnairesTable = document.querySelector('[data-filter-target="questionnaires"]');
+    const questionnaireSearch = document.querySelector('[data-table-filter="questionnaires"]');
+    const questionnaireMinScore = document.querySelector('[data-score-filter="questionnaires"]');
+    const applyQuestionnaireFilters = () => {
+      if (!questionnairesTable) {
+        return;
+      }
+      const term = (questionnaireSearch?.value || '').trim().toLowerCase();
+      const minScore = Number.parseFloat(questionnaireMinScore?.value || '');
+      const useMinScore = !Number.isNaN(minScore);
+      const rows = questionnairesTable.querySelectorAll('tbody tr');
+      rows.forEach((row) => {
+        const text = (row.textContent || '').toLowerCase();
+        const scoreCell = row.children[6];
+        const scoreValue = Number.parseFloat((scoreCell?.textContent || '').replace(/[^\d.-]/g, ''));
+        const scoreMatch = !useMinScore || (!Number.isNaN(scoreValue) && scoreValue >= minScore);
+        const termMatch = term === '' || text.includes(term);
+        row.classList.toggle('is-hidden-by-filter', !(scoreMatch && termMatch));
+      });
+      setupRowLimit('questionnaires');
+    };
+    questionnaireSearch?.addEventListener('input', applyQuestionnaireFilters);
+    questionnaireMinScore?.addEventListener('input', applyQuestionnaireFilters);
+    applyQuestionnaireFilters();
+
+    ['responses', 'sectional-scores', 'section-aggregates', 'participant-breakdown', 'training-recommendation', 'department-performance', 'team-performance', 'work-role-performance']
+      .forEach(setupRowLimit);
   });
 </script>
 <?php if ($hasAnalyticsCharts): ?>


### PR DESCRIPTION
### Motivation
- Introduce distinct overview and drilldown workflows so admins can switch between org-level insights and per-questionnaire investigation.
- Surface a Department × Role heatmap to make cross-cutting performance issues easier to spot.
- Improve discoverability and usability of large analytics tables and reports with filtering, pagination controls and collapsible sections.

### Description
- Add `view` query handling and a sticky top navigation to toggle between `overview` and `drilldown` modes and anchor to page sections. 
- Query and build a `departmentRoleSummary` mapping and render a Department × Role matrix with a new `heatColorForScore` helper to produce heatmap background colours. 
- Rework the page layout with an insights strip, collapsible `details` blocks for many report sections, reorganised download/tools areas, and new accessibility anchors. 
- Add client-side enhancements: table search and minimum-score filter for questionnaires, data attributes for filter/limit targets, row-limit "Show more/Show less" toggles, and JS to apply filters and hide/show rows; plus CSS for the new controls and matrix styling. 

### Testing
- Performed a PHP syntax check with `php -l admin/analytics.php` which reported no syntax errors. 
- No automated unit tests were added in this change; interactive behaviour was implemented with progressive enhancement and leverages existing chart rendering code when data is present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09b7d2e24832da79730c43302a87c)