### PR TITLE
Client-side localized formatting for user dates

### DIFF
--- a/admin/pending_accounts.php
+++ b/admin/pending_accounts.php
@@ -75,6 +75,17 @@ $pendingUsers = $pdo->query("SELECT * FROM users WHERE account_status='pending' 
 $activeStaffStmt = $pdo->prepare("SELECT u.*, approver.full_name AS approver_name FROM users u LEFT JOIN users approver ON approver.id = u.approved_by WHERE u.account_status='active' AND u.role='staff' ORDER BY (u.next_assessment_date IS NULL), u.next_assessment_date ASC, u.full_name ASC");
 $activeStaffStmt->execute();
 $activeStaff = $activeStaffStmt->fetchAll();
+
+$activeStaffDateMeta = [];
+foreach ($activeStaff as $staffRow) {
+    $id = (int)($staffRow['id'] ?? 0);
+    $nextRaw = (string)($staffRow['next_assessment_date'] ?? '');
+    $approvedRaw = (string)($staffRow['approved_at'] ?? '');
+    $activeStaffDateMeta[$id] = [
+        'next_iso' => $nextRaw !== '' ? $nextRaw . 'T00:00:00' : '',
+        'approved_iso' => $approvedRaw !== '' ? date(DATE_ATOM, strtotime($approvedRaw)) : '',
+    ];
+}
 ?>
 <!doctype html>
 <html lang="<?=htmlspecialchars($locale, ENT_QUOTES, 'UTF-8')?>" data-base-url="<?=htmlspecialchars(BASE_URL, ENT_QUOTES, 'UTF-8')?>">
@@ -162,10 +173,10 @@ $activeStaff = $activeStaffStmt->fetchAll();
         <tr>
           <td><?=htmlspecialchars($staff['full_name'] ?: $staff['username'])?></td>
           <td><?=htmlspecialchars($staff['email'] ?? '')?></td>
-          <td><?=htmlspecialchars($staff['next_assessment_date'] ?? t($t,'not_set','Not set'))?></td>
+          <td data-client-date="<?=htmlspecialchars($activeStaffDateMeta[(int)$staff['id']]['next_iso'] ?? '', ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="date"><?=htmlspecialchars($staff['next_assessment_date'] ?? t($t,'not_set','Not set'))?></td>
           <td>
             <?php if (!empty($staff['approved_at'])): ?>
-              <?=htmlspecialchars($staff['approved_at'])?><?php if (!empty($staff['approver_name'])): ?> · <?=htmlspecialchars($staff['approver_name'])?><?php endif; ?>
+              <span data-client-date="<?=htmlspecialchars($activeStaffDateMeta[(int)$staff['id']]['approved_iso'] ?? '', ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="datetime"><?=htmlspecialchars($staff['approved_at'])?></span><?php if (!empty($staff['approver_name'])): ?> · <?=htmlspecialchars($staff['approver_name'])?><?php endif; ?>
             <?php else: ?>
               <?=t($t,'not_applicable','N/A')?>
             <?php endif; ?>

--- a/admin/users.php
+++ b/admin/users.php
@@ -384,12 +384,14 @@ foreach ($rows as $r) {
         $ts = strtotime((string)$nextAssessment);
         $nextAssessmentDisplay = $ts ? date('M j, Y', $ts) : $nextAssessment;
     }
+    $nextAssessmentIso = $nextAssessment !== '' ? ($nextAssessment . 'T00:00:00') : '';
     $createdAt = $r['created_at'] ?? '';
     $createdDisplay = '—';
     if ($createdAt !== '') {
         $ts = strtotime((string)$createdAt);
         $createdDisplay = $ts ? date('M j, Y', $ts) : $createdAt;
     }
+    $createdIso = $createdAt !== '' ? date(DATE_ATOM, strtotime((string)$createdAt)) : '';
     $roleKey = $r['role'] ?? 'staff';
     $roleLabel = $roleLabels[$roleKey] ?? $roleKey;
     $userId = (int)$r['id'];
@@ -472,7 +474,9 @@ foreach ($rows as $r) {
         'team_label' => $teamLabel,
         'next_assessment' => $nextAssessment,
         'next_assessment_display' => $nextAssessmentDisplay,
+        'next_assessment_iso' => $nextAssessmentIso,
         'created_display' => $createdDisplay,
+        'created_iso' => $createdIso,
         'created_at' => $createdAt,
         'role_key' => $roleKey,
         'role_label' => $roleLabel,
@@ -655,7 +659,7 @@ foreach ($rows as $r) {
             </div>
             <div>
               <dt><?=t($t,'next_assessment','Next Assessment')?></dt>
-              <dd><?=htmlspecialchars($record['next_assessment_display'], ENT_QUOTES, 'UTF-8')?></dd>
+              <dd data-client-date="<?=htmlspecialchars($record['next_assessment_iso'], ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="date"><?=htmlspecialchars($record['next_assessment_display'], ENT_QUOTES, 'UTF-8')?></dd>
             </div>
             <div>
               <dt><?=t($t,'created','Created')?></dt>
@@ -788,7 +792,7 @@ foreach ($rows as $r) {
               <td><?=htmlspecialchars($record['team_label'] ?? '—', ENT_QUOTES, 'UTF-8')?></td>
               <td><?=htmlspecialchars($record['work_function_label'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
               <td><span class="md-user-chip <?=$record['status_class']?>"><?=htmlspecialchars($record['status_label'], ENT_QUOTES, 'UTF-8')?></span></td>
-              <td><?=htmlspecialchars($record['next_assessment_display'], ENT_QUOTES, 'UTF-8')?></td>
+              <td data-client-date="<?=htmlspecialchars($record['next_assessment_iso'], ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="date"><?=htmlspecialchars($record['next_assessment_display'], ENT_QUOTES, 'UTF-8')?></td>
               <td><?=htmlspecialchars($record['created_display'], ENT_QUOTES, 'UTF-8')?></td>
               <td>
                 <button type="button" class="md-button md-outline md-user-manage md-user-action-button" data-scroll-target="user-card-<?=$record['id']?>"><?=t($t,'manage','Manage')?></button>

--- a/admin/users.php
+++ b/admin/users.php
@@ -663,7 +663,7 @@ foreach ($rows as $r) {
             </div>
             <div>
               <dt><?=t($t,'created','Created')?></dt>
-              <dd><?=htmlspecialchars($record['created_display'], ENT_QUOTES, 'UTF-8')?></dd>
+              <dd data-client-date="<?=htmlspecialchars($record['created_iso'], ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="datetime"><?=htmlspecialchars($record['created_display'], ENT_QUOTES, 'UTF-8')?></dd>
             </div>
           </dl>
           <div class="md-user-card__footer">
@@ -793,7 +793,7 @@ foreach ($rows as $r) {
               <td><?=htmlspecialchars($record['work_function_label'] ?? '', ENT_QUOTES, 'UTF-8')?></td>
               <td><span class="md-user-chip <?=$record['status_class']?>"><?=htmlspecialchars($record['status_label'], ENT_QUOTES, 'UTF-8')?></span></td>
               <td data-client-date="<?=htmlspecialchars($record['next_assessment_iso'], ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="date"><?=htmlspecialchars($record['next_assessment_display'], ENT_QUOTES, 'UTF-8')?></td>
-              <td><?=htmlspecialchars($record['created_display'], ENT_QUOTES, 'UTF-8')?></td>
+              <td data-client-date="<?=htmlspecialchars($record['created_iso'], ENT_QUOTES, 'UTF-8')?>" data-client-date-mode="datetime"><?=htmlspecialchars($record['created_display'], ENT_QUOTES, 'UTF-8')?></td>
               <td>
                 <button type="button" class="md-button md-outline md-user-manage md-user-action-button" data-scroll-target="user-card-<?=$record['id']?>"><?=t($t,'manage','Manage')?></button>
               </td>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -93,6 +93,26 @@
 
   installAssessmentContentProtection();
 
+  const formatClientDates = () => {
+    const nodes = document.querySelectorAll('[data-client-date]');
+    if (!nodes.length || typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
+      return;
+    }
+    nodes.forEach((node) => {
+      const isoValue = node.getAttribute('data-client-date');
+      if (!isoValue) return;
+      const mode = node.getAttribute('data-client-date-mode') || 'date';
+      const date = new Date(isoValue);
+      if (Number.isNaN(date.getTime())) return;
+      const options = mode === 'datetime'
+        ? { dateStyle: 'medium', timeStyle: 'short' }
+        : { dateStyle: 'medium' };
+      node.textContent = new Intl.DateTimeFormat(undefined, options).format(date);
+    });
+  };
+
+  formatClientDates();
+
   const applyTheme = (theme) => {
     const next = theme === 'dark' ? 'dark' : 'light';
     document.body.classList.toggle('theme-dark', next === 'dark');

--- a/docs/date-format-review.md
+++ b/docs/date-format-review.md
@@ -1,0 +1,65 @@
+# Date Field & Formatting Review
+
+## Current state
+
+### Database-level date/datetime fields
+- `users.date_of_birth` and `users.next_assessment_date` are typed as `DATE` in schema and migrations, which is good for date-only business values. 
+- Most audit/system fields (`created_at`, `updated_at`, `first_login_at`, `reviewed_at`) are `DATETIME`/`TIMESTAMP` and represent server-side event time.
+
+### Server-side display formatting
+- Several places format dates with fixed PHP patterns like `Y-m-d`, `Y-m-d H:i`, or `F j, Y g:i a`.
+- This creates mixed presentation styles and ties output to server decisions instead of end-user locale/timezone.
+
+### Client-side formatting
+- There is already at least one client-side formatter using `Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' })`, which automatically picks locale-friendly formatting from the browser.
+
+## Can the system pick client-side data format?
+
+Yes — for **display formatting**, the frontend can and should pick client-side format using browser locale and timezone.
+
+Recommended split of responsibilities:
+- **Backend transport/storage format (canonical):**
+  - Date only: `YYYY-MM-DD`
+  - Date-time: ISO 8601 with timezone (prefer UTC source, e.g. `2026-05-18T14:30:00Z`)
+- **Frontend display format:**
+  - Use `Intl.DateTimeFormat` with `undefined` locale (or user-selected locale)
+  - Let the browser format according to user regional settings.
+
+## Best approach
+
+1. **Standardize outbound date payloads**
+   - Keep DB as-is for typed fields.
+   - Normalize API/template-provided timestamps to ISO 8601 where possible.
+
+2. **Introduce shared formatting helpers**
+   - JS utility: `formatDate(value, { dateStyle, timeStyle, timeZone })`
+   - PHP utility: for non-JS surfaces (PDF/email/export), define one shared formatter per output type so patterns are centralized.
+
+3. **Apply by surface**
+   - **Interactive UI:** client-side `Intl` formatting.
+   - **CSV exports:** machine-friendly fixed format (ISO-like), clearly documented.
+   - **Emails/PDFs:** explicit stable format (and, if relevant, include timezone label).
+
+4. **Timezone policy**
+   - Store datetimes in UTC (or treat DB values as UTC consistently).
+   - Convert only for display.
+
+5. **Validation policy**
+   - Keep `<input type="date">` fields bound to `YYYY-MM-DD`.
+   - Avoid locale-formatted strings for data submission; locale formatting is display-only.
+
+## Practical migration plan
+
+- Step 1: Identify all direct `date()`/`format()` presentation calls and classify by output surface (UI, export, PDF, email).
+- Step 2: Replace UI-facing embedded formatted strings with raw ISO values + client-side formatter.
+- Step 3: Consolidate non-UI formats in one PHP helper per surface.
+- Step 4: Add regression tests for parsing/formatting around timezone boundaries.
+
+## Summary recommendation
+
+Use a **canonical wire format + localized client rendering** architecture:
+- Canonical data in server responses (`YYYY-MM-DD` for date-only, ISO 8601 for datetime)
+- Localized display in browser via `Intl.DateTimeFormat`
+- Explicit fixed formats only for exports and generated documents.
+
+This gives consistency, locale correctness, and fewer date bugs.


### PR DESCRIPTION
### Motivation
- Server-side date formatting produced fixed presentation that didn't respect the end-user locale or timezone and led to mixed formats across the UI. 
- Dates shown in the users list and user cards should be presented in the browser using the user's locale and timezone for clearer, consistent display. 
- Introduce a canonical wire format for dates so the frontend can localize presentation reliably.

### Description
- Add ISO-style fields to user payloads returned to templates: `next_assessment_iso` and `created_iso` are populated in `admin/users.php` and included in the `userRecords` array. 
- Emit `data-client-date` and `data-client-date-mode` attributes on date elements in the user card and list rows so the frontend can reformat them (`admin/users.php`).
- Implement `formatClientDates()` in `assets/js/app.js` to detect `[data-client-date]` nodes and replace their text with a localized string using `Intl.DateTimeFormat`, supporting `date` and `datetime` modes. 
- Add `docs/date-format-review.md` documenting the recommended canonical wire-format + client-side localized display approach and a migration plan.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b344188dc832da2b116004e7f5866)