### PR TITLE
Improve Work Function Defaults UI, accessibility, assignment picker and error handling

### DIFF
--- a/admin/work_function_defaults.php
+++ b/admin/work_function_defaults.php
@@ -272,7 +272,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($pdo->inTransaction()) {
             $pdo->rollBack();
         }
-        $metadataErrors[] = $e->getMessage();
+        error_log('work_function_defaults fatal error: ' . $e->getMessage());
+        $metadataErrors[] = t($t, 'work_function_defaults_save_failed', 'Unable to save work function defaults. Please try again.');
     }
 }
 
@@ -306,8 +307,24 @@ if ($assignments === []) {
 
 
 $assignmentCounts = [];
+$assignmentCountStmt = $pdo->query(
+    "SELECT department_slug, COUNT(DISTINCT questionnaire_id) AS selected_count
+     FROM questionnaire_department
+     GROUP BY department_slug"
+);
+if ($assignmentCountStmt) {
+    foreach ($assignmentCountStmt->fetchAll(PDO::FETCH_ASSOC) as $row) {
+        $depSlug = trim((string)($row['department_slug'] ?? ''));
+        if ($depSlug === '') {
+            continue;
+        }
+        $assignmentCounts[$depSlug] = (int)($row['selected_count'] ?? 0);
+    }
+}
 foreach ($departmentOptions as $depSlug => $_depLabel) {
-    $assignmentCounts[$depSlug] = isset($assignments[$depSlug]) ? count($assignments[$depSlug]) : 0;
+    if (!isset($assignmentCounts[$depSlug])) {
+        $assignmentCounts[$depSlug] = 0;
+    }
 }
 ?>
 <!doctype html><html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>"><head>
@@ -350,7 +367,10 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
   .md-tab-chip.is-active { background: #1f6feb; color: #fff; }
   .md-pane { display: none; }
   .md-pane.is-active { display: block; }
-  .md-multiselect { width: 100%; min-height: 120px; }
+  .md-assignment-options { width: 100%; max-height: 160px; overflow: auto; padding: .45rem .55rem; border: 1px solid rgba(0,0,0,.22); border-radius: 6px; background: #fff; }
+  .md-assignment-options label { display: flex; gap: .45rem; align-items: flex-start; margin-bottom: .35rem; font-size: .92rem; }
+  .md-assignment-options label:last-child { margin-bottom: 0; }
+  .md-assignment-options input[type="checkbox"] { margin-top: .1rem; }
   .md-inline-editor { margin-top: .4rem; padding-top: .4rem; border-top: 1px dashed rgba(0,0,0,.15); }
   .md-status-chip { display: inline-block; padding: .15rem .45rem; border-radius: 999px; font-size: .8rem; font-weight: 600; }
   .md-status-chip.active { background: #e7f8ee; color: #136c3a; }
@@ -373,11 +393,11 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
     <?php if ($msg !== ''): ?><div class="md-alert success"><?=htmlspecialchars($msg, ENT_QUOTES, 'UTF-8')?></div><?php endif; ?>
     <?php if ($metadataErrors): ?><div class="md-alert error"><?php foreach ($metadataErrors as $err): ?><p><?=htmlspecialchars($err, ENT_QUOTES, 'UTF-8')?></p><?php endforeach; ?></div><?php endif; ?>
 
-    <div class="md-tab-row">
-      <button type="button" class="md-tab-chip is-active" data-tab-target="departments">Departments</button>
-      <button type="button" class="md-tab-chip" data-tab-target="teams">Teams</button>
-      <button type="button" class="md-tab-chip" data-tab-target="roles">Work Roles</button>
-      <button type="button" class="md-tab-chip" data-tab-target="defaults">Questionnaire Defaults</button>
+    <div class="md-tab-row" role="tablist" aria-label="Work function defaults sections">
+      <a class="md-tab-chip is-active" id="tab-departments" data-tab-target="departments" href="#departments" role="tab" aria-controls="departments" aria-selected="true">Departments</a>
+      <a class="md-tab-chip" id="tab-teams" data-tab-target="teams" href="#teams" role="tab" aria-controls="teams" aria-selected="false">Teams</a>
+      <a class="md-tab-chip" id="tab-roles" data-tab-target="roles" href="#roles" role="tab" aria-controls="roles" aria-selected="false">Work Roles</a>
+      <a class="md-tab-chip" id="tab-defaults" data-tab-target="defaults" href="#defaults" role="tab" aria-controls="defaults" aria-selected="false">Questionnaire Defaults</a>
     </div>
 
     <div class="md-filter-row">
@@ -386,7 +406,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       <a class="md-filter-chip <?=$statusFilter==='all'?'is-active':''?>" href="<?=htmlspecialchars(url_for('admin/work_function_defaults.php') . '?status=all', ENT_QUOTES, 'UTF-8')?>">All</a>
     </div>
 
-    <section class="md-defaults-group md-pane is-active" id="departments" data-pane>
+    <section class="md-defaults-group md-pane is-active" id="departments" data-pane role="tabpanel" aria-labelledby="tab-departments">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'department','Department'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeDepartmentCount : ($statusFilter === 'inactive' ? ($totalDepartmentCount - $activeDepartmentCount) : $totalDepartmentCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -432,7 +452,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </section>
 
-    <section class="md-defaults-group md-pane" id="teams" data-pane>
+    <section class="md-defaults-group md-pane" id="teams" data-pane role="tabpanel" aria-labelledby="tab-teams">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'team_catalog_title','Manage Teams in the Department'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeTeamCount : ($statusFilter === 'inactive' ? ($totalTeamCount - $activeTeamCount) : $totalTeamCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -479,7 +499,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </section>
 
-    <section class="md-defaults-group md-pane" id="roles" data-pane>
+    <section class="md-defaults-group md-pane" id="roles" data-pane role="tabpanel" aria-labelledby="tab-roles">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'work_function','Work Role'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=$statusFilter === 'active' ? $activeWorkRoleCount : ($statusFilter === 'inactive' ? ($totalWorkRoleCount - $activeWorkRoleCount) : $totalWorkRoleCount)?> <?=htmlspecialchars(t($t,'items','items'), ENT_QUOTES, 'UTF-8')?></span>
@@ -523,7 +543,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
       </div>
     </section>
 
-    <section class="md-defaults-group md-pane" id="defaults" data-pane>
+    <section class="md-defaults-group md-pane" id="defaults" data-pane role="tabpanel" aria-labelledby="tab-defaults">
       <div class="md-defaults-header">
         <span><?=htmlspecialchars(t($t,'assignment_overview','Department questionnaire defaults'), ENT_QUOTES, 'UTF-8')?></span>
         <span class="md-defaults-meta"><?=count($questionnaires)?> <?=htmlspecialchars(t($t,'questionnaires','Questionnaires'), ENT_QUOTES, 'UTF-8')?></span>
@@ -564,13 +584,16 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
                 <tr>
                   <td><?=htmlspecialchars($depLabel, ENT_QUOTES, 'UTF-8')?></td>
                   <td>
-                    <select class="md-multiselect" name="assignments[<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>][]" multiple>
+                    <div class="md-assignment-options" data-assignment-options>
                       <?php foreach ($questionnaires as $q): $qid=(int)$q['id']; ?>
-                        <option value="<?=$qid?>" <?=isset($assignments[$depSlug][$qid])?'selected':''?>><?=htmlspecialchars((string)($q['title'] ?: t($t,'untitled_questionnaire','Untitled questionnaire')), ENT_QUOTES, 'UTF-8')?></option>
+                        <label>
+                          <input type="checkbox" name="assignments[<?=htmlspecialchars($depSlug, ENT_QUOTES, 'UTF-8')?>][]" value="<?=$qid?>" <?=isset($assignments[$depSlug][$qid])?'checked':''?>>
+                          <span><?=htmlspecialchars((string)($q['title'] ?: t($t,'untitled_questionnaire','Untitled questionnaire')), ENT_QUOTES, 'UTF-8')?></span>
+                        </label>
                       <?php endforeach; ?>
-                    </select>
+                    </div>
                   </td>
-                  <td><?= (int)($assignmentCounts[$depSlug] ?? 0) ?></td>
+                  <td data-selected-count><?= (int)($assignmentCounts[$depSlug] ?? 0) ?></td>
                 </tr>
               <?php endforeach; ?>
               </tbody>
@@ -583,7 +606,7 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
   </div>
 </section>
 <?php include __DIR__ . '/../templates/footer.php'; ?>
-<script>
+<script nonce="<?=htmlspecialchars(csp_nonce(), ENT_QUOTES, 'UTF-8')?>">
   document.addEventListener('DOMContentLoaded', function () {
     var activePaneId = 'departments';
     var tabLinks = document.querySelectorAll('.md-tab-chip');
@@ -595,7 +618,11 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
         pane.classList.toggle('is-active', isMatch);
         if (isMatch) hasMatch = true;
       });
-      tabLinks.forEach(function (link) { link.classList.toggle('is-active', link.getAttribute('data-tab-target') === paneId); });
+      tabLinks.forEach(function (link) {
+        var isActiveTab = link.getAttribute('data-tab-target') === paneId;
+        link.classList.toggle('is-active', isActiveTab);
+        link.setAttribute('aria-selected', isActiveTab ? 'true' : 'false');
+      });
       activePaneId = paneId;
       return hasMatch;
     }
@@ -663,6 +690,24 @@ foreach ($departmentOptions as $depSlug => $_depLabel) {
         input.value = activePaneId || 'departments';
       });
     });
+    var assignmentTable = document.querySelector('.md-assignment-picker table');
+    if (assignmentTable) {
+      var syncSelectedCounts = function () {
+        var rows = assignmentTable.querySelectorAll('tbody tr');
+        rows.forEach(function (row) {
+          var countCell = row.querySelector('[data-selected-count]');
+          if (!countCell) return;
+          var checked = row.querySelectorAll('[data-assignment-options] input[type="checkbox"]:checked').length;
+          countCell.textContent = String(checked);
+        });
+      };
+      assignmentTable.addEventListener('change', function (event) {
+        var target = event.target;
+        if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') return;
+        syncSelectedCounts();
+      });
+      syncSelectedCounts();
+    }
   });
 </script>
 </body></html>


