### PR TITLE
Convert DATETIME audit columns to TIMESTAMP in init.sql

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -227,8 +227,8 @@ CREATE TABLE competency_level_band (
   max_pct DECIMAL(5,2) NOT NULL,
   rank_order INT NOT NULL DEFAULT 0,
   is_system_default TINYINT(1) NOT NULL DEFAULT 1,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE KEY uniq_competency_level_band_name (name),
   UNIQUE KEY uniq_competency_level_band_rank (rank_order)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -241,8 +241,8 @@ CREATE TABLE competency_benchmark_policy (
   effective_from DATE NULL,
   effective_to DATE NULL,
   created_by INT NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_benchmark_scope (scope_type, scope_id),
   KEY idx_benchmark_effective (effective_from, effective_to)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -256,10 +256,10 @@ CREATE TABLE analytics_report_snapshot_v2 (
   filters_json LONGTEXT NULL,
   summary_json LONGTEXT NOT NULL,
   details_json LONGTEXT NOT NULL,
-  generated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  generated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   finalized_at DATETIME NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_snapshot_status (status),
   KEY idx_snapshot_questionnaire (questionnaire_id),
   KEY idx_snapshot_generated_at (generated_at)
@@ -270,7 +270,7 @@ CREATE TABLE work_function_catalog (
   label VARCHAR(255) NOT NULL,
   sort_order INT NOT NULL DEFAULT 0,
   archived_at DATETIME NULL,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO work_function_catalog (slug, label, sort_order) VALUES
@@ -307,7 +307,7 @@ CREATE TABLE questionnaire_assignment (
   staff_id INT NOT NULL,
   questionnaire_id INT NOT NULL,
   assigned_by INT NULL,
-  assigned_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  assigned_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (staff_id, questionnaire_id),
   KEY idx_assignment_questionnaire (questionnaire_id),
   KEY idx_assignment_assigned_by (assigned_by),
@@ -326,8 +326,8 @@ CREATE TABLE analytics_report_schedule (
   questionnaire_id INT NULL,
   include_details TINYINT(1) NOT NULL DEFAULT 0,
   active TINYINT(1) NOT NULL DEFAULT 1,
-  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   KEY idx_report_schedule_next_run (next_run_at),
   KEY idx_report_schedule_active (active),
   CONSTRAINT fk_report_schedule_creator FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE SET NULL,


### PR DESCRIPTION
### Motivation
- Normalize and standardize timestamp columns to use `TIMESTAMP` with `CURRENT_TIMESTAMP` defaults and `ON UPDATE` behavior for consistent auto-populated audit fields.
- Reduce surprises around default/auto-update behavior across MySQL versions and improve compatibility with built-in timestamp semantics.

### Description
- Replaced `DATETIME` with `TIMESTAMP` for audit columns across the schema in `init.sql` so that `created_at`/`updated_at` (and other auto-populated fields) use `TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP` and `TIMESTAMP ... ON UPDATE CURRENT_TIMESTAMP` where applicable.
- Updated the following tables/columns: `competency_level_band` (`created_at`,`updated_at`), `competency_benchmark_policy` (`created_at`,`updated_at`), `analytics_report_snapshot_v2` (`generated_at`,`created_at`,`updated_at`), `work_function_catalog` (`created_at`), `questionnaire_assignment` (`assigned_at`), and `analytics_report_schedule` (`created_at`,`updated_at`).
- Preserved nullable datetime fields (for example `finalized_at` and `archived_at`) as `DATETIME NULL` where explicit NULLability semantics were previously used.

### Testing
- Ran an automated SQL syntax/schema validation of `init.sql` against MySQL and it completed without errors.
- Executed CI database migration tests that apply the schema and validate table/column existence, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f9fcd9cc832db1e2407b8a3f6ad9)