### PR TITLE
Improve accessibility for tabs and add CSP nonce to inline script in work_function_defaults

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -373,11 +373,11 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
     <?php if ($msg !== ''): ?><div class="md-alert success"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
     <?php if ($metadataErrors): ?><div class="md-alert error"><?php foreach ($metadataErrors as $err): ?><p><?=htmlspecialchars($err, ENT_QUOTES, 'UTF-8')?></p><?php endforeach; ?></div><?php endif; ?>
 
-    <div class="md-tab-row">
-      <button type="button" class="md-tab-chip is-active" data-tab-target="departments">Departments</button>
-      <button type="button" class="md-tab-chip" data-tab-target="teams">Teams</button>
-      <button type="button" class="md-tab-chip" data-tab-target="roles">Work Roles</button>
-      <button type="button" class="md-tab-chip" data-tab-target="defaults">Questionnaire Defaults</button>
+    <div class="md-tab-row" role="tablist" aria-label="Work function defaults sections">
+      <a class="md-tab-chip is-active" id="tab-departments" data-tab-target="departments" href="#departments" role="tab" aria-controls="departments" aria-selected="true">Departments</a>
+      <a class="md-tab-chip" id="tab-teams" data-tab-target="teams" href="#teams" role="tab" aria-controls="teams" aria-selected="false">Teams</a>
+      <a class="md-tab-chip" id="tab-roles" data-tab-target="roles" href="#roles" role="tab" aria-controls="roles" aria-selected="false">Work Roles</a>
+      <a class="md-tab-chip" id="tab-defaults" data-tab-target="defaults" href="#defaults" role="tab" aria-controls="defaults" aria-selected="false">Questionnaire Defaults</a>
     </div>
 
     <div class="md-filter-row">
@@ -386,7 +386,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       <a class="md-filter-chip <?=$statusFilter==='all'?'is-active':''?>" href="<?=htmlspecialchars(url_for('admin/work_function_defaults.php') . '?status=all', ENT_QUOTES, 'UTF-8')?>">All</a>
     </div>
 
-    <section class="md-defaults-group md-pane is-active" id="departments" data-pane>
+    <section class="md-defaults-group md-pane is-active" id="departments" data-pane role="tabpanel" aria-labelledby="tab-departments">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'department','Department'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeDepartmentCount : ($statusFilter === 'inactive' ? ($totalDepartmentCount - $activeDepartmentCount) : $totalDepartmentCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -432,7 +432,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </section>
 
-    <section class="md-defaults-group md-pane" id="teams" data-pane>
+    <section class="md-defaults-group md-pane" id="teams" data-pane role="tabpanel" aria-labelledby="tab-teams">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'team_catalog_title','Manage Teams in the Department'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeTeamCount : ($statusFilter === 'inactive' ? ($totalTeamCount - $activeTeamCount) : $totalTeamCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -479,7 +479,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </section>
 
-    <section class="md-defaults-group md-pane" id="roles" data-pane>
+    <section class="md-defaults-group md-pane" id="roles" data-pane role="tabpanel" aria-labelledby="tab-roles">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'work_function','Work Role'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeWorkRoleCount : ($statusFilter === 'inactive' ? ($totalWorkRoleCount - $activeWorkRoleCount) : $totalWorkRoleCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -523,7 +523,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </section>
 
-    <section class="md-defaults-group md-pane" id="defaults" data-pane>
+    <section class="md-defaults-group md-pane" id="defaults" data-pane role="tabpanel" aria-labelledby="tab-defaults">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'assignment_overview','Department questionnaire defaults'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=count($questionnaires)?> <?=htmlspecialchars(t($t,'questionnaires','Questionnaires'), ENT_QUOTES, 'UTF-8')?></span>
@@ -583,7 +583,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
   </div>
 </section>
 <?php include __DIR__ . '/../templates/footer.php'; ?>
-<script>
+<script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
   document.addEventListener('DOMContentLoaded', function () {
     var activePaneId = 'departments';
     var tabLinks = document.querySelectorAll('.md-tab-chip');
@@ -595,7 +595,11 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
         pane.classList.toggle('is-active', isMatch);
         if (isMatch) hasMatch = true;
       });
-      tabLinks.forEach(function (link) { link.classList.toggle('is-active', link.getAttribute('data-tab-target') === paneId); });
+      tabLinks.forEach(function (link) {
+        var isActiveTab = link.getAttribute('data-tab-target') === paneId;
+        link.classList.toggle('is-active', isActiveTab);
+        link.setAttribute('aria-selected', isActiveTab ? 'true' : 'false');
+      });
       activePaneId = paneId;
       return hasMatch;
     }


### PR DESCRIPTION
### Motivation
- Improve accessibility of the Work Function Defaults UI by implementing an accessible tab pattern and explicitly linking tabs and panels via ARIA attributes.
- Strengthen CSP compliance by adding a nonce to the inline script so it can run under stricter Content Security Policy rules.

### Description
- Replace tab `button`s with anchor-like tab controls that include `role="tab"`, `id`, `href`, `aria-controls`, and `aria-selected`, and add `role="tablist"` and `aria-label` to the tab container.
- Add `role="tabpanel"` and `aria-labelledby` to each section pane to associate panels with their corresponding tabs.
- Add a CSP nonce to the inline script with `nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>"` and update the client-side code to set `aria-selected` on tab links when switching panes.
- Small JS refactor preserves history hash behavior and centralizes tab active state toggling.

### Testing
- No automated tests were added for this change and the existing automated test suite was not executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0b30dbec832dae415e217a8ce072)