### PR TITLE
Improve first-login password reset UX and seed default 'Not Listed' team

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -454,7 +454,7 @@
   "my_workspace_summary": "Stay on top of your goals and tasks.",
   "name": "Name",
   "navigation_menu": "Navigation",
-  "new_password": "New Password (optional)",
+  "new_password": "New Password",
   "new_password_reset": "New Password",
   "next_assessment": "Next Assessment",
   "next_assessment_not_set": "Your next assessment date has not been scheduled yet.",
@@ -871,5 +871,8 @@
   "stat_total_registered_users": "Total registered users",
   "stat_total_submissions": "Total submissions",
   "stat_latest_submission_date": "Latest submission date",
-  "stat_top_indicator": "Staff reaching 80%+ (top KPI)"
+  "stat_top_indicator": "Staff reaching 80%+ (top KPI)",
+  "new_password_optional": "New Password (optional)",
+  "confirm_password": "Confirm Password",
+  "password_confirm_mismatch": "Password confirmation does not match."
 }

--- a/lib/department_teams.php
+++ b/lib/department_teams.php
@@ -322,6 +322,18 @@ function ensure_department_team_catalog(PDO $pdo): void
         }
         $sort = count($teamRows) + 1;
 
+        if (!isset($seenLabelsByDepartment['general_service']['not listed'])) {
+            $defaultSlug = 'general_service_not_listed';
+            if (isset($seenSlugs[$defaultSlug])) {
+                $defaultSlug = unique_slug($defaultSlug, $seenSlugs);
+            }
+            $insert->execute([$defaultSlug, 'general_service', 'Not Listed', $sort]);
+            $seenSlugs[$defaultSlug] = true;
+            $teamRows[$defaultSlug] = ['department_slug' => 'general_service', 'label' => 'Not Listed'];
+            $seenLabelsByDepartment['general_service']['not listed'] = true;
+            $sort++;
+        }
+
         $sourceStmt = $pdo->query("SELECT DISTINCT department, cadre FROM users WHERE cadre IS NOT NULL AND TRIM(cadre) <> '' ORDER BY department, cadre");
         if ($sourceStmt) {
             while ($row = $sourceStmt->fetch(PDO::FETCH_ASSOC)) {

--- a/profile.php
+++ b/profile.php
@@ -128,6 +128,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $epssWorkExperienceBand = trim((string)($_POST['epss_work_experience_band'] ?? ''));
     $language = $_POST['language'] ?? ($_SESSION['lang'] ?? 'en');
     $password = $_POST['password'] ?? '';
+    $passwordConfirm = $_POST['password_confirm'] ?? '';
 
     $validCountryCodes = array_column($phoneCountries, 'code');
     if (!in_array($phoneCountry, $validCountryCodes, true)) {
@@ -191,6 +192,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $error = t($t,'invalid_phone','Enter a valid phone number including the country code.');
     } elseif ($forcePasswordReset && trim((string)$password) === '') {
         $error = t($t,'password_reset_required','Please set a new password before continuing.');
+    } elseif ($password !== '' && $password !== $passwordConfirm) {
+        $error = t($t,'password_confirm_mismatch','Password confirmation does not match.');
     } elseif ($password !== '' && !password_meets_policy($password)) {
         $error = t($t,'password_policy_invalid','Password must be at least 8 characters and include at least one number or symbol.');
     } else {
@@ -460,8 +463,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </select>
       </label>
       <label class="md-field">
-        <span><?=t($t,'new_password','New Password (optional)')?></span>
+        <span><?=$forcePasswordReset ? t($t,'new_password','New Password') : t($t,'new_password_optional','New Password (optional)')?></span>
         <input type="password" name="password" minlength="8" data-password-field>
+      </label>
+      <label class="md-field">
+        <span><?=t($t,'confirm_password','Confirm Password')?></span>
+        <input type="password" name="password_confirm" minlength="8" data-password-confirm-field>
       </label>
       </div>
       <div class="md-form-actions md-profile-actions">


### PR DESCRIPTION
### Motivation
- Fix the first-admin/first-login flow where forced password reset appeared optional and lacked a confirmation field, and ensure an initial Team option exists to avoid blocking account setup.

### Description
- Show a required `New Password` label when `must_reset_password` is active and preserve the optional label otherwise by using `new_password`/`new_password_optional` localization keys in `profile.php` and `lang/en.json`.
- Add a `Confirm Password` input to the profile form and server-side validation that sets `password_confirm_mismatch` when the confirmation does not match `password` in `profile.php` and add corresponding localization entries in `lang/en.json`.
- Seed an idempotent default `Not Listed` team under the `general_service` department in `ensure_department_team_catalog()` so the Team select is never empty on first admin login (`lib/department_teams.php`).

### Testing
- Ran `php -l profile.php` and it returned no syntax errors. (succeeded)
- Ran `php -l lib/department_teams.php` and it returned no syntax errors. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21de46214832da557f2f9c53588b5)