### PR TITLE
Add finance/hrm/wim work functions and preserve unknown work function slugs

### DIFF
--- a/lib/work_functions.php
+++ b/lib/work_functions.php
@@ -14,6 +14,9 @@ define('APP_WORK_FUNCTIONS_LOADED', true);
 function built_in_work_function_definitions(): array
 {
     return [
+        'finance' => 'Finance & Grants',
+        'hrm' => 'HRM',
+        'wim' => 'WIM',
         'director' => 'Director',
         'manager' => 'Manager',
         'team_lead' => 'Team Lead',
@@ -401,7 +404,8 @@ function canonical_work_function_key(string $value, ?array $definitions = null):
         return 'manager';
     }
 
-    return 'expert';
+    // Preserve unknown slugs (legacy/custom values) instead of coercing to a default role.
+    return $normalized;
 }
 
 function canonical(string $value, ?array $definitions = null): string


### PR DESCRIPTION
### Motivation
- Add several built-in work function definitions (`finance`, `hrm`, `wim`) to represent Finance & Grants, HRM, and WIM roles.
- Preserve legacy or custom work function slugs instead of coercing unknown values to a default role.

### Description
- Updated `built_in_work_function_definitions()` in `lib/work_functions.php` to include `'finance' => 'Finance & Grants'`, `'hrm' => 'HRM'`, and `'wim' => 'WIM'`.
- Modified `canonical_work_function_key()` to return the normalized slug for unknown values instead of returning `'expert'`, thereby preserving unknown/legacy slugs.
- Retained the backward-compatible alias that maps `director_manager` to `manager` and left other catalog logic unchanged.

### Testing
- Ran the project's automated test suite (`composer test` / `phpunit`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3dab71538832d98f260d21fc22513)