### PR TITLE
Theme: set light surfaces to white, increase border contrast, and add configurable card shadow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -850,7 +850,7 @@ body.theme-dark .md-page-header::after {
   border-radius: 16px;
   overflow: hidden;
   background: var(--app-surface);
-  box-shadow: var(--app-shadow-soft);
+  box-shadow: var(--app-card-shadow, var(--app-shadow-soft));
   border: 1px solid var(--app-border);
   position: relative;
   padding-top: calc(1.35rem + 4px);

--- a/config.php
+++ b/config.php
@@ -1423,9 +1423,9 @@ function site_brand_palette(array $cfg): array
     $mutedLight = tint_color($base, 0.55);
     // Keep application surfaces on a very light brand-tinted gradient,
     // matching the softer treatment used on the login experience.
-    $bgStart = tint_color($primaryLight, 0.78);
-    $bgMid = tint_color($secondary, 0.82);
-    $bgEnd = tint_color($base, 0.9);
+    $bgStart = '#ffffff';
+    $bgMid = '#ffffff';
+    $bgEnd = tint_color($base, 0.985);
 
     return [
         'primary' => $base,
@@ -1513,10 +1513,10 @@ function site_theme_tokens(array $cfg): array
     $success = $semanticSuccess;
     $info = $semanticWarning;
 
-    $lightSurface = tint_color($primary, 0.9);
-    $lightSurfaceAlt = tint_color($primary, 0.95);
-    $lightSurfaceMuted = tint_color($primary, 0.85);
-    $lightSurfaceHighlight = tint_color($primary, 0.82);
+    $lightSurface = '#ffffff';
+    $lightSurfaceAlt = '#ffffff';
+    $lightSurfaceMuted = tint_color($primary, 0.975);
+    $lightSurfaceHighlight = tint_color($primary, 0.965);
     $lightText = adjust_hsl($primary, 0.0, 1.05, 0.38);
     $lightTextSecondary = adjust_hsl($primary, 0.0, 1.0, 0.46);
     $lightTextMuted = adjust_hsl($primary, 0.0, 0.88, 0.58);
@@ -1529,9 +1529,9 @@ function site_theme_tokens(array $cfg): array
     $onSurfaceMuted = rgba_string(shade_color($onSurface, 0.18), 1.0);
     $onSurfaceStrong = shade_color($onSurface, 0.08);
 
-    $lightBorder = rgba_string($primary, 0.16);
-    $lightBorderStrong = rgba_string($primaryDark, 0.24);
-    $lightDivider = rgba_string($primaryDarker, 0.12);
+    $lightBorder = rgba_string($primary, 0.34);
+    $lightBorderStrong = rgba_string($primaryDark, 0.46);
+    $lightDivider = rgba_string($primaryDarker, 0.24);
 
     $shadowSoft = '0 18px 44px ' . rgba_string($primaryDarker, 0.22);
     $shadowStrong = '0 22px 54px ' . rgba_string($primaryDarker, 0.3);
@@ -1707,6 +1707,7 @@ function site_theme_tokens(array $cfg): array
         '--app-bg' => $bgGradient,
         '--app-shadow-soft' => $shadowSoft,
         '--app-shadow-strong' => $shadowStrong,
+        '--app-card-shadow' => '0 8px 20px ' . rgba_string($primaryDarker, 0.12),
         '--app-primary-soft' => $primarySoft,
         '--app-primary-softer' => $primarySofter,
         '--app-danger' => $danger,
@@ -1759,6 +1760,7 @@ function site_theme_tokens(array $cfg): array
         '--app-bg' => $darkBgGradient,
         '--app-shadow-soft' => $darkShadow,
         '--app-shadow-strong' => $darkShadowStrong,
+        '--app-card-shadow' => '0 16px 34px ' . rgba_string(shade_color($primary, 0.7), 0.62),
         '--app-primary-soft' => $darkPrimarySoft,
         '--app-primary-softer' => $darkPrimarySofter,
         '--app-danger' => $darkDanger,


### PR DESCRIPTION
### Motivation
- Improve visual contrast and produce a consistent, very light background treatment for the light theme.  
- Make card shadows configurable separately from the general app shadow to allow finer control over card elevation.  
- Tighten border/divider strength to improve perceived separation on light backgrounds.

### Description
- Updated `site_brand_palette()` to use near-white gradient endpoints for light backgrounds by setting `bgStart` and `bgMid` to `#ffffff` and `bgEnd` to a very subtle tint of the brand.  
- Set primary light surfaces in `site_theme_tokens()` to explicit white (`#ffffff`) and reduced the tint usage for muted/highlight surfaces.  
- Increased opacity for `--app-border`, `--app-border-strong`, and `--app-divider` values to make borders/dividers more visible.  
- Added a new CSS variable `--app-card-shadow` for both light and dark token sets and updated `.md-card` in `assets/css/styles.css` to use `var(--app-card-shadow, var(--app-shadow-soft))` so card elevation can be customized independently of general shadows.

### Testing
- Ran a PHP syntax check on the modified file with `php -l config.php`, which completed without syntax errors.  
- Validated the stylesheet change by rebuilding front-end assets with `npm run build` (local build), which completed successfully.  
- Verified style token outputs by loading the app locally and inspecting computed CSS variables in the browser; visual checks reflected the intended surface, border, and card shadow changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b3173fd0832d9c1ae36770984f2a)