### PR DESCRIPTION
### Motivation
- Provide a more accessible and user-friendly UI for managing department questionnaire defaults and related work functions. 
- Replace the brittle multi-select with per-questionnaire checkboxes so selection counts can be shown and updated live. 
- Surface a clearer user-facing error message while preserving server-side error logs when saving fails. 

### Description
- Replaced the multi-select `select` for department questionnaire assignments with a styled checkbox list inside `.md-assignment-options` and updated CSS to support it. 
- Added a SQL aggregation query to compute per-department selected counts (`COUNT(DISTINCT questionnaire_id)`) and used those values to seed the displayed selected counts. 
- Added client-side JS to synchronize the `Selected` count column live when checkboxes change and to initialize counts on load. 
- Improved tab markup and ARIA attributes to make tabs and panels accessible, set `aria-selected` on tab links, and switched tab controls to anchor elements with fragment navigation support. 
- Added a CSP `nonce` to the inline script and set `aria`/`role` attributes on pane sections. 
- Improved error handling in the save flow by logging the original exception via `error_log` and replacing the raw exception text shown to users with a localized friendly message via `t($t, 'work_function_defaults_save_failed', ...)`. 
- Minor JS tweaks to set `current_tab` on POSTs and ensure active tab state persists in the URL hash. 

### Testing
- Ran PHP syntax check with `php -l` on the modified file and it passed. 
- Verified the new SQL aggregation query executes and populates `assignmentCounts` without errors in integration-like runs. 
- Executed a headless browser smoke test to confirm tabs, ARIA attributes, checkbox selection toggles, and the live selected-count syncing run without JS console errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0b30dbec832dae415e217a8ce072)