### PR TITLE
Add bulk 'Copy assignments' feature and UX plan

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -212,6 +212,48 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $_SESSION[$flashKey] = t($t,'work_function_defaults_saved','Default questionnaire assignments updated.');
             header('Location: ' . $buildRedirect()); exit;
         }
+        if ($mode === 'assignments_bulk_clone') {
+            $sourceDepartment = trim((string)($_POST['source_department'] ?? ''));
+            $targetDepartments = $_POST['target_departments'] ?? [];
+            if (!isset($departmentOptions[$sourceDepartment])) {
+                throw new InvalidArgumentException(t($t,'invalid_department','Select a valid department.'));
+            }
+            if (!is_array($targetDepartments)) {
+                $targetDepartments = [];
+            }
+            $validTargets = [];
+            foreach ($targetDepartments as $depSlugRaw) {
+                $depSlug = trim((string)$depSlugRaw);
+                if ($depSlug === '' || $depSlug === $sourceDepartment || !isset($departmentOptions[$depSlug])) {
+                    continue;
+                }
+                $validTargets[$depSlug] = true;
+            }
+            if ($validTargets === []) {
+                throw new InvalidArgumentException(t($t,'work_function_defaults_bulk_target_required','Select at least one target department.'));
+            }
+            $sourceQuestionnaireIds = [];
+            $sourceAssignStmt = $pdo->prepare('SELECT questionnaire_id FROM questionnaire_department WHERE department_slug = ?');
+            $sourceAssignStmt->execute([$sourceDepartment]);
+            foreach ($sourceAssignStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $qid = (int)($row['questionnaire_id'] ?? 0);
+                if ($qid > 0) {
+                    $sourceQuestionnaireIds[$qid] = true;
+                }
+            }
+            $pdo->beginTransaction();
+            $deleteStmt = $pdo->prepare('DELETE FROM questionnaire_department WHERE department_slug = ?');
+            $insertStmt = $pdo->prepare('INSERT INTO questionnaire_department (questionnaire_id, department_slug) VALUES (?, ?)');
+            foreach (array_keys($validTargets) as $targetDepartment) {
+                $deleteStmt->execute([$targetDepartment]);
+                foreach (array_keys($sourceQuestionnaireIds) as $qid) {
+                    $insertStmt->execute([$qid, $targetDepartment]);
+                }
+            }
+            $pdo->commit();
+            $_SESSION[$flashKey] = t($t,'work_function_defaults_bulk_cloned','Assignments copied to selected departments.');
+            header('Location: ' . $buildRedirect()); exit;
+        }
     } catch (InvalidArgumentException $e) {
         $metadataErrors[] = $e->getMessage();
     } catch (Throwable $e) {
@@ -357,6 +399,31 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
         <span class="md-defaults-meta"><?=count($questionnaires)?> <?=htmlspecialchars(t($t,'questionnaires','Questionnaires'), ENT_QUOTES, 'UTF-8')?></span>
       </summary>
       <div class="md-defaults-group-body md-assignment-picker">
+        <form method="post" class="md-compact-actions" style="margin-bottom:.8rem; padding:.65rem; border:1px solid rgba(0,0,0,.08); border-radius:8px;">
+          <input type="hidden" name="csrf" value="<?=csrf_token()?>">
+          <input type="hidden" name="mode" value="assignments_bulk_clone">
+          <label class="md-field">
+            <span><?=htmlspecialchars(t($t,'bulk_clone_from','Copy assignments from'), ENT_QUOTES, 'UTF-8')?></span>
+            <select name="source_department" required>
+              <option value=""><?=htmlspecialchars(t($t,'select','Select'), ENT_QUOTES, 'UTF-8')?></option>
+              <?php foreach ($departmentOptions as $depSlug => $depLabel): ?>
+                <option value="<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>"><?=htmlspecialchars($depLabel, ENT_QUOTES, 'UTF-8')?></option>
+              <?php endforeach; ?>
+            </select>
+          </label>
+          <div class="md-field" style="flex:2 1 380px;">
+            <span><?=htmlspecialchars(t($t,'bulk_clone_to','Apply to departments'), ENT_QUOTES, 'UTF-8')?></span>
+            <div style="display:flex; flex-wrap:wrap; gap:.5rem; max-height:120px; overflow:auto; padding:.35rem; border:1px solid rgba(0,0,0,.1); border-radius:6px;">
+              <?php foreach ($departmentOptions as $depSlug => $depLabel): ?>
+                <label style="display:inline-flex; align-items:center; gap:.25rem;">
+                  <input type="checkbox" name="target_departments[]" value="<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>">
+                  <span><?=htmlspecialchars($depLabel, ENT_QUOTES, 'UTF-8')?></span>
+                </label>
+              <?php endforeach; ?>
+            </div>
+          </div>
+          <button type="submit" class="md-button md-outline"><?=htmlspecialchars(t($t,'copy_assignments','Copy Assignments'), ENT_QUOTES, 'UTF-8')?></button>
+        </form>
         <form method="post" class="md-compact-actions">
           <input type="hidden" name="csrf" value="<?=csrf_token()?>"><input type="hidden" name="mode" value="assignments_save">
           <?php foreach ($departmentOptions as $depSlug => $depLabel): ?>

--- a/docs/department-team-role-assignment-ux-plan.md
+++ b/docs/department-team-role-assignment-ux-plan.md
@@ -1,0 +1,52 @@
+# Department / Team / Work Role / Assignment UX Improvement Plan
+
+## Problem Summary
+Current administration requires managing four related entities in separate actions:
+1. Department catalog
+2. Team catalog
+3. Work role catalog
+4. Questionnaire assignment defaults by department
+
+This creates extra navigation and increases the risk of inconsistent data entry (e.g., team added without immediate default assignment review).
+
+## Proposed User-Friendly Flow
+
+### 1) “Organization Setup Wizard” (single guided flow)
+Create one guided screen (or modal stepper) with 4 steps:
+- Step 1: Add/edit departments
+- Step 2: Add/edit teams (scoped to selected department)
+- Step 3: Add/edit work roles
+- Step 4: Map default assignments (department + optional role overrides)
+
+### 2) Terminology cleanup in UI
+Use consistent labels everywhere:
+- `Department`
+- `Team`
+- `Work Role` (replace technical term `work_function` in UI)
+- `Default Assignment`
+
+### 3) Smart defaults
+- Auto-create a “General Team” when a new department is created.
+- Optional “Clone from existing department” for assignment defaults.
+- Auto-suggest work role based on account role (`admin/supervisor/staff`) with override.
+
+### 4) Inline validation and dependency checks
+- Prevent archiving a department that still has active teams/assigned users without a guided reassignment prompt.
+- Show “impacted users” count before archive/rename actions.
+- Validate uniqueness as user types (department/team/work-role labels).
+
+### 5) Bulk operations
+- CSV import for department-team-role hierarchy.
+- Multi-select assignment updates (apply one questionnaire set to multiple departments).
+- “Preview changes” before save.
+
+## Minimum Viable Increment (low risk)
+1. Add a read-only “Impact summary” panel to the current admin page.
+2. Add “Clone assignments from department X” action.
+3. Replace user-facing “Work Function” strings with “Work Role” while preserving existing DB column names.
+
+## Suggested Implementation Order
+1. UI terminology normalization.
+2. Clone defaults feature.
+3. Impact summary widgets.
+4. Wizard (optional, phase 2).


### PR DESCRIPTION
### Motivation
- Provide a fast way to replicate questionnaire default assignments from one department to many others to reduce repetitive manual updates.
- Preserve existing per-department assignment editing while enabling a bulk clone operation to improve admin UX.
- Capture broader UX improvements and next steps in a new design plan document. 

### Description
- Added server-side handling for a new POST `mode` of `assignments_bulk_clone` in `admin/work_function_defaults.php` that validates inputs, reads assignments from `questionnaire_department`, and atomically deletes/inserts rows to copy assignments to selected target departments within a transaction.
- Added a compact UI form to the assignments section in `admin/work_function_defaults.php` to select a `source_department` and multiple `target_departments[]`, and submit the `assignments_bulk_clone` action with appropriate CSRF token and user-facing flash message on success.
- Introduced a new doc `docs/department-team-role-assignment-ux-plan.md` capturing an improvement plan (wizard, terminology updates, smart defaults, bulk operations) and listing a minimal viable increment including the clone feature. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3eb67d044832d835a50d59544888a)