### PR TITLE
Improve demo dataset role realism and cleanup safety

### DIFF
--- a/docs/dummy-data-seeding.md
+++ b/docs/dummy-data-seeding.md
@@ -18,7 +18,8 @@ Before running, ensure your `.env` has valid `DB_HOST`, `DB_PORT`, `DB_NAME`, `D
 
 - Defaults to seeding both `draft` and `published` questionnaires (override with `--statuses=<comma-separated-statuses>`).
 - Selects all questionnaires in the selected statuses that have at least one active item.
-- Ensures a fixed set of `demo_*` users exists (one supervisor and several staff users).
+- Ensures a fixed set of `demo_*` users exists (one `supervisor` account and several `staff` accounts).
+- Applies business/profile role metadata to demo users using system role vocabulary (`team_lead`, `manager`, `expert`) so analytics role filters look realistic.
 - Creates/updates annual performance periods for the selected year range (default `2020`–`2025`, override with `--start-year` and `--end-year`).
 - Deletes prior demo assignments and responses for `demo_*` users, then recreates assignments and one response per demo staff per selected questionnaire.
 - Seeds response-item answers and computes a score (graded for `requires_correct` questions; randomized fallback otherwise), with assignment/response timestamps spread across the selected year range.
@@ -38,4 +39,4 @@ Use `dummy_data_cleanup.sql` to remove seeded demo-user submissions when needed.
 Administrators can now enable or disable the full demo dataset directly from **Admin → Settings**:
 
 - **Enable Demo Dataset** executes `dummy_data.sql` (fictive demo users plus generated assignments/responses for existing draft/published questionnaires; no questionnaire creation/deletion).
-- **Disable Demo Dataset** executes `dummy_data_cleanup.sql` (removes demo/dummy records without touching questionnaire definitions).
+- **Disable Demo Dataset** executes `dummy_data_cleanup.sql` (removes demo/dummy records without touching questionnaire definitions, and nulls metadata foreign-key references such as reviewer/assigner/snapshot creator pointers).

--- a/dummy_data.sql
+++ b/dummy_data.sql
@@ -41,6 +41,50 @@ WHERE created_by IN (
        OR username LIKE 'dummy_%'
 );
 
+DELETE FROM analytics_report_snapshot_v2
+WHERE generated_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE questionnaire_assignment
+SET assigned_by = NULL
+WHERE assigned_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE questionnaire_response
+SET reviewed_by = NULL
+WHERE reviewed_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE users
+SET approved_by = NULL
+WHERE approved_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE competency_benchmark_policy
+SET created_by = NULL
+WHERE created_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
 DELETE FROM logs
 WHERE user_id IN (
     SELECT id
@@ -67,13 +111,16 @@ ON DUPLICATE KEY UPDATE
     period_end = VALUES(period_end);
 
 -- Insert fictive demo users ------------------------------------------------------
-INSERT INTO users (username, password, role, full_name, email, work_function, account_status, profile_completed, must_reset_password, language)
+INSERT INTO users (
+    username, password, role, full_name, email, work_function, department, directorate, cadre,
+    business_role, profile_role, job_grade, education_level, account_status, profile_completed, must_reset_password, language
+)
 VALUES
-('demo_supervisor', @password, 'supervisor', 'Demo Supervisor', 'demo.supervisor@example.com', 'leadership_tn', 'active', 1, 1, 'en'),
-('demo_staff_finance', @password, 'staff', 'Demo Finance Staff', 'demo.finance@example.com', 'finance', 'active', 1, 1, 'en'),
-('demo_staff_hr', @password, 'staff', 'Demo HR Staff', 'demo.hr@example.com', 'hrm', 'active', 1, 1, 'en'),
-('demo_staff_ict', @password, 'staff', 'Demo ICT Staff', 'demo.ict@example.com', 'ict', 'active', 1, 1, 'en'),
-('demo_staff_ops', @password, 'staff', 'Demo Operations Staff', 'demo.ops@example.com', 'general_service', 'active', 1, 1, 'en');
+('demo_supervisor', @password, 'supervisor', 'Demo Supervisor', 'demo.supervisor@example.com', 'leadership_tn', 'leadership_tn', 'Leadership', 'leadership_tn_team_leads', 'team_lead', 'team_lead', 'JG-11', 'masters', 'active', 1, 1, 'en'),
+('demo_staff_finance', @password, 'staff', 'Demo Finance Staff', 'demo.finance@example.com', 'finance', 'finance', 'Corporate Services', 'finance_budget_and_reporting', 'expert', 'expert', 'JG-08', 'bachelors', 'active', 1, 1, 'en'),
+('demo_staff_hr', @password, 'staff', 'Demo HR Staff', 'demo.hr@example.com', 'hrm', 'hrm', 'People & Culture', 'hrm_talent_management', 'manager', 'manager', 'JG-09', 'bachelors', 'active', 1, 1, 'en'),
+('demo_staff_ict', @password, 'staff', 'Demo ICT Staff', 'demo.ict@example.com', 'ict', 'ict', 'Technology', 'ict_platform_and_support', 'expert', 'expert', 'JG-10', 'bachelors', 'active', 1, 1, 'en'),
+('demo_staff_ops', @password, 'staff', 'Demo Operations Staff', 'demo.ops@example.com', 'general_service', 'general_service', 'Operations', 'general_service_facilities_and_logistics', 'expert', 'expert', 'JG-07', 'diploma', 'active', 1, 1, 'en');
 
 -- Seed analytics-friendly assignments and responses against existing forms -------
 SET @demo_supervisor_id := (SELECT id FROM users WHERE username = 'demo_supervisor' LIMIT 1);

--- a/dummy_data_cleanup.sql
+++ b/dummy_data_cleanup.sql
@@ -38,6 +38,50 @@ WHERE created_by IN (
        OR username LIKE 'dummy_%'
 );
 
+DELETE FROM analytics_report_snapshot_v2
+WHERE generated_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE questionnaire_assignment
+SET assigned_by = NULL
+WHERE assigned_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE questionnaire_response
+SET reviewed_by = NULL
+WHERE reviewed_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE users
+SET approved_by = NULL
+WHERE approved_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
+UPDATE competency_benchmark_policy
+SET created_by = NULL
+WHERE created_by IN (
+    SELECT id
+    FROM users
+    WHERE username LIKE 'demo_%'
+       OR username LIKE 'dummy_%'
+);
+
 DELETE FROM logs
 WHERE user_id IN (
     SELECT id

--- a/scripts/seed_dummy_data_from_questionnaires.php
+++ b/scripts/seed_dummy_data_from_questionnaires.php
@@ -211,7 +211,7 @@ function ensure_demo_users(PDO $pdo): array
             'directorate' => 'Operations',
             'cadre' => 'general_service_facilities_and_logistics',
             'team_label' => 'Facilities & Logistics',
-            'business_role' => 'staff',
+            'business_role' => 'expert',
             'job_grade' => 'JG-07',
             'education_level' => 'diploma',
         ],


### PR DESCRIPTION
### Motivation
- Demo users used minimal role fields which confused analytics and administrators, so demo data should use system metadata to appear realistic.
- Disabling the demo dataset previously removed demo users but could leave nullable foreign-key references or snapshots pointing to deleted ids, risking FK issues or confusing analytics.
- Documentation did not make the demo dataset metadata choices or cleanup behavior explicit, which made admin actions unclear.

### Description
- Set demo user metadata in the CLI seeder (`scripts/seed_dummy_data_from_questionnaires.php`) to include department, directorate, cadre and align `business_role` values to the system reporting vocabulary (`team_lead`, `manager`, `expert`).
- Expanded the SQL seed (`dummy_data.sql`) to insert fuller user profile columns and added statements to remove snapshots and null out nullable user-reference fields (`assigned_by`, `reviewed_by`, `approved_by`, `created_by`) before seeding responses.
- Expanded the cleanup SQL (`dummy_data_cleanup.sql`) to delete `analytics_report_snapshot_v2` records and to null those nullable user-reference fields prior to deleting demo/dummy users to avoid orphaned references.
- Updated the docs (`docs/dummy-data-seeding.md`) to describe the access roles and business/profile role metadata used by the demo dataset and to clarify what the disable/cleanup action now nulls or removes.

### Testing
- Ran `php -l scripts/seed_dummy_data_from_questionnaires.php` and confirmed there are no PHP syntax errors.
- Reviewed the SQL seed and cleanup files against the `settings_apply_sql_file` statement-splitting/sanitization logic to ensure statement ordering and compatibility with the Admin → Settings SQL executor.
- No automated unit tests were modified, and no test failures were produced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a2105668832d9114571956a23b0c